### PR TITLE
CASMNET-895: Fix confusing warning and user guidance in config generation.

### DIFF
--- a/canu/generate/network/config/config.py
+++ b/canu/generate/network/config/config.py
@@ -388,11 +388,11 @@ def config(
         click.secho("\nWarning", fg="red")
 
         click.secho(
-            "\nThe following devices were not found in the configurations.",
+            "\nThe following devices typically exist, but were not found in the current configuration.",
             fg="red",
         )
         click.secho(
-            "If the network contains these devices, check the SHCD to ensure all tabs were included.",
+            "If the network is supposed to have these devices, check the SHCD to ensure all tabs were included.",
             fg="red",
         )
         click.secho(


### PR DESCRIPTION
### Summary and Scope

When generating configurations, different architectures typically expect some node/device types - UAN for example.  Absence of the expected type isn't necessarily an error, but CANU warns when some device types aren't found.  The warning was very confusing and this change attempts to provide better user guidance.

### Issues and Related PRs

* Resolves CASMNET-895

### Testing

Passed modified nox tests.