### PR TITLE
CASMNET-806: add PDU to to model/config

### DIFF
--- a/network_modeling/models/cray-network-architecture.yaml
+++ b/network_modeling/models/cray-network-architecture.yaml
@@ -130,7 +130,7 @@ network_v2:
     - lookup_name: ["sn"]
       shasta_name: "ncn-s"
       architecture_type: "river_ncn_node_4_port"
-    - lookup_name: ["uan"]
+    - lookup_name: ["uan", "slurm"]
       shasta_name: "uan"
       architecture_type: "river_ncn_node_4_port"
     - lookup_name: ["Ln", "ln"]
@@ -270,6 +270,7 @@ network_v2_tds:
       architecture_type: "river_ncn_node_4_port"
     - lookup_name:
         - "uan"
+        - "slurm"
       shasta_name: "uan"
       architecture_type: "river_ncn_node_4_port"
     - lookup_name:
@@ -386,6 +387,7 @@ network_v1:
       architecture_type: "river_ncn_node_2_port_gigabyte"
     - lookup_name:
         - "uan"
+        - "slurm"
       shasta_name: "uan"
       architecture_type: "river_ncn_node_4_port_gigabyte"
     - lookup_name:

--- a/network_modeling/models/cray-network-architecture.yaml
+++ b/network_modeling/models/cray-network-architecture.yaml
@@ -166,7 +166,7 @@ network_v2:
     - lookup_name: ["cmm"]
       shasta_name: "cmm"
       architecture_type: "cmm"
-    - lookup_name: ["cn"]
+    - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"
 network_v2_tds:
@@ -300,7 +300,7 @@ network_v2_tds:
         - "cmm"
       shasta_name: "cmm"
       architecture_type: "cmm"
-    - lookup_name: ["cn"]
+    - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"
 network_v1:
@@ -423,6 +423,6 @@ network_v1:
     - lookup_name: ["cmm"]
       shasta_name: "cmm"
       architecture_type: "cmm"
-    - lookup_name: ["cn"]
+    - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"


### PR DESCRIPTION
This adds PDUs as a hardware/architecture option.

It also adds more `lookup_names` for `slurm` and `nid` node types (both of which are used in `csi`.

This PR, along with #22 should close #15.
