### PR TITLE
add regex support, closes #35

### DIFF
--- a/network_modeling/schema/cray-network-architecture-schema.yaml
+++ b/network_modeling/schema/cray-network-architecture-schema.yaml
@@ -40,3 +40,5 @@ lookup_map:
   lookup_name: list(str(min=1, exclude=' '))
   shasta_name: str(min=1, exclude=' ')
   architecture_type: str(min=1, exclude=' ')
+  regex: bool(required=False)
+  


### PR DESCRIPTION
new entries added to cray-network-architecture can now contain a 'regex:' key,
which is a list of regex patterns to be searched.  an example is that pdus can
have a name like x3000p1 or pdup1, so this allows the user to search for both.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>