### PR TITLE
add PDU hardware types, closes #36

### DIFF
--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -249,7 +249,7 @@ def get_node_common_name(name, rack_number, rack_elevation, mapper):
                 elif node[1].find("cec") != -1:
                     tmp_name = node[1] + "-" + rack_number + "-"
                 elif node[1].find("pdu") != -1:
-                    tmp_name = node[1] + "-" + rack_number + "-"
+                    tmp_name = node[1] + rack_elevation
                 else:
                     tmp_name = node[1]
                 if tmp_name == "sw-cdu-" and not name.startswith("sw-cdu"):
@@ -261,13 +261,19 @@ def get_node_common_name(name, rack_number, rack_elevation, mapper):
                     # cdu2sw2 --> sw-cdu-006
                     digits = re.findall(r"\d+", name)
                     tmp_id = int(digits[0]) * 2 + int(digits[1])
+                    common_name = f"{tmp_name}{tmp_id:0>3}"
+                elif tmp_name.startswith("pdu"):
+                    digits = re.findall(r"\d+", name)
+                    digit = digits[1]
+                    # The name becomes pdu-NNN
+                    common_name = f"{node[1]}-{digit:0>3}"
                 else:
                     tmp_id = re.sub(
                         "^({})0*([1-9]*)".format(lookup_name),
                         r"\2",
                         name,
                     ).strip("-")
-                common_name = f"{tmp_name}{tmp_id:0>3}"
+                    common_name = f"{tmp_name}{tmp_id:0>3}"
                 return common_name
     return common_name
 


### PR DESCRIPTION
this adds pdus, which requires #35 to work properly.
It can find pdus with names like x3000p1 and pdup1.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>