### PR TITLE
add pdus to network hardware and architecture

### DIFF
--- a/network_modeling/models/cray-network-architecture.yaml
+++ b/network_modeling/models/cray-network-architecture.yaml
@@ -120,6 +120,11 @@ network_v2:
       connections:
         - name: "mountain_compute_leaf"
           speed: 10
+    - name: "pdu"
+      model: "pdu"
+      connections:
+        - name: "river_bmc_leaf"
+          speed: 1
   lookup_mapper:
     - lookup_name: ["mn"]
       shasta_name: "ncn-m"
@@ -169,6 +174,12 @@ network_v2:
     - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"
+    - lookup_name: 
+        - '^x\d+p\d+$'
+        - '^pdu\d+$'
+      shasta_name: "pdu"
+      architecture_type: "pdu"
+      regex: true
 network_v2_tds:
   name: "Version 2 TDS"
   description: "Aruba Hardware"
@@ -255,6 +266,11 @@ network_v2_tds:
       connections:
         - name: "mountain_compute_leaf"
           speed: 10
+    - name: "pdu"
+      model: "pdu"
+      connections:
+        - name: "river_bmc_leaf"
+          speed: 1
   lookup_mapper:
     - lookup_name:
         - "mn"
@@ -304,6 +320,12 @@ network_v2_tds:
     - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"
+    - lookup_name: 
+        - '^x\d+p\d+$'
+        - '^pdu\d+$'
+      shasta_name: "pdu"
+      architecture_type: "pdu"
+      regex: true
 network_v1:
   name: "Dell and Mellanox Architecture"
   description: "Dell and Mellanox Hardware"
@@ -381,6 +403,11 @@ network_v1:
         - name: "river_bmc_leaf"
           speed: 1
           comment: "bmc"
+    - name: "pdu"
+      model: "pdu"
+      connections:
+        - name: "river_bmc_leaf"
+          speed: 1
   lookup_mapper:
     - lookup_name:
         - "mn"
@@ -437,3 +464,9 @@ network_v1:
     - lookup_name: ["cn", "nid"]
       shasta_name: "cn"
       architecture_type: "river_compute_node"
+    - lookup_name: 
+        - '^x\d+p\d+$'
+        - '^pdu\d+$'
+      shasta_name: "pdu"
+      architecture_type: "pdu"
+      regex: true

--- a/network_modeling/models/cray-network-hardware.yaml
+++ b/network_modeling/models/cray-network-hardware.yaml
@@ -225,3 +225,12 @@ network_hardware:
     ports:
       - count: 2
         speed: 10
+  - name: "HPE G2 Mtrd/Swtd 3P 17.3kVA/C13 NA/J PDU"
+    vendor: "hpe"
+    model: "pdu"
+    type: "none"
+    deprecated: False
+    ports:
+      - count: 1
+        speed: 1
+        slot: "bmc"


### PR DESCRIPTION
Utilizing the new functionality added in #38 and #37, this adds the PDUs to the network hardware and architecture yaml files.
 
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>