### PR TITLE
MTL-1556 print ncn mac addresses for use with 'csi config shcd'

### DIFF
--- a/docs/validate_shcd_cabling.md
+++ b/docs/validate_shcd_cabling.md
@@ -86,6 +86,10 @@ Level of logging.
 ### --out( <out>)
 Output results to a file
 
+
+### --macs()
+Print NCN MAC addresses
+
 ## Example
 
 ### Validate SHCD and Cabling


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

### Summary and Scope

Adds a `--macs` flag to the `canu validate shcd-cabling` command, which prints off mac addresses needed for use with `csi config init`.

```
/  Connecting to 10.103.2.101 - Switch 10 of 10        

ncn-w001,ab:cd:ef:12:34:56
ncn-w002,ab:cd:ef:12:34:56
...
...
(.venv) jsalmela:~/git/canu (ncn_macs)$ 
```

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py

### Issues and Related PRs

* Relates to MTL-1556

### Testing

Tested on:

* odin
