### PR TITLE
CASMNET-1056 - Include jq in CANU docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo 'export PS1="canu \w : "' >> /etc/bash.bashrc
 
 # prep image layer for faster builds
 COPY requirements.txt /app/canu/
-RUN zypper -n install python3 python3-pip vim
+RUN zypper -n install python3 python3-pip vim jq
 RUN pip3 install -r /app/canu/requirements.txt
 
 # copy canu files

--- a/readme.md
+++ b/readme.md
@@ -1153,6 +1153,7 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 - Computes/HSN-bmcs/VizNodes/LoginNodes/pdus now have their switch config generated.
 - Added SubRack support for reading in all variations from the SHCD, and added **sub_location** and **parent** to the JSON output
 - Added Paddle / CCJ (CSM Cabling JSON) support. Commands `canu validate paddle` and `canu validate paddle-cabling` can validate the CCJ. Config can be generated using CCJ.
+- Added the `jq` command to the Docker image.
 
 ## [unreleased]
 


### PR DESCRIPTION
### Summary and Scope

Include `jq` in the CANU docker environment so `sls_input_file.json` can be inspected and processed without having to break out of the container environment.

PR checklist (you may replace this section):
- [X] I have updated the appropriate Changelog entries in readme.md

### Issues and Related PRs

* Resolves `CASMNET-1056`

### Testing

Tested on:

* Tested locally using a Linux VM.

