### PR TITLE
CASMNET-1070: Modify setup.py file globs to use migrated Jinja2 templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1127,6 +1127,7 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 
 ## [development]
 
+- Changed setup.py file glob to follow previously updated Jinja2 template locations.
 - Command line option --csi-folder has changed to --sls-file. Any SLS JSON file can be used.
 - Installation via pip now supports non-developer modes. Pyinstaller binary and RPM now work as advertised.
 - The directory of canu_cache.yaml is now dynamically configured in the user's home directory (preferred), or the system temporary directory depending on filesystem permissions.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
                   "network_modeling": ["schema/*.json",
                                        "schema/*.yaml",
                                        "models/*yaml",
-                                       "configs/templates/**/*"],
+                                       "configs/templates/**/**/**/*"],
                   },
     exclude_package_data={"canu": ["canu_cache.yaml"]},
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
### Summary and Scope

Jinja2 configuration templates were moved down one level to accommodate CSM version differences.  The installer via setup.py was not changed to follow the new template locations.  This causes generation of configurations to fail in the 1.0.0 release. 

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py

### Issues and Related PRs

* Resolves CASMNET-1070

### Testing

Tested on:

* Docker local.
* Python virtual environment.
* Pyinstaller binary.
