### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ In order to run CANU, both python3 and pip3 need to be installed.
   ```bash
     python3 -m venv .venv
     source ./.venv/bin/activate
-    pip3 install ./canu
+    pip3 install .
   ```
 
   - When you are done working in the Python Virtualenv.


### PR DESCRIPTION
.venv canu install directions are incorrect.
Assuming I'm in the canu repo, I'll install .
setup.py is locaded at ., not at ./canu

### Summary and Scope

Description: What does this change do?  Use examples of new options and output changes when possible.  If other changes were made list these as well in a list.

PR checklist (you may replace this section):
- [ ] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have updated the appropriate Changelog entries in readme.md
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py

### Issues and Related PRs

* Resolves `Issue`
* Relates to `Issue`
* Requires `Issue`


### Testing

Tested on:

* List of virtual system tested.
* List of physical systems tested.
