### PR TITLE
Fix conflict between nornir and dataclasses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dataclasses==0.7
 aiofiles==0.7.0
 aiohttp==3.8.0
 aiosignal==1.2.0


### PR DESCRIPTION
dataclasses 0.8 is getting pulled in implicitly by ... something ... in the context of a docker build.  This causes the program to not operate correctly as reported in https://github.com/Cray-HPE/canu/issues/78.  One possible fix is to simply constrain the version of dataclasses to 0.7 to prevent this anomalous behavior, another would be to identify what is pulling in dataclasses and address it more explicitly elsewhere.  Being unfamiliar with this package, I've chosen the former.

### Summary and Scope

Description: What does this change do?  Use examples of new options and output changes when possible.  If other changes were made list these as well in a list.

PR checklist (you may replace this section):
- [X] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [ ] I have updated the appropriate Changelog entries in readme.md
- [ ] I have incremented the version in the readme.md
- [ ] I have incremented the version in `canu/.version`

### Issues and Related PRs

Potentially resolves https://github.com/Cray-HPE/canu/issues/78


### Testing

Tested on:

* modified buildah/podman instance of Dockerfile (will file issue on that separately) on the alvarez management VM.
