### PR TITLE
CASMINST-4000 CASMNET-1153

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.1.10~develop
+1.1.11~develop

--- a/canu/utils/sls.py
+++ b/canu/utils/sls.py
@@ -160,6 +160,7 @@ def pull_sls_networks(sls_file=None):
         sls_networks = sls_cache
 
     sls_variables = {
+        "SWITCH_ASN": None,
         "CAN": None,
         "CAN_VLAN": None,
         "CMN": None,
@@ -267,6 +268,10 @@ def pull_sls_networks(sls_file=None):
             sls_variables["NMN"] = sls_network.get("ExtraProperties", {}).get(
                 "CIDR",
                 "",
+            )
+            sls_variables["SWITCH_ASN"] = sls_network.get("ExtraProperties", {}).get(
+                "PeerASN",
+                {},
             )
             for subnets in sls_network.get("ExtraProperties", {}).get("Subnets", {}):
                 sls_variables["NMN_VLAN"] = subnets.get("VlanID", "")

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -80,6 +80,7 @@ def bgp(ctx, username, password, asn, verbose):
         password: Switch password
         asn: Switch ASN
         verbose: Bool indicating verbose output
+        network: The network that BGP neighbors are checked
     """
     credentials = {"username": username, "password": password}
     data = {}
@@ -191,6 +192,7 @@ def get_bgp_neighbors(ip, credentials, asn):
         ip: IPv4 address of the switch
         credentials: Dictionary with username and password of the switch
         asn: Switch ASN
+        network: The network that BGP neighbors are checked
 
     Returns:
         bgp_neighbors: A dict with switch neighbors
@@ -203,6 +205,7 @@ def get_bgp_neighbors(ip, credentials, asn):
         if vendor is None:
             return None, None
         elif vendor == "aruba":
+<<<<<<< HEAD
             bgp_neighbors, switch_info = get_bgp_neighbors_aruba(ip, credentials, asn)
         elif vendor == "dell":
             # This function returns: {}, switch_info
@@ -210,6 +213,29 @@ def get_bgp_neighbors(ip, credentials, asn):
             bgp_neighbors, switch_info = get_bgp_neighbors_dell(ip, credentials)
         elif vendor == "mellanox":
             bgp_neighbors, switch_info = get_bgp_neighbors_mellanox(ip, credentials)
+=======
+            bgp_neighbors, switch_info = get_bgp_neighbors_aruba(
+                ip,
+                credentials,
+                asn,
+                network,
+            )
+        elif vendor == "dell":
+            # This function returns: {}, switch_info
+            # There won't be any Dell switches with BGP neighbors
+            bgp_neighbors, switch_info = get_bgp_neighbors_dell(
+                ip,
+                credentials,
+                asn,
+                network,
+            )
+        elif vendor == "mellanox":
+            bgp_neighbors, switch_info = get_bgp_neighbors_mellanox(
+                ip,
+                credentials,
+                network,
+            )
+>>>>>>> d60c268 (fix tests)
 
     except (
         requests.exceptions.HTTPError,
@@ -236,6 +262,7 @@ def get_bgp_neighbors_aruba(ip, credentials, asn):
         ip: IPv4 address of the switch
         credentials: Dictionary with username and password of the switch
         asn: Switch ASN
+        network: The network that BGP neighbors are checked
 
     Returns:
         bgp_neighbors: A dict with switch neighbors
@@ -367,6 +394,7 @@ def get_bgp_neighbors_mellanox(ip, credentials):
     Args:
         ip: IPv4 address of the switch
         credentials: Dictionary with username and password of the switch
+        network: The network that BGP neighbors are checked
 
     Returns:
         bgp_neighbors: A dict with switch neighbors

--- a/docs/validate_shcd.md
+++ b/docs/validate_shcd.md
@@ -48,6 +48,34 @@ The corners on each tab, comma separated e.g. ‘J37,U227,J15,T47,J20,U167’.
 
 
 ### --out( <out>)
+Output JSON model to a file
+
+
+### --out( <out>)
+Output results to a file
+
+
+### --json()
+Output JSON model to a file
+
+
+### --out( <out>)
+Output results to a file
+
+
+### --json()
+Output JSON model to a file
+
+
+### --out( <out>)
+Output results to a file
+
+
+### --json()
+Output JSON model to a file
+
+
+### --out( <out>)
 Output results to a file
 
 

--- a/docs/validate_shcd.md
+++ b/docs/validate_shcd.md
@@ -48,34 +48,6 @@ The corners on each tab, comma separated e.g. ‘J37,U227,J15,T47,J20,U167’.
 
 
 ### --out( <out>)
-Output JSON model to a file
-
-
-### --out( <out>)
-Output results to a file
-
-
-### --json()
-Output JSON model to a file
-
-
-### --out( <out>)
-Output results to a file
-
-
-### --json()
-Output JSON model to a file
-
-
-### --out( <out>)
-Output results to a file
-
-
-### --json()
-Output JSON model to a file
-
-
-### --out( <out>)
 Output results to a file
 
 

--- a/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-m.lag.j2
+++ b/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-m.lag.j2
@@ -6,7 +6,10 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} lacp-individual enable force
+{%- endif %}
+
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-s.lag.j2
+++ b/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-s.lag.j2
@@ -6,7 +6,9 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} lacp-individual enable force
+{%- endif %}
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-w.lag.j2
+++ b/network_modeling/configs/templates/1.0/dellmellanox/common/ncn-w.lag.j2
@@ -6,7 +6,9 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} lacp-individual enable force
+{%- endif %}
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-m.lag.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-m.lag.j2
@@ -6,7 +6,10 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} lacp-individual enable force
+{%- endif %}
+
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-s.lag.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-s.lag.j2
@@ -6,7 +6,9 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER_V1 }} lacp-individual enable force
+{%- endif %}
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-w.lag.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/common/ncn-w.lag.j2
@@ -6,7 +6,9 @@ interface mlag-port-channel {{ node.config.LAG_NUMBER }} mtu 9216 force
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} switchport mode hybrid
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} description "{{ node.config.DESCRIPTION }}"
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} no shutdown
+{%- if variables.HOSTNAME == "sw-spine-001" %}
 interface mlag-port-channel {{ node.config.LAG_NUMBER }} lacp-individual enable force
+{%- endif %}
 
 interface ethernet 1/{{ node.config.PORT }} speed 40G force
 interface ethernet 1/{{ node.config.PORT }} mtu 9216 force

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.1.10-develop
+# 🛶 CANU v1.1.11-develop
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1166,6 +1166,10 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.1.11-develop]
+- `canu validate BGP` now has an option to choose what network to run against.
+- Remove `'lacp-individual` from mellanox spine02.
 
 ## [1.1.10-develop]
 - Update canu validate to user heir config diff and cleaner output.

--- a/tests/test_generate_switch_config_dellanox_csm_1_0.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_0.py
@@ -599,18 +599,6 @@ def test_switch_config_spine_secondary():
             + "interface mlag-port-channel 201 no shutdown\n"
         ) in str(result.output)
         assert (
-            "interface mlag-port-channel 1 lacp-individual enable force\n"
-            + "interface mlag-port-channel 2 lacp-individual enable force\n"
-            + "interface mlag-port-channel 3 lacp-individual enable force\n"
-            + "interface mlag-port-channel 4 lacp-individual enable force\n"
-            + "interface mlag-port-channel 5 lacp-individual enable force\n"
-            + "interface mlag-port-channel 6 lacp-individual enable force\n"
-            + "interface mlag-port-channel 7 lacp-individual enable force\n"
-            + "interface mlag-port-channel 8 lacp-individual enable force\n"
-            + "interface mlag-port-channel 9 lacp-individual enable force\n"
-            + "interface mlag-port-channel 13 lacp-individual enable force\n"
-        ) in str(result.output)
-        assert (
             "vlan 2\n"
             + "vlan 4\n"
             + "vlan 7\n"

--- a/tests/test_generate_switch_config_dellanox_csm_1_2.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_2.py
@@ -648,18 +648,6 @@ def test_switch_config_spine_secondary():
             + "interface mlag-port-channel 201 no shutdown\n"
         ) in str(result.output)
         assert (
-            "interface mlag-port-channel 1 lacp-individual enable force\n"
-            + "interface mlag-port-channel 2 lacp-individual enable force\n"
-            + "interface mlag-port-channel 3 lacp-individual enable force\n"
-            + "interface mlag-port-channel 4 lacp-individual enable force\n"
-            + "interface mlag-port-channel 5 lacp-individual enable force\n"
-            + "interface mlag-port-channel 6 lacp-individual enable force\n"
-            + "interface mlag-port-channel 7 lacp-individual enable force\n"
-            + "interface mlag-port-channel 8 lacp-individual enable force\n"
-            + "interface mlag-port-channel 9 lacp-individual enable force\n"
-            + "interface mlag-port-channel 13 lacp-individual enable force\n"
-        ) in str(result.output)
-        assert (
             "vlan 2\n"
             + "vlan 4\n"
             + "vlan 6\n"


### PR DESCRIPTION
### Summary and Scope

- `canu validate BGP` now has an option to choose what network to run against.
- Remove `'lacp-individual` from mellanox spine02.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

CASMINST-4000
CASMNET-1153

### Testing

Tested on:
 
Hela
Drax
