### PR TITLE
CASMNET-1160

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.1.11~develop
+1.1.20~develop

--- a/canu/backup/__init__.py
+++ b/canu/backup/__init__.py
@@ -1,0 +1,22 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""CANU backup commands."""

--- a/canu/backup/backup.py
+++ b/canu/backup/backup.py
@@ -1,0 +1,39 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""CANU backup commands."""
+import click
+from click_help_colors import HelpColorsGroup
+
+from canu.backup.network import network
+
+
+@click.group(
+    cls=HelpColorsGroup,
+    help_headers_color="yellow",
+    help_options_color="blue",
+)
+@click.pass_context
+def backup(ctx):
+    """Canu backup commands."""
+
+
+backup.add_command(network.network)

--- a/canu/backup/network/__init__.py
+++ b/canu/backup/network/__init__.py
@@ -1,0 +1,22 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""CANU backup network commands."""

--- a/canu/backup/network/network.py
+++ b/canu/backup/network/network.py
@@ -1,0 +1,173 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""CANU backup switch commands."""
+import json
+import logging
+from os import path
+import os
+from pathlib import Path
+import pprint
+import sys
+import regex
+
+import click
+from click_help_colors import HelpColorsCommand
+import click_spinner
+from nornir import InitNornir
+from nornir_netmiko import netmiko_send_command
+from netutils.config.clean import sanitize_config
+
+from canu.utils.inventory import inventory
+
+# Get project root directory
+if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cover
+    project_root = sys._MEIPASS
+else:
+    prog = __file__
+    project_root = Path(__file__).resolve().parent.parent.parent
+
+
+@click.option("--username", default="admin", show_default=True, help="Switch username")
+@click.option(
+    "--password",
+    hide_input=True,
+    confirmation_prompt=False,
+    help="Switch password",
+)
+@click.command(
+    cls=HelpColorsCommand,
+    help_headers_color="yellow",
+    help_options_color="blue",
+)
+@click.option(
+    "--sls-file",
+    help="File containing system SLS JSON data.",
+    type=click.File("r"),
+)
+@click.option(
+    "--network",
+    default="HMN",
+    show_default=True,
+    type=click.Choice(["HMN", "CMN"], case_sensitive=False),
+    help="The network that is used to connect to the switches.",
+)
+@click.option(
+    "--log",
+    "log_",
+    is_flag=True,
+    help="enable logging.",
+    required=False,
+)
+@click.option(
+    "--folder",
+    help="Folder to store config files",
+    required=True,
+    prompt="Folder for configs",
+)
+@click.option(
+    "--unsanitized",
+    help="Retain sensitive data",
+    is_flag=True,
+    required=False,
+)
+@click.option(
+    "--name",
+    "switch_name",
+    required=False,
+    help="The name of the switch that you want to back up. e.g. 'sw-spine-001'",
+)
+@click.option("--sls-address", default="api-gw-service-nmn.local", show_default=True)
+@click.pass_context
+def network(
+    ctx,
+    username,
+    password,
+    sls_file,
+    sls_address,
+    network,
+    log_,
+    folder,
+    unsanitized,
+    switch_name,
+):
+    if not password:
+        password = click.prompt(
+            "Enter the switch password",
+            type=str,
+            hide_input=True,
+        )
+    switch_inventory = inventory(username, password, network, sls_file)
+    print(switch_inventory)
+    nr = InitNornir(
+        runner={
+            "plugin": "threaded",
+            "options": {
+                "num_workers": 10,
+            },
+        },
+        inventory=switch_inventory,
+        logging={"enabled": log_, "to_console": True, "level": "DEBUG"},
+    )
+
+    def save_config_to_file(hostname, config):
+        if not unsanitized:
+            config = sanitize_config(config, SANITIZE_FILTERS)
+        filename = f"{hostname}-.cfg"
+        with open(os.path.join(folder, hostname), "w") as f:
+            f.write(config)
+
+    def get_netmiko_backups():
+        if switch_name:
+            nr_name = nr.filter(filter_func=lambda h: switch_name in h.name)
+            backup_results = nr_name.run(
+                task=netmiko_send_command, enable=True, command_string="show run"
+            )
+        else:
+            backup_results = nr.run(
+                task=netmiko_send_command, enable=True, command_string="show run"
+            )
+
+        for hostname in backup_results:
+            save_config_to_file(
+                hostname=hostname,
+                config=backup_results[hostname][0].result,
+            )
+
+    SANITIZE_FILTERS = [
+        {
+            "regex": r"()(?<=ciphertext).+",
+            "replace": r"\1 <removed>",
+        },
+        {
+            "regex": r"()(?<=password 7).+",
+            "replace": r"\1 <removed>",
+        },
+        {
+            "regex": r"()(?<=password).+",
+            "replace": r"\1 <removed>",
+        },
+        {
+            "regex": r"()(?<=md5).+",
+            "replace": r"\1 <removed>",
+        },
+    ]
+    get_netmiko_backups()

--- a/canu/cli.py
+++ b/canu/cli.py
@@ -31,6 +31,7 @@ import requests
 from ruamel.yaml import YAML
 import urllib3
 
+from canu.backup import backup
 from canu.cache import cache
 from canu.config import config
 from canu.generate import generate
@@ -88,6 +89,7 @@ def cli(ctx, cache_minutes):
     ctx.obj["cache_minutes"] = cache_minutes
 
 
+cli.add_command(backup.backup)
 cli.add_command(cache.cache)
 cli.add_command(config.config)
 cli.add_command(generate.generate)

--- a/canu/utils/inventory.py
+++ b/canu/utils/inventory.py
@@ -1,0 +1,86 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Create Nornir Inventory from SLS."""
+import json
+import pprint
+import click
+from canu.utils.sls import pull_sls_hardware, pull_sls_networks
+
+
+def inventory(username, password, network, sls_json=None):
+    inventory = {"groups": "shasta", "hosts": {}}
+    if sls_json:
+        try:
+            input_json = json.load(sls_json)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            click.secho(
+                f"The file {sls_file.name} is not valid JSON.",
+                fg="red",
+            )
+            return
+        sls_variables = pull_sls_networks(input_json)
+        sls_hardware = pull_sls_hardware(input_json)
+    else:
+        sls_variables = pull_sls_networks()
+        sls_hardware = pull_sls_hardware()
+
+    for k in sls_variables[network + "_IPs"]:
+        if "sw" in k:
+            inventory["hosts"].update(
+                {
+                    k: {
+                        "hostname": str(sls_variables[network + "_IPs"][k]),
+                        "platform": "",
+                        "username": username,
+                        "password": password,
+                    },
+                },
+            )
+    # pull in the platform type from sls hardware data
+    for x in sls_hardware:
+        if (
+            x["Type"] == "comptype_hl_switch"
+            or x["Type"] == "comptype_mgmt_switch"
+            or x["Type"] == "comptype_cdu_mgmt_switch"
+        ):
+            for host in inventory["hosts"]:
+                if host == x["ExtraProperties"]["Aliases"][0]:
+                    if x["ExtraProperties"]["Brand"] == "Aruba":
+                        inventory["hosts"][host]["platform"] = "aruba_os"
+                        vendor = "aruba"
+                    elif x["ExtraProperties"]["Brand"] == "Dell":
+                        inventory["hosts"][host]["platform"] = "dell_os10"
+                    elif x["ExtraProperties"]["Brand"] == "Mellanox":
+                        inventory["hosts"][host]["platform"] = "mellanox"
+                        vendor = "dellanox"
+                    else:
+                        inventory["hosts"][host]["platform"] = "generic"
+    inventory = {
+        "plugin": "DictInventory",
+        "options": {
+            "hosts": inventory["hosts"],
+            "groups": {},
+            "defaults": {},
+        },
+    }
+
+    return inventory

--- a/canu/utils/inventory.py
+++ b/canu/utils/inventory.py
@@ -21,19 +21,21 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """Create Nornir Inventory from SLS."""
 import json
-import pprint
+
 import click
+
 from canu.utils.sls import pull_sls_hardware, pull_sls_networks
 
 
 def inventory(username, password, network, sls_json=None):
+    """Build Nornir inventory from sls_input."""
     inventory = {"groups": "shasta", "hosts": {}}
     if sls_json:
         try:
             input_json = json.load(sls_json)
         except (json.JSONDecodeError, UnicodeDecodeError):
             click.secho(
-                f"The file {sls_file.name} is not valid JSON.",
+                f"The file {sls_json.name} is not valid JSON.",
                 fg="red",
             )
             return
@@ -66,12 +68,10 @@ def inventory(username, password, network, sls_json=None):
                 if host == x["ExtraProperties"]["Aliases"][0]:
                     if x["ExtraProperties"]["Brand"] == "Aruba":
                         inventory["hosts"][host]["platform"] = "aruba_os"
-                        vendor = "aruba"
                     elif x["ExtraProperties"]["Brand"] == "Dell":
                         inventory["hosts"][host]["platform"] = "dell_os10"
                     elif x["ExtraProperties"]["Brand"] == "Mellanox":
                         inventory["hosts"][host]["platform"] = "mellanox"
-                        vendor = "dellanox"
                     else:
                         inventory["hosts"][host]["platform"] = "generic"
     inventory = {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.1.11-develop
+# 🛶 CANU v1.2.0-develop
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -14,6 +14,7 @@ CANU can be used to:
 - Convert SHCD to CCJ (CSM Cabling JSON)
 - Use CCJ / Paddle to validate the network and generate network config
 - Run tests against the mgmt network to check for faults/inconsistencies.
+- Backup switch configs.
 
 # Quickstart Guide
 
@@ -70,6 +71,7 @@ The SHCD can easily be converted into CCJ by using `canu validate shcd --shcd SH
 **[Generate Network Config](#generate-network-config)**<br>
 **[Validate Switch Config](#validate-switch-config)**<br>
 **[Validate Network Config](#validate-network-config)**<br>
+**[Backup Network](#backup-network)**<br>
 **[Cache](#cache)**<br>
 **[Uninstallation](#uninstallation)**<br>
 **[Road Map](#road-map)**<br>
@@ -1092,8 +1094,6 @@ There are several commands to help with the canu cache:
 
 ### Test The Network
 
-Aruba support only.
-
 CANU has the ability to run a set of tests against all of the switches in the management network.
 It is utilizing the nornir automation framework and additional nornir plugins to do this.
 
@@ -1131,7 +1131,42 @@ Example test
     - leaf-bmc
     - spine
 ```
-This test logs into the cdu, leaf, leaf-bmc, and spine switches and runs the command `show version` and checks that `10.08.1021` is in the output.  If it's not the test fails.
+This test logs into the cdu, leaf, leaf-bmc, and spine switches and runs the command `show version` and checks that `10.09.0010` is in the output.  If it's not the test fails.
+
+### Backup Network
+
+Canu can backup the running configurations for switches in the management network.
+It backs up the entire swithc inventory from SLS by defualt, if you want to backup just one switch use the `--name` flag.
+
+Required Input
+You can either use an SLS file or pull the SLS file from the API-Gateway using a token.
+- `--sls-file`
+- `--folder` "Folder to store running config files"
+
+Options
+- `--log` outputs the nornir debug logs
+- `--network [HMN|CMN]` This gives the user the ability to connect to the switches over the CMN.  This allows the use of this tool from outside the Mgmt Network.  The default network used is the HMN.
+- `--password` prompts if password is not entered
+- `--username` defaults to admin
+- `--unsanitized` Retains sensitive data such as passwords and SNMP credentials.  The default is to sanitize the config.
+- `--name` The name of the switch that you want to back up. e.g. 'sw-spine-001'
+
+Example
+```bash
+$ canu backup network --sls-file ./sls_input_file.json --network CMN --folder ./ --unsanitized
+$ ls | grep sw
+sw-cdu-001.cfg
+sw-cdu-002.cfg
+sw-leaf-001.cfg
+sw-leaf-002.cfg
+sw-leaf-003.cfg
+sw-leaf-004.cfg
+sw-leaf-bmc-001.cfg
+sw-leaf-bmc-002.cfg
+sw-spine-001.cfg
+sw-spine-002.cfg
+```
+
 
 ## Uninstallation
 
@@ -1166,6 +1201,9 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.2.0-develop]
+- Add `canu backup network`
 
 ## [1.1.11-develop]
 - `canu validate BGP` now has an option to choose what network to run against.

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ natsort==7.1.1
 ncclient==0.6.12
 netaddr==0.8.0
 netmiko==3.4.0
+netutils==1.0.0
 nornir==3.1.1
 nornir-netmiko==0.1.1
 nornir-salt==0.4.0

--- a/tests/test_backup_network.py
+++ b/tests/test_backup_network.py
@@ -1,0 +1,89 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU backup network."""
+
+from pathlib import Path
+
+from click import testing
+import requests
+import responses
+
+from canu.cli import cli
+
+test_file_directory = Path(__file__).resolve().parent
+
+sls_address = "api-gw-service-nmn.local"
+runner = testing.CliRunner()
+username = "user"
+password = "password"
+folder = "./"
+
+
+@responses.activate
+def test_backup_network_sls_address_bad():
+    """Test that the `canu backup network config` command errors with bad SLS address."""
+    bad_sls_address = "192.168.254.254"
+    responses.add(
+        responses.GET,
+        f"https://{bad_sls_address}/apis/sls/v1/networks",
+        body=requests.exceptions.ConnectionError(
+            "Failed to establish a new connection: [Errno 51] Network is unreachable",
+        ),
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "backup",
+            "network",
+            "--folder",
+            folder,
+            "--sls-address",
+            bad_sls_address,
+            "--password",
+            password,
+        ],
+    )
+    assert result.exit_code == 1
+    print(result.output)
+    assert "Error collecting secret from Kubernetes:" in str(result.output)
+
+
+def test_backup_network_sls_file_missing():
+    """Test that the `canu backup network` command errors on sls_file.json file missing."""
+    bad_sls_file = "/bad_folder"
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "backup",
+                "network",
+                "--sls-file",
+                bad_sls_file,
+                "password",
+                password,
+                "--folder",
+                folder,
+            ],
+        )
+        assert result.exit_code == 2
+        assert "No such file or directory" in str(result.output)


### PR DESCRIPTION
### Summary and Scope

Adds the ability to backup the running config of switches from SLS.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

CASMNET-1160


### Testing

Tested on:

virtualenv, Hela, drax
