### PR TITLE
Track SHCD filename in paddle JSON.

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.2.1~develop
+1.2.2~develop

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -145,7 +145,7 @@ def shcd(ctx, architecture, shcd, tabs, corners, out, json_, log_):
     )
 
     if json_:
-        json_output(node_list, factory, architecture, out)
+        json_output(node_list, factory, architecture, shcd, out)
     else:
         print_node_list(node_list, "SHCD", out)
 
@@ -1132,7 +1132,7 @@ def print_node_list(node_list, title, out="-"):
             logical_index += 1
 
 
-def json_output(node_list, factory, architecture, out):
+def json_output(node_list, factory, architecture, shcd, out):
     """Create a schema-validated JSON Topology file from the model."""
     topology = []
     for node in node_list:
@@ -1141,6 +1141,7 @@ def json_output(node_list, factory, architecture, out):
     paddle = {
         "canu_version": version,
         "architecture": architecture,
+        "shcd_file": path.basename(shcd.name),
         "updated_at": datetime.datetime.now().strftime(
             "%Y-%m-%d %H:%M:%S",
         ),

--- a/network_modeling/schema/paddle-schema.json
+++ b/network_modeling/schema/paddle-schema.json
@@ -10,6 +10,9 @@
             "architecture": {
                 "type": "string"
             },
+            "shcd_file": {
+                "type": "string"
+            },
             "updated_at": {
                 "type": "string"
             },
@@ -102,5 +105,5 @@
             }
         }
     },
-    "required": ["canu_version", "architecture", "topology"]
+    "required": ["canu_version", "architecture", "shcd_file", "topology"]
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.2.1-develop
+# 🛶 CANU v1.2.2-develop
 
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
@@ -1161,6 +1161,8 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+## [1.2.2-develop]
+- Add SHCD filename to paddle/ccj JSON to obtain originating SHCD version.
 
 ## [1.2.1-develop]
 - Remove `canu config bgp`, there is no need for this as it's configured during `canu generated switch/network config`

--- a/tests/data/Full_Architecture_Golden_Config_1.1.5.json
+++ b/tests/data/Full_Architecture_Golden_Config_1.1.5.json
@@ -1,6 +1,7 @@
 {
   "canu_version": "1.1.5~develop",
   "architecture": "network_v2",
+  "shcd_file": "Full_Architecture_Golden_Config_1.1.5.xlsx",
   "updated_at": "2022-01-27 18:26:37",
   "topology": [
     {

--- a/tests/test_validate_paddle.py
+++ b/tests/test_validate_paddle.py
@@ -120,6 +120,7 @@ def test_validate_paddle_no_architecture():
 
 bad_ccj = {
     "canu_version": "0.0.6",
+    "shcd_file": "bad_ccj",
     "topology": [
         {
             "common_name": "sw-spine-001",

--- a/tests/test_validate_paddle_cabling.py
+++ b/tests/test_validate_paddle_cabling.py
@@ -108,7 +108,6 @@ def test_validate_paddle_cabling(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-
         assert (
             "sw-spine-001\n"
             + "Rack: x3000    Elevation: u12\n"
@@ -609,6 +608,7 @@ def test_validate_paddle_cabling_bad_file():
 ccj = {
     "canu_version": "0.0.6",
     "architecture": "network_v2_tds",
+    "shcd_file": "ccj",
     "topology": [
         {
             "common_name": "sw-spine-001",


### PR DESCRIPTION
### Summary and Scope

Previously when a Paddle/CCJ file was created from a validated SHCD there was no way to reference which SHCD (or SHCD version more specifically) was used to create the CCJ file.  This change adds the originating SHCD filename to the CCJ JSON file.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

* Resolves CASMNET-1188

### Testing

Tested on:

* Fanta data