### PR TITLE
Add ospf to vlan 1. Add 'ip ospf passive' to vla 1,4.

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.2.3~develop
+1.2.4~develop

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-leaf-bmc.j2
@@ -49,6 +49,8 @@ interface loopback 0
 interface vlan {{ variables.NATIVE_VLAN }}
     ip mtu 9198
     ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -59,6 +61,7 @@ interface vlan {{ variables.HMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer
     description CMN

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.primary.j2
@@ -81,6 +81,8 @@ interface loopback 0
 interface vlan {{ variables.NATIVE_VLAN }}
     ip mtu 9198
     ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -91,6 +93,7 @@ interface vlan {{ variables.HMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer
     description CMN

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.secondary.j2
@@ -81,6 +81,8 @@ interface loopback 0
 interface vlan {{ variables.NATIVE_VLAN }}
     ip mtu 9198
     ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -91,6 +93,7 @@ interface vlan {{ variables.HMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer
     description CMN

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-spine.primary.j2
@@ -79,6 +79,8 @@ interface vlan {{ variables.NATIVE_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.MTL_IP_GATEWAY }}
     ip helper-address 10.92.100.222
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -95,6 +97,7 @@ interface vlan {{ variables.HMN_VLAN }}
     active-gateway ip {{ variables.HMN_IP_GATEWAY }}
     ip helper-address 10.94.100.222
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 {%- if variables.CMN != None %}
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-spine.secondary.j2
@@ -79,6 +79,8 @@ interface vlan {{ variables.NATIVE_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.MTL_IP_GATEWAY }}
     ip helper-address 10.92.100.222
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -95,6 +97,7 @@ interface vlan {{ variables.HMN_VLAN }}
     active-gateway ip {{ variables.HMN_IP_GATEWAY }}
     ip helper-address 10.94.100.222
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 {%- if variables.CMN != None %}
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer

--- a/network_modeling/configs/templates/1.2/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.2/aruba/tds/sw-leaf-bmc.j2
@@ -49,6 +49,8 @@ interface loopback 0
 interface vlan 1
     ip mtu 9198
     ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -59,6 +61,7 @@ interface vlan {{ variables.HMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer
     description CMN

--- a/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.primary.j2
@@ -83,6 +83,8 @@ interface vlan 1
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.MTL_IP_GATEWAY }}
     ip helper-address 10.92.100.222
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -99,6 +101,7 @@ interface vlan {{ variables.HMN_VLAN }}
     active-gateway ip {{ variables.HMN_IP_GATEWAY }}
     ip helper-address 10.94.100.222
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 {%- if variables.CMN != None %}
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer

--- a/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.secondary.j2
@@ -83,6 +83,8 @@ interface vlan 1
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.MTL_IP_GATEWAY }}
     ip helper-address 10.92.100.222
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
 interface vlan {{ variables.NMN_VLAN }}
     description NMN
     ip mtu 9198
@@ -99,6 +101,7 @@ interface vlan {{ variables.HMN_VLAN }}
     active-gateway ip {{ variables.HMN_IP_GATEWAY }}
     ip helper-address 10.94.100.222
     ip ospf 1 area 0.0.0.0
+    ip ospf passive
 {%- if variables.CMN != None %}
 interface vlan {{ variables.CMN_VLAN }}
     vrf attach Customer

--- a/network_modeling/configs/templates/1.2/dellmellanox/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/full/sw-leaf-bmc.j2
@@ -18,6 +18,8 @@ interface vlan{{ variables.NATIVE_VLAN }}
  no shutdown
  mtu 9216
  ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+ ip ospf 1 area 0.0.0.0
+ ip ospf passive
 
 interface vlan{{ variables.NMN_VLAN }}
  description RIVER_NMN
@@ -36,6 +38,7 @@ interface vlan{{ variables.HMN_VLAN }}
  ip access-group nmn-hmn in
  ip access-group nmn-hmn out
  ip ospf 1 area 0.0.0.0
+ ip ospf passive
 
 interface vlan{{ variables.CMN_VLAN }}
  description CMN

--- a/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.primary.j2
@@ -116,9 +116,12 @@ router ospf 1 vrf default router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer default-information originate
 interface loopback 0 ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
+interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp
 
 ip dhcp relay instance 2 vrf default

--- a/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.secondary.j2
@@ -116,9 +116,12 @@ router ospf 1 vrf default router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer default-information originate
 interface loopback 0 ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
+interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp
 
 ip dhcp relay instance 2 vrf default

--- a/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-leaf-bmc.j2
@@ -18,6 +18,8 @@ interface vlan{{ variables.NATIVE_VLAN }}
  no shutdown
  mtu 9216
  ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}}
+ ip ospf 1 area 0.0.0.0
+ ip ospf passive
 
 interface vlan{{ variables.NMN_VLAN }}
  description RIVER_NMN
@@ -36,6 +38,7 @@ interface vlan{{ variables.HMN_VLAN }}
  ip access-group nmn-hmn in
  ip access-group nmn-hmn out
  ip ospf 1 area 0.0.0.0
+ ip ospf passive
 
 interface vlan{{ variables.CMN_VLAN }}
  description CMN

--- a/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-spine.primary.j2
@@ -110,9 +110,12 @@ router ospf 1 vrf default router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer default-information originate
 interface loopback 0 ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
+interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp
 
 ip dhcp relay instance 2 vrf default

--- a/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/tds/sw-spine.secondary.j2
@@ -110,9 +110,12 @@ router ospf 1 vrf default router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer router-id {{ variables.LOOPBACK_IP }}
 router ospf 2 vrf Customer default-information originate
 interface loopback 0 ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
+interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp
 
 ip dhcp relay instance 2 vrf default

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.2.3-develop
+# 🛶 CANU v1.2.4-develop
 
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
@@ -1161,6 +1161,9 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+## [1.2.4-develop]
+- Add OSPF to vlan 1. Add 'ip ospf passive to vlan 1,4.
+
 ## [1.2.3-develop]
 - Config backup create /running.
 


### PR DESCRIPTION
### Summary and Scope

Description: 

Add 'ip ospf 1 area 0.0.0.0' to VLAN 1  (NATIVE_VLAN)
Add 'ip ospf passive' to VLAN 1,4. (NATIVE_VLAN &  HMN_VLAN"
- This will make OSPF peering more deterministic, and force peering to happen only on VLAN(s) NMN and CAN. 
- Benefits: Easier to troubleshoot and more deterministic peering resulting less of a race condition with OSPF. 

PR checklist (you may replace this section):
- [x ] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have added new tests to cover the new code
- [x ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [x ] I have updated the appropriate Changelog entries in readme.md
- [x ] I have incremented the version in the readme.md
- [x ] I have incremented the version in `canu/.version`

### Issues and Related PRs

* Resolves `CASMNNET-1181`
*
### Testing

Tested on:  Local (configuration previously also tested on mug)

