### PR TITLE
CASMNET-1195 exit(1) bugfix

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.2.6~develop
+1.2.7~develop

--- a/canu/generate/network/config/config.py
+++ b/canu/generate/network/config/config.py
@@ -347,7 +347,7 @@ def config(
                 "The override yaml file was not found, check that you entered the right file name and path.",
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
 
     # make folder
     if not path.exists(folder):

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -363,7 +363,7 @@ def config(
                 "The override yaml file was not found, check that you entered the right file name and path.",
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
 
     switch_config, devices, unknown = generate_switch_config(
         csm,
@@ -501,14 +501,14 @@ def generate_switch_config(
             + "\nMake sure the --csm flag matches the CSM version you are using.",
             fg="red",
         )
-        exit(1)
+        sys.exit(1)
     elif sls_variables["CMN_VLAN"] is None and float(csm) >= 1.2:
         click.secho(
             "\nCMN network not found in SLS, this is required for csm 1.2 "
             + "\nHas the CSM 1.2 SLS upgrade procedure been run?",
             fg="red",
         )
-        exit(1)
+        sys.exit(1)
     spine_leaf_vlan = groupby_vlan_range(spine_leaf_vlan)
     leaf_bmc_vlan = groupby_vlan_range(leaf_bmc_vlan)
 
@@ -593,7 +593,7 @@ def generate_switch_config(
 
     if switch_name not in sls_variables["HMN_IPs"].keys():
         click.secho(f"Cannot find {switch_name} in CSI / SLS nodes.", fg="red")
-        exit(1)
+        sys.exit(1)
 
     cmm_switch_ip = sls_variables.get("CMN_IPs")
     if cmm_switch_ip:
@@ -820,7 +820,7 @@ def get_switch_nodes(switch_name, network_node_list, factory, sls_variables):
             f"For switch {switch_name}, the type cannot be determined. Please check the switch name and try again.",
             fg="red",
         )
-        exit(1)
+        sys.exit(1)
 
     for port in nodes_by_name[switch_name]["ports"]:
         destination_node_id = port["destination_node_id"]

--- a/canu/validate/network/cabling/cabling.py
+++ b/canu/validate/network/cabling/cabling.py
@@ -484,7 +484,7 @@ def node_model_from_canu(factory, canu_cache, ips):
                                 fg="red",
                             ),
                         )
-                        exit(1)
+                        sys.exit(1)
                     if connected:
                         log.info(
                             f"Connected {src_node.common_name()} to"

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -394,7 +394,7 @@ def validate_shcd_port_data(cell, sheet, warnings, is_src_port=False, node_type=
                 "A port number must be specified. "
                 + f"Please correct the SHCD for {sheet}:{location} with an empty value",
             )
-            exit(1)
+            sys.exit(1)
         if port[0].lower() == "j":
             warnings["shcd_port_data"].append(f"{sheet}:{location}")
             log.warning(
@@ -437,7 +437,7 @@ def validate_shcd_port_data(cell, sheet, warnings, is_src_port=False, node_type=
                 "A port number must be specified. "
                 + f"Please correct the SHCD for {sheet}:{cell.coordinate} with an empty value",
             )
-            exit(1)
+            sys.exit(1)
 
     return int(port)
 
@@ -716,7 +716,7 @@ def node_model_from_shcd(factory, spreadsheet, sheets):
                             fg="red",
                         ),
                     )
-                    exit(1)
+                    sys.exit(1)
                 # If the tmp_port is None, make one connection:
                 #   src ==> parent
                 # Continue to connect the rest of the nodes
@@ -822,7 +822,7 @@ def node_model_from_shcd(factory, spreadsheet, sheets):
                             fg="red",
                         ),
                     )
-                    exit(1)
+                    sys.exit(1)
 
     wb.close()
 

--- a/canu/validate/switch/config/config.py
+++ b/canu/validate/switch/config/config.py
@@ -331,7 +331,7 @@ def config(
                 "The override yaml file was not found, check that you entered the right file name and path.",
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
     compare_config_heir(
         running_config_hier.difference(generated_config_hier),
         generated_config_hier.difference(running_config_hier),

--- a/network_modeling/NetworkNodeFactory.py
+++ b/network_modeling/NetworkNodeFactory.py
@@ -442,7 +442,7 @@ class NetworkNodeFactory:
                 + "Cannot generate and write Topology JSON file.",
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
 
         errors = sorted(validator.iter_errors(ccj_json), key=str)
 
@@ -450,4 +450,4 @@ class NetworkNodeFactory:
             click.secho("CCJ failed schema checks:", fg="red")
             for error in errors:
                 click.secho(f"    {error.message}", fg="red")
-            exit(1)
+            sys.exit(1)

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.2.6-develop
+# 🛶 CANU v1.2.7-develop
 
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
@@ -1161,6 +1161,9 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+## [1.2.7-develop]
+- Fixed bug to allow canu to exit gracefully with sys.exit(1)
+
 ## [1.2.6-develop]
 - Add network test cases
 - Add network test cases for DNS and site connectivity
@@ -1175,7 +1178,7 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 - Fix Canu test --network
 
 ## [1.2.4-develop]
-- Add OSPF to vlan 1. 
+- Add OSPF to vlan 1.
 - Add 'ip ospf passive' to vlan 1,4.
 - Fix test cases: test_generate_switch_config_aruba_csm_1_2.py | test_generate_switch_config_dellanox_csm_1_2.py.
 - Fix missing OSPF configuration from VLAN 7 in /network_modeling/configs/templates/dellmellanox/1.2/*.


### PR DESCRIPTION
### Summary and Scope

Description: Allows canu to gracefully exit.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

* Resolves CASMNET-1195

### Testing

Tested on:

* Tested locally
