### PR TITLE
CASMNET-1346

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.3.1~develop
+1.3.2~develop

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -515,7 +515,6 @@ def generate_switch_config(
     """
     node_shasta_name = get_shasta_name(switch_name, factory.lookup_mapper())
 
-    print(node_shasta_name)
     if node_shasta_name is None:
         return Exception(
             click.secho(

--- a/canu/validate/switch/config/config.py
+++ b/canu/validate/switch/config/config.py
@@ -568,6 +568,14 @@ def print_difference_line(additions, additions_int, deletions, deletions_int, ou
 
 
 def aruba_banner(config):
+    """Hier config removes the ! from the end of the Aruba banner, this function adds it back.
+
+    Args:
+        config: hier config object
+
+    Returns:
+        corrected banner
+    """
     banner = config.get_child("contains", "banner")
     if banner is None:
         return

--- a/canu/validate/switch/config/config.py
+++ b/canu/validate/switch/config/config.py
@@ -288,7 +288,6 @@ def config(
     generated_config_hier.load_from_file(generated_config)
 
     dash = "-" * 73
-
     compare_config_heir(
         running_config_hier.difference(generated_config_hier),
         generated_config_hier.difference(running_config_hier),
@@ -328,6 +327,8 @@ def config(
             generated_config_hier,
         )
 
+        if vendor == "aruba":
+            aruba_banner(remediation_config_hier)
         for line in remediation_config_hier.all_children():
             click.echo(line.cisco_style_text(), file=out)
 
@@ -566,6 +567,17 @@ def print_difference_line(additions, additions_int, deletions, deletions_int, ou
     )
 
 
+def aruba_banner(config):
+    banner = config.get_child("contains", "banner")
+    if banner is None:
+        return
+    else:
+        banner_str = str(banner) + "\n!"
+        config.del_child(banner)
+        config.add_child(banner_str)
+        return config
+
+
 def compare_config_heir(config1, config2, vendor, out="-"):
     """Compare and print two switch configurations.
 
@@ -584,6 +596,10 @@ def compare_config_heir(config1, config2, vendor, out="-"):
     config1.set_order_weight()
     config2.set_order_weight()
 
+    # fix aruba banner
+    if vendor == "aruba":
+        aruba_banner(config1)
+        aruba_banner(config2)
     for config1_line in config1.all_children_sorted():
         one.append(config1_line.cisco_style_text())
     for config2_line in config2.all_children_sorted():

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.3.1-develop
+# 🛶 CANU v1.3.2-develop
 
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
@@ -1071,6 +1071,9 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.3.2-develop]
+- Fix aruba banner output during canu validate
 
 ## [1.3.1-develop]
 - shutdown unused ports by default on aruba 6300+dell+mellanox


### PR DESCRIPTION
### Summary and Scope

Fix aruba banner output during `canu validate`

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

CASMNET-1346


### Testing

virtual env/surtur
