### PR TITLE
CASMNET-1191 - define warnings variable as defaultdict(list) to handl…

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.3.2~develop
+1.3.3~develop

--- a/canu/validate/paddle/paddle.py
+++ b/canu/validate/paddle/paddle.py
@@ -106,7 +106,7 @@ def node_model_from_paddle(factory, ccj_json):
     # Add location and Connect Ports
     add_location_and_ports_from_ccj_json(node_list, ccj_json)
 
-    warnings = []
+    warnings = defaultdict(list)
     # FUTURE ==> warnings = factory.check_connections()
     return node_list, warnings
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.3.2-develop
+# 🛶 CANU v1.3.3-develop
 
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
@@ -1071,6 +1071,9 @@ $ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.3.3-develop]
+- Define warnings variable as defaultdict(list) to handle invalid key errors
 
 ## [1.3.2-develop]
 - Fix aruba banner output during canu validate


### PR DESCRIPTION
### Summary and Scope

Description: Define warnings variable as defaultdict(list) to handle invalid key errors by returning an empty list instead of a KeyValue error

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

* Resolves CASMNET-1191

### Testing

Tested on:

* nox, local image
