### PR TITLE
CASMNET-1413

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.5.1~develop
+1.5.3~develop

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.primary.j2
@@ -29,12 +29,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-leaf.secondary.j2
@@ -29,12 +29,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-spine.primary.j2
@@ -28,12 +28,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree
@@ -88,6 +90,7 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
 {%- endif %}
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
     vrf attach Customer
     description CAN
@@ -96,6 +99,7 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include '1.2/aruba/common/prefix-list.j2' %}
 {% include '1.2/aruba/common/route-map.j2' %}

--- a/network_modeling/configs/templates/1.2/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/full/sw-spine.secondary.j2
@@ -28,12 +28,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree
@@ -88,6 +90,7 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
 {%- endif %}
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
     vrf attach Customer
     description CAN
@@ -96,6 +99,7 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include '1.2/aruba/common/prefix-list.j2' %}
 {% include '1.2/aruba/common/route-map.j2' %}

--- a/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.primary.j2
@@ -28,12 +28,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree
@@ -92,6 +94,7 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
 {%- endif %}
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
     vrf attach Customer
     description CAN
@@ -100,6 +103,7 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include '1.2/aruba/common/prefix-list.j2' %}
 {% include '1.2/aruba/common/route-map.j2' %}

--- a/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/aruba/tds/sw-spine.secondary.j2
@@ -28,12 +28,14 @@ vlan {{ variables.HMN_VLAN }}
     apply access-list ip nmn-hmn out
 vlan {{ variables.CMN_VLAN }}
     name CMN
+{%- if variables.CAN != None %}
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
 vlan {{ variables.CAN_VLAN }}
     name CAN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- endif %}
 vlan 10
     name SUN
 spanning-tree
@@ -92,6 +94,7 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
 {%- endif %}
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
     vrf attach Customer
     description CAN
@@ -100,6 +103,7 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include '1.2/aruba/common/prefix-list.j2' %}
 {% include '1.2/aruba/common/route-map.j2' %}

--- a/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.primary.j2
@@ -11,13 +11,21 @@ protocol bgp
 vlan {{ variables.NMN_VLAN }}
 vlan {{ variables.HMN_VLAN }}
 vlan {{ variables.CMN_VLAN }}
-vlan {{ variables.CAN_VLAN }}
 vlan 4000
 vlan {{ variables.NMN_VLAN }} name "RVR_NMN"
 vlan {{ variables.HMN_VLAN }} name "RVR_HMN"
 vlan {{ variables.CMN_VLAN }} name "CMN"
-vlan {{ variables.CAN_VLAN }} name "CAN"
 vlan 4000 name "MLAG" 
+
+{%- if variables.CAN != None %}
+vlan {{ variables.CAN_VLAN }}
+vlan {{ variables.CAN_VLAN }} name "CAN"
+interface vlan {{ variables.CAN_VLAN }} vrf forwarding Customer
+interface vlan {{ variables.CAN_VLAN }} ip address {{ variables.CAN_IP_PRIMARY }}/{{variables.CAN_PREFIX_LEN}} primary
+no interface vlan {{ variables.CAN_VLAN }} ip icmp redirect
+interface vlan {{ variables.CAN_VLAN }} mtu 9184
+interface vlan {{ variables.CAN_VLAN }} ipv4 port access-group cmn-can
+{%- endif %}
 
 no ntp server {{ variables.NCN_W001 }} disable
 ntp server {{ variables.NCN_W001 }} keyID 0
@@ -49,7 +57,6 @@ interface vlan {{ variables.NATIVE_VLAN }}
 interface vlan {{ variables.NMN_VLAN }}
 interface vlan {{ variables.HMN_VLAN }}
 interface vlan {{ variables.CMN_VLAN }} vrf forwarding Customer
-interface vlan {{ variables.CAN_VLAN }} vrf forwarding Customer
 interface vlan 10
 interface vlan 4000
 interface loopback 0 ip address {{ variables.LOOPBACK_IP }}/32 primary
@@ -57,7 +64,6 @@ interface vlan 1 ip address {{ variables.MTL_IP }}/{{variables.MTL_PREFIX_LEN}} 
 interface vlan {{ variables.NMN_VLAN }} ip address {{ variables.NMN_IP }}/{{variables.NMN_PREFIX_LEN}} primary
 interface vlan {{ variables.HMN_VLAN }} ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}} primary
 interface vlan {{ variables.CMN_VLAN }} ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}} primary
-interface vlan {{ variables.CAN_VLAN }} ip address {{ variables.CAN_IP_PRIMARY }}/{{variables.CAN_PREFIX_LEN}} primary
 interface vlan 4000 ip address 192.168.255.253/30 primary
 no interface vlan {{ variables.NATIVE_VLAN }} ip icmp redirect
 interface vlan {{ variables.NATIVE_VLAN }} mtu 9184
@@ -67,13 +73,10 @@ no interface vlan {{ variables.HMN_VLAN }} ip icmp redirect
 interface vlan {{ variables.HMN_VLAN }} mtu 9184
 no interface vlan {{ variables.CMN_VLAN }} ip icmp redirect
 interface vlan {{ variables.CMN_VLAN }} mtu 9184
-no interface vlan {{ variables.CAN_VLAN }} ip icmp redirect
-interface vlan {{ variables.CAN_VLAN }} mtu 9184
 interface vlan 4000 mtu 9216 
 interface vlan {{ variables.NMN_VLAN }} ipv4 port access-group nmn-hmn
 interface vlan {{ variables.HMN_VLAN }} ipv4 port access-group nmn-hmn
 interface vlan {{ variables.CMN_VLAN }} ipv4 port access-group cmn-can
-interface vlan {{ variables.CAN_VLAN }} ipv4 port access-group cmn-can
 ip load-sharing source-ip-port
 ip load-sharing type consistent
    
@@ -111,7 +114,9 @@ interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }} ip ospf area 0.0.0.0
+{%- endif %}
 interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
 interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp

--- a/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.2/dellmellanox/full/sw-spine.secondary.j2
@@ -11,13 +11,21 @@ protocol bgp
 vlan {{ variables.NMN_VLAN }}
 vlan {{ variables.HMN_VLAN }}
 vlan {{ variables.CMN_VLAN }}
-vlan {{ variables.CAN_VLAN }}
 vlan 4000
 vlan {{ variables.NMN_VLAN }} name "RVR_NMN"
 vlan {{ variables.HMN_VLAN }} name "RVR_HMN"
 vlan {{ variables.CMN_VLAN }} name "CMN"
-vlan {{ variables.CAN_VLAN }} name "CAN"
 vlan 4000 name "MLAG" 
+
+{%- if variables.CAN != None %}
+vlan {{ variables.CAN_VLAN }}
+vlan {{ variables.CAN_VLAN }} name "CAN"
+interface vlan {{ variables.CAN_VLAN }} vrf forwarding Customer
+interface vlan {{ variables.CAN_VLAN }} ip address {{ variables.CAN_IP_SECONDARY }}/{{variables.CAN_PREFIX_LEN}} primary
+no interface vlan {{ variables.CAN_VLAN }} ip icmp redirect
+interface vlan {{ variables.CAN_VLAN }} mtu 9184
+interface vlan {{ variables.CAN_VLAN }} ipv4 port access-group cmn-can
+{%- endif %}
 
 no ntp server {{ variables.NCN_W001 }} disable
 ntp server {{ variables.NCN_W001 }} keyID 0
@@ -49,7 +57,6 @@ interface vlan {{ variables.NATIVE_VLAN }}
 interface vlan {{ variables.NMN_VLAN }}
 interface vlan {{ variables.HMN_VLAN }}
 interface vlan {{ variables.CMN_VLAN }} vrf forwarding Customer
-interface vlan {{ variables.CAN_VLAN }} vrf forwarding Customer
 interface vlan 10
 interface vlan 4000
 interface loopback 0 ip address {{ variables.LOOPBACK_IP }}/32 primary
@@ -57,7 +64,6 @@ interface vlan {{ variables.NATIVE_VLAN }} ip address {{ variables.MTL_IP }}/{{v
 interface vlan {{ variables.NMN_VLAN }} ip address {{ variables.NMN_IP }}/{{variables.NMN_PREFIX_LEN}} primary
 interface vlan {{ variables.HMN_VLAN }} ip address {{ variables.HMN_IP }}/{{variables.HMN_PREFIX_LEN}} primary
 interface vlan {{ variables.CMN_VLAN }} ip address {{ variables.CMN_IP }}/{{ variables.CMN_PREFIX_LEN }} primary
-interface vlan {{ variables.CAN_VLAN }} ip address {{ variables.CAN_IP_SECONDARY }}/{{ variables.CAN_PREFIX_LEN }} primary
 interface vlan 4000 ip address 192.168.255.254/30 primary
 no interface vlan {{ variables.NATIVE_VLAN }} ip icmp redirect
 interface vlan {{ variables.NATIVE_VLAN }} mtu 9184
@@ -67,13 +73,10 @@ no interface vlan {{ variables.HMN_VLAN }} ip icmp redirect
 interface vlan {{ variables.HMN_VLAN }} mtu 9184
 no interface vlan {{ variables.CMN_VLAN }} ip icmp redirect
 interface vlan {{ variables.CMN_VLAN }} mtu 9184
-no interface vlan {{ variables.CAN_VLAN }} ip icmp redirect
-interface vlan {{ variables.CAN_VLAN }} mtu 9184
 interface vlan 4000 mtu 9216 
 interface vlan {{ variables.NMN_VLAN }} ipv4 port access-group nmn-hmn
 interface vlan {{ variables.HMN_VLAN }} ipv4 port access-group nmn-hmn
 interface vlan {{ variables.CMN_VLAN }} ipv4 port access-group cmn-can
-interface vlan {{ variables.CAN_VLAN }} ipv4 port access-group cmn-can
 ip load-sharing source-ip-port
 ip load-sharing type consistent
    
@@ -111,7 +114,9 @@ interface vlan {{ variables.NATIVE_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.NMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.HMN_VLAN }} ip ospf area 0.0.0.0
 interface vlan {{ variables.CMN_VLAN }} ip ospf area 0.0.0.0
+{%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }} ip ospf area 0.0.0.0
+{%- endif %}
 interface vlan {{ variables.NATIVE_VLAN }} ip ospf passive-interface
 interface vlan {{ variables.HMN_VLAN }} ip ospf passive-interface
 router ospf 1 vrf default redistribute bgp

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.5.1-develop
+# 🛶 CANU v1.5.3-develop
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1153,6 +1153,10 @@ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.5.3-develop]
+
+- Fixed aruba and dell 1.2 templates so CAN config is only generated when it's detected in SLS.
 
 ## [1.5.1-develop]
 

--- a/tests/test_generate_switch_config_dellanox_csm_1_2.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_2.py
@@ -257,13 +257,13 @@ def test_switch_config_spine_primary():
             "vlan 2\n"
             + "vlan 4\n"
             + "vlan 6\n"
-            + "vlan 7\n"
             + "vlan 4000\n"
             + 'vlan 2 name "RVR_NMN"\n'
             + 'vlan 4 name "RVR_HMN"\n'
             + 'vlan 6 name "CMN"\n'
-            + 'vlan 7 name "CAN"\n'
             + 'vlan 4000 name "MLAG"\n'
+            + "vlan 7\n"
+            + 'vlan 7 name "CAN"\n'
         ) in str(result.output)
         print(result.output)
         assert (
@@ -323,18 +323,20 @@ def test_switch_config_spine_primary():
             + "ip name-server vrf vrf-default 10.92.100.225\n"
             + "interface loopback 0\n"
             + "interface loopback 0 ip address 10.2.0.2/32 primary\n"
+            + "interface vlan 7 vrf forwarding Customer\n"
+            + "interface vlan 7 ip address 192.168.11.2/24 primary\n"
+            + "no interface vlan 7 ip icmp redirect\n"
+            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 1\n"
             + "interface vlan 2\n"
             + "interface vlan 4\n"
             + "interface vlan 6 vrf forwarding Customer\n"
-            + "interface vlan 7 vrf forwarding Customer\n"
             + "interface vlan 10\n"
             + "interface vlan 4000\n"
             + "interface vlan 1 ip address 192.168.1.2/16 primary\n"
             + "interface vlan 2 ip address 192.168.3.2/17 primary\n"
             + "interface vlan 4 ip address 192.168.0.2/17 primary\n"
             + "interface vlan 6 ip address 192.168.12.2/24 primary\n"
-            + "interface vlan 7 ip address 192.168.11.2/24 primary\n"
             + "interface vlan 4000 ip address 192.168.255.253/30 primary\n"
             + "no interface vlan 1 ip icmp redirect\n"
             + "interface vlan 1 mtu 9184\n"
@@ -344,8 +346,6 @@ def test_switch_config_spine_primary():
             + "interface vlan 4 mtu 9184\n"
             + "no interface vlan 6 ip icmp redirect\n"
             + "interface vlan 6 mtu 9184\n"
-            + "no interface vlan 7 ip icmp redirect\n"
-            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 4000 mtu 9216\n"
         ) in str(result.output)
         print(result.output)
@@ -381,10 +381,10 @@ def test_switch_config_spine_primary():
             + "ipv4 access-list cmn-can seq-number 10 deny ip 192.168.12.0 mask 255.255.255.0 192.168.11.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 20 deny ip 192.168.11.0 mask 255.255.255.0 192.168.12.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 30 permit ip any any\n"
+            + "interface vlan 7 ipv4 port access-group cmn-can\n"
             + "interface vlan 2 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 4 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 6 ipv4 port access-group cmn-can\n"
-            + "interface vlan 7 ipv4 port access-group cmn-can\n"
         ) in str(result.output)
         print(result.output)
         assert (
@@ -706,13 +706,13 @@ def test_switch_config_spine_primary_custom():
             "vlan 2\n"
             + "vlan 4\n"
             + "vlan 6\n"
-            + "vlan 7\n"
             + "vlan 4000\n"
             + 'vlan 2 name "RVR_NMN"\n'
             + 'vlan 4 name "RVR_HMN"\n'
             + 'vlan 6 name "CMN"\n'
-            + 'vlan 7 name "CAN"\n'
             + 'vlan 4000 name "MLAG"\n'
+            + "vlan 7\n"
+            + 'vlan 7 name "CAN"\n'
         ) in str(result.output)
         print(result.output)
 
@@ -773,18 +773,20 @@ def test_switch_config_spine_primary_custom():
             + "ip name-server vrf vrf-default 10.92.100.225\n"
             + "interface loopback 0\n"
             + "interface loopback 0 ip address 10.2.0.2/32 primary\n"
+            + "interface vlan 7 vrf forwarding Customer\n"
+            + "interface vlan 7 ip address 192.168.11.2/24 primary\n"
+            + "no interface vlan 7 ip icmp redirect\n"
+            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 1\n"
             + "interface vlan 2\n"
             + "interface vlan 4\n"
             + "interface vlan 6 vrf forwarding Customer\n"
-            + "interface vlan 7 vrf forwarding Customer\n"
             + "interface vlan 10\n"
             + "interface vlan 4000\n"
             + "interface vlan 1 ip address 192.168.1.2/16 primary\n"
             + "interface vlan 2 ip address 192.168.3.2/17 primary\n"
             + "interface vlan 4 ip address 192.168.0.2/17 primary\n"
             + "interface vlan 6 ip address 192.168.12.2/24 primary\n"
-            + "interface vlan 7 ip address 192.168.11.2/24 primary\n"
             + "interface vlan 4000 ip address 192.168.255.253/30 primary\n"
             + "no interface vlan 1 ip icmp redirect\n"
             + "interface vlan 1 mtu 9184\n"
@@ -794,8 +796,6 @@ def test_switch_config_spine_primary_custom():
             + "interface vlan 4 mtu 9184\n"
             + "no interface vlan 6 ip icmp redirect\n"
             + "interface vlan 6 mtu 9184\n"
-            + "no interface vlan 7 ip icmp redirect\n"
-            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 4000 mtu 9216\n"
         ) in str(result.output)
         print(result.output)
@@ -833,10 +833,10 @@ def test_switch_config_spine_primary_custom():
             + "ipv4 access-list cmn-can seq-number 10 deny ip 192.168.12.0 mask 255.255.255.0 192.168.11.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 20 deny ip 192.168.11.0 mask 255.255.255.0 192.168.12.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 30 permit ip any any\n"
+            + "interface vlan 7 ipv4 port access-group cmn-can\n"
             + "interface vlan 2 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 4 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 6 ipv4 port access-group cmn-can\n"
-            + "interface vlan 7 ipv4 port access-group cmn-can\n"
         ) in str(result.output)
         print(result.output)
         assert (
@@ -1146,13 +1146,13 @@ def test_switch_config_spine_secondary():
             "vlan 2\n"
             + "vlan 4\n"
             + "vlan 6\n"
-            + "vlan 7\n"
             + "vlan 4000\n"
             + 'vlan 2 name "RVR_NMN"\n'
             + 'vlan 4 name "RVR_HMN"\n'
             + 'vlan 6 name "CMN"\n'
-            + 'vlan 7 name "CAN"\n'
             + 'vlan 4000 name "MLAG"\n'
+            + "vlan 7\n"
+            + 'vlan 7 name "CAN"\n'
         ) in str(result.output)
         print(result.output)
         assert (
@@ -1211,18 +1211,20 @@ def test_switch_config_spine_secondary():
             + "ip name-server vrf vrf-default 10.92.100.225\n"
             + "interface loopback 0\n"
             + "interface loopback 0 ip address 10.2.0.3/32 primary\n"
+            + "interface vlan 7 vrf forwarding Customer\n"
+            + "interface vlan 7 ip address 192.168.11.3/24 primary\n"
+            + "no interface vlan 7 ip icmp redirect\n"
+            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 1\n"
             + "interface vlan 2\n"
             + "interface vlan 4\n"
             + "interface vlan 6 vrf forwarding Customer\n"
-            + "interface vlan 7 vrf forwarding Customer\n"
             + "interface vlan 10\n"
             + "interface vlan 4000\n"
             + "interface vlan 1 ip address 192.168.1.3/16 primary\n"
             + "interface vlan 2 ip address 192.168.3.3/17 primary\n"
             + "interface vlan 4 ip address 192.168.0.3/17 primary\n"
             + "interface vlan 6 ip address 192.168.12.3/24 primary\n"
-            + "interface vlan 7 ip address 192.168.11.3/24 primary\n"
             + "interface vlan 4000 ip address 192.168.255.254/30 primary\n"
             + "no interface vlan 1 ip icmp redirect\n"
             + "interface vlan 1 mtu 9184\n"
@@ -1232,8 +1234,6 @@ def test_switch_config_spine_secondary():
             + "interface vlan 4 mtu 9184\n"
             + "no interface vlan 6 ip icmp redirect\n"
             + "interface vlan 6 mtu 9184\n"
-            + "no interface vlan 7 ip icmp redirect\n"
-            + "interface vlan 7 mtu 9184\n"
             + "interface vlan 4000 mtu 9216\n"
         ) in str(result.output)
         assert (
@@ -1266,10 +1266,10 @@ def test_switch_config_spine_secondary():
             + "ipv4 access-list cmn-can seq-number 10 deny ip 192.168.12.0 mask 255.255.255.0 192.168.11.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 20 deny ip 192.168.11.0 mask 255.255.255.0 192.168.12.0 mask 255.255.255.0\n"
             + "ipv4 access-list cmn-can seq-number 30 permit ip any any\n"
+            + "interface vlan 7 ipv4 port access-group cmn-can\n"
             + "interface vlan 2 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 4 ipv4 port access-group nmn-hmn\n"
             + "interface vlan 6 ipv4 port access-group cmn-can\n"
-            + "interface vlan 7 ipv4 port access-group cmn-can\n"
         ) in str(result.output)
         assert (
             "protocol ospf\n"


### PR DESCRIPTION
### Summary and Scope

Fixed aruba and dell 1.2 templates so CAN config is only generated when it's detected in SLS.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version`

### Issues and Related PRs

CASMNET-1413


### Testing

VirtualEnv
Wasp