### PR TITLE
Cleanup Builds

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -31,30 +31,27 @@ pipeline {
     }
 
     environment {
-        NAME = "cray-canu"
         DESCRIPTION = "CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze."
-        RPM_NAME = "canu"
-        SPEC_FILE = "canu.spec"
         IS_STABLE = getBuildIsStable()
+        GIT_REPO_NAME = getRepoName()
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
-        PUBLISH_SP2 = "sle-15sp2"
-        PUBLISH_SP3 = "sle-15sp3"
+        OS = "sle-15sp3"
         VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
-        DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
+        DOCKER_ARGS = getDockerBuildArgs(name: "cray-${getRepoName()}", description: env.DESCRIPTION)
     }
 
     stages {
 
-        stage("Prepare") {
+        stage("Prepare: RPM") {
             steps {
                 script {
-                    runLibraryScript("addRpmMetaData.sh", env.SPEC_FILE)
+                    runLibraryScript("addRpmMetaData.sh", env.GIT_REPO_NAME)
                     sh "make prepare"
                 }
             }
         }
 
-        stage("Test") {
+        stage("Test: UnitTests") {
             steps {
                 script {
                     sh "make test"
@@ -62,36 +59,16 @@ pipeline {
             }
         }
 
-        stage("Build Binary") {
+        stage("Build: Binary") {
             steps {
                 script {
                     sh "make binary"
                 }
             }
         }
-        stage("Build SP2") {
-            agent {
-                docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
 
-        stage('Publish SP2') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.RPM_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP2, arch: "x86_64", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.RPM_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP2, arch: "src", isStable: env.IS_STABLE)
-                }
-            }
-        }
-        stage("Build SP3") {
+
+        stage("Build: RPMs") {
             agent {
                 docker {
                     image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
@@ -105,38 +82,35 @@ pipeline {
             }
         }
 
-        stage('Publish SP3') {
+        stage('Publish: RPMs') {
             steps {
                 script {
-                    publishCsmRpms(component: env.RPM_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.PUBLISH_SP3, arch: "x86_64", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.RPM_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP3, arch: "src", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.OS, arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.OS, arch: "src", isStable: env.IS_STABLE)
                 }
             }
         }
-        stage("Build") {
-            parallel {
-                stage('Image') {
-                    steps {
-                        script {
-                            sh "printenv"
-                            sh "make -f Makefile_image image"
-                        }
-                    }
+
+        stage('Build: Image') {
+            steps {
+                script {
+                    sh "printenv"
+                    sh "make -f Makefile_image image"
                 }
             }
         }
-        stage('Publish ') {
+
+        stage('Publish: Image') {
             steps {
                 script {
-                    publishCsmDockerImage(image: env.NAME, tag: env.VERSION, isStable: env.IS_STABLE)
+                    publishCsmDockerImage(image: "cray-${env.GIT_REPO_NAME}", tag: env.VERSION, isStable: env.IS_STABLE)
                 }
             }
         }
     }
     post {
         cleanup {
-            // Own files so jenkins can clean them up later
-            sh "sudo chown -R jenkins ${env.WORKSPACE}"
+            postChownFiles()
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-name = canu
+name ?= ${GIT_REPO_NAME}
 
-version := $(shell cat canu/.version)
+version := $(shell cat $(name)/.version)
 
 build_image := cdrx/pyinstaller-linux:python3
 

--- a/Makefile_image
+++ b/Makefile_image
@@ -1,4 +1,25 @@
-NAME ?= cray-canu
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+NAME ?= cray-${GIT_REPO_NAME}
 VERSION ?= $(shell .version)
 
 


### PR DESCRIPTION
Only build and publish an RPM for one service pack, this'll shorten the build length. There's no functional difference in canu between SP2 and SP3 to require building for both.

Remove redundant instances of "canu". Replace manual cleanup of file permissions with the csm-shared-library.postChownFiles() function.

This will publish only a sles15sp3 RPM, meaning the CSM manifest will now need to:
- Cease including canu in https://github.com/Cray-HPE/csm/blob/main/rpm/cray/csm/sle-15sp2/index.yaml
- Will start needing to include canu in https://github.com/Cray-HPE/csm/blob/main/rpm/cray/csm/sle-15sp3/index.yaml