### PR TITLE
Amend the Previous Cleanup

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -43,6 +43,14 @@ pipeline {
     stages {
 
         stage("Prepare: RPM") {
+            agent {
+                docker {
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10"
+                    reuseNode true
+                    // Support docker in docker for clamav scan
+                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+                }
+            }
             steps {
                 script {
                     runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
@@ -71,7 +79,7 @@ pipeline {
         stage("Build: RPMs") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -45,7 +45,7 @@ pipeline {
         stage("Prepare: RPM") {
             steps {
                 script {
-                    runLibraryScript("addRpmMetaData.sh", env.GIT_REPO_NAME)
+                    runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
                     sh "make prepare"
                 }
             }


### PR DESCRIPTION
The previous cleanup produces an RPM, but the addRpmMetaData script
fails early on. the addRpmMetaData script is looking for `canu` when it
needs to look for `canu.spec`.

Example of the error in the pipeline:
```bash
08:31:22  + ./addRpmMetaData.sh canu
08:31:22  Warning: Specfile doesn't exist
```

Despite the error, a valid RPM is produced. However some meta about the Git repo is missing: 
```bash
Description :
Git Repository: canu
Git Branch: 1.5.7
Git Commit Revision: 8c9052fd
Git Commit Timestamp: Fri Apr 22 14:18:08 2022 -0500

CSM Automatic Network Utility
Distribution: Debian GNU/Linux 11 (bullseye)
```

Example of a good RPM:
```bash
redbull-ncn-m001-pit:~ # rpm -qi canu
Name        : canu
Version     : 1.5.7
Release     : 1
Architecture: x86_64
Install Date: Tue 10 May 2022 07:52:07 PM UTC
Group       : Metal
Size        : 30385588
License     : MIT License
Signature   : (none)
Source RPM  : canu-1.5.7-1.src.rpm
Build Date  : Tue 10 May 2022 10:28:06 AM UTC
Build Host  : 48fcc4cd0da4
Relocations : (not relocatable)
Vendor      : Cray Inc.
URL         : https://github.com/Cray-HPE/canu.git
Summary     : CSM Automatic Network Utility
Description :
Git Repository: canu
Git Branch: 1.5.7
Git Commit Revision: 8c9052fd
Git Commit Timestamp: Fri Apr 22 14:18:08 2022 -0500

CSM Automatic Network Utility
Distribution: Debian GNU/Linux 11 (bullseye)
```

Example of the RPM built by develop after merging #150 
```bash
redbull-ncn-m001-pit:~ # rpm -qi canu
Name        : canu
Version     : 1.5.7~develop
Release     : 1~develop~20220516133120.35d3a04
Architecture: x86_64
Install Date: Mon 16 May 2022 02:11:29 PM UTC
Group       : Metal
Size        : 30374460
License     : MIT License
Signature   : (none)
Source RPM  : canu-1.5.7~develop-1~develop~20220516133120.35d3a04.src.rpm
Build Date  : Mon 16 May 2022 01:42:37 PM UTC
Build Host  : 5ca923a38f65
Relocations : (not relocatable)
Vendor      : Cray Inc.
Summary     : CSM Automatic Network Utility
Description :
CSM Automatic Network Utility
Distribution: (none)
```

This change builds an RPM with the metadata added back in, but also with the distribution corrected for SLES:
```bash
Description :
Git Repository: canu
Git Branch: fix-rpm-metadata
Git Commit Revision: e54a2168
Git Commit Timestamp: Mon May 16 09:16:45 2022 -0500

CSM Automatic Network Utility
Distribution: SUSE Linux Enterprise Server 15 SP3
```

### Summary and Scope

Description: What does this change do?  Use examples of new options and output changes when possible.  If other changes were made list these as well in a list.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have added new tests to cover the new code
- [ x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [ ] I have updated the appropriate Changelog entries in readme.md
- [ ] I have incremented the version in the readme.md
- [ ] I have incremented the version in `canu/.version` and `.version`

### Issues and Related PRs

* Relates to #150 


### Testing

Tested on:

* List of virtual system tested.
* List of physical systems tested.
