### PR TITLE
CASMNET-1557: fix for Dell4148 port count

### DIFF
--- a/canu/.version
+++ b/canu/.version
@@ -1,1 +1,1 @@
-1.5.10~develop
+1.5.13~develop

--- a/network_modeling/models/cray-network-hardware.yaml
+++ b/network_modeling/models/cray-network-hardware.yaml
@@ -212,7 +212,7 @@ network_hardware:
     ports:
       - count: 24
         speed: [1, 10]
-      - count: 4
+      - count: 6
         speed: 100
       - count: 24
         speed: [1, 10]

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.5.9-develop
+# 🛶 CANU v1.5.13-develop
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1153,6 +1153,10 @@ nox -s tests -- tests/test_report_switch_firmware.py
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.5.13-develop]
+
+- Fix Dell4148 template to inclure correct port count 
 
 ## [1.5.10-develop]
 


### PR DESCRIPTION
### Summary and Scope

Description: 

Dell 4148 hardware model is incorrect and does not recognize ports 53-54. 

Changing model to add 2 extra ports in here: 

 ports:
          - count: 24
            speed: [1, 10]
          - count: 4  <--- should be six to make amount of port numbers available

/networkmodeling/models/cray-network-hardware yaml

    name: "Dell 4148T"
        vendor: "dell"
        model: "S4148T-ON"
        type: "switch"
        deprecated: True
        preserve_hardware_model_port_layout: True
        ports:
          - count: 24
            speed: [1, 10]
          - count: 6
            speed: 100
          - count: 24
            speed: [1, 10]
          - count: 1
            speed: 1
            slot: "mgmt"
      - name: "SLINGSHOT 200G 64P"
        vendor: "cray"
        model: "slingshot_hsn_switch"
        type: "switch"
        deprecated: False
        ports:
          - count: 1
            speed: 1
            slot: "mgmt"
          - count: 64
            speed: 200



PR checklist (you may replace this section):
- [ ] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [ ] I have updated the appropriate Changelog entries in readme.md
- [ ] I have incremented the version in the readme.md
- [ ] I have incremented the version in `canu/.version` and `.version`

### Issues and Related PRs

* Resolves `CASMNET-1557`
* Relates to `Issue`
* Requires `Issue`


### Testing

Tested on: nox, shandy