### PR TITLE
Publish RPMs to both dropoff locations

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -38,7 +38,6 @@ pipeline {
         IS_STABLE = getBuildIsStable()
         GIT_REPO_NAME = getRepoName()
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
-        OS = "sle-15sp3"
         IMAGE_VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
         DOCKER_ARGS = getDockerBuildArgs(name: "cray-${getRepoName()}", description: env.DESCRIPTION)
     }
@@ -88,8 +87,10 @@ pipeline {
         stage('Publish: RPMs') {
             steps {
                 script {
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: env.OS, arch: "x86_64", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.OS, arch: "src", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: env.IS_STABLE)
                 }
             }
         }


### PR DESCRIPTION
This just publishes RPMs to both locations:
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp2/
- https://artifactory.algol60.net/ui/repos/tree/General/csm-rpms/sle-15sp3/

Since the package is compatible with both distros, this removes the opportunity for any misconception while allowing zypper to pull the latest RPM all the same.