### PR TITLE
Use python docker image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*   @Cray-HPE/management-network
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,35 +20,32 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-from artifactory.algol60.net/csm-docker/stable/docker.io/python:slim-bullseye
+FROM artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:3.10
 
 # create canu user
-RUN useradd -ms /bin/bash canu
+RUN     useradd -ms /bin/bash canu
 
 # update command prompt
-RUN echo 'export PS1="canu \w : "' >> /etc/bash.bashrc
+RUN     echo 'export PS1="canu \w : "' >> /etc/bash.bashrc
 
 # make files dir
-RUN mkdir /files
+RUN     mkdir /files
 
 # prep image layer for faster builds
-COPY requirements.txt /app/canu/
+COPY    requirements.txt /app/canu/
 
-RUN apt-get -yq update && apt-get -yq install gcc openssl jq vim libffi-dev musl-dev \
-    python3 python3-dev python3-pip
-
-RUN pip3 install --upgrade pip && pip3 install -r /app/canu/requirements.txt
+RUN     pip3 install -r /app/canu/requirements.txt
 
 # copy canu files
-COPY . /app/canu
+COPY    . /app/canu
 
 # install canu
-RUN pip3 install --editable /app/canu/
+RUN     pip3 install --editable /app/canu/
 
 # set file perms for canu
-RUN chown -R canu /app/canu /files
+RUN     chown -R canu /app/canu /files
 
 # set none root user: canu
-USER canu
+USER    canu
 
 WORKDIR /files


### PR DESCRIPTION
This switches the docker image to a new base image that has the same environment we use to build canu.