### PR TITLE
Add edge router ISLs to all 3 network architectures

### DIFF
--- a/network_modeling/models/cray-network-architecture.yaml
+++ b/network_modeling/models/cray-network-architecture.yaml
@@ -136,6 +136,8 @@ network_v2:
       connections:
         - name: "spine"
           speed: 100
+        - name: "customer_edge_router"
+          speed: 100
     - name: "cec"
       model: "cec"
       connections:
@@ -309,6 +311,8 @@ network_v2_tds:
       model: "customer_edge_router"
       connections:
         - name: "spine"
+          speed: 100
+        - name: "customer_edge_router"
           speed: 100
     - name: "river_compute_node"
       model: "river_compute_node"


### PR DESCRIPTION
### Summary and Scope

Edge router ISLs available for the v2 full architecture, but not for tds and v1.  Added to those architectures.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [ ] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated pyinstaller.py
- [ ] I have updated the appropriate Changelog entries in readme.md
- [ ] I have incremented the version in the readme.md
- [ ] I have incremented the version in `canu/.version` and `.version`

### Issues and Related PRs

* Resolves `Issue`
* Relates to `Issue`
* Requires `Issue`


### Testing

Tested on:

* List of virtual system tested.
* List of physical systems tested.
