### PR TITLE
CASMNET-1896

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.6.20
+# 🛶 CANU v1.6.21
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1283,6 +1283,12 @@ To run a specific test file:
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.6.21]
+
+- Update Arista BGP templates
+- Add feature flag for CHN BGP control plane
+- Fix ordering of switch configuration when using custom switch configs or `--reorder`
 
 ## [1.6.20]
 

--- a/canu/generate/network/config/config.py
+++ b/canu/generate/network/config/config.py
@@ -154,6 +154,13 @@ csm_options = canu_config["csm_versions"]
     help="reorder config to heir config order",
     required=False,
 )
+@click.option(
+    "--bgp-control-plane",
+    type=click.Choice(["CMN", "CHN"], case_sensitive=False),
+    help="Network used for BGP control plane",
+    required=False,
+    default="CHN",
+)
 @click.pass_context
 def config(
     ctx,
@@ -170,6 +177,7 @@ def config(
     preserve,
     custom_config,
     reorder,
+    bgp_control_plane,
 ):
     """Generate the config of all switches (Aruba, Dell, or Mellanox) on the network using the SHCD.
 
@@ -228,6 +236,7 @@ def config(
         preserve: Folder where switch running configs exist.  This folder should be populated from the "canu backup network" command.
         custom_config: yaml file containing customized switch configurations which is merged with the generated config.
         reorder: Filters generated configurations through hier_config generate a more natural running-configuration order.
+        bgp_control_plane: Network used for BGP control plane
     """
     # SHCD Parsing
     if shcd:
@@ -398,6 +407,7 @@ def config(
                 preserve,
                 custom_config,
                 reorder,
+                bgp_control_plane,
             )
             all_unknown.extend(unknown)
             config_devices.update(devices)

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -31,13 +31,18 @@ import sys
 
 import click
 from click_help_colors import HelpColorsCommand
-from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
-from hier_config import HConfig, Host
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from click_option_group import optgroup
+from click_option_group import RequiredMutuallyExclusiveOptionGroup
+from hier_config import HConfig
+from hier_config import Host
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
+from jinja2 import StrictUndefined
 import natsort
 import netaddr
 from netutils.mac import is_valid_mac
 from network_modeling.NetworkNodeFactory import NetworkNodeFactory
+import pkg_resources
 import requests
 from ruamel.yaml import YAML
 from ttp import ttp
@@ -68,7 +73,6 @@ else:
 # Schema and Data files
 canu_cache_file = path.join(cache_directory(), "canu_cache.yaml")
 canu_config_file = path.join(project_root, "canu", "canu.yaml")
-canu_version_file = path.join(project_root, "canu", ".version")
 
 # ttp preserve templates
 # pulls the interface and lag from switch configs.
@@ -112,10 +116,7 @@ with open(canu_config_file, "r") as file:
 
 csm_options = canu_config["csm_versions"]
 
-# Get CANU version from .version
-with open(canu_version_file, "r") as file:
-    canu_version = file.readline()
-canu_version = canu_version.strip()
+canu_version = pkg_resources.get_distribution("canu").version
 
 dash = "-" * 60
 

--- a/canu/validate/switch/config/aoscx_options.yaml
+++ b/canu/validate/switch/config/aoscx_options.yaml
@@ -90,6 +90,9 @@ ordering:
       - startswith: ip
     order: 820
   - lineage:
+      - startswith: route-map
+    order: 830
+  - lineage:
       - startswith: router
     order: 850
   - lineage:

--- a/network_modeling/configs/templates/1.3/arista/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.3/arista/sw-edge.primary.j2
@@ -4,20 +4,24 @@ transceiver qsfp default-mode 4x10G
 !
 hostname sw-edge-001
 !
-spanning-tree mode rstp
+spanning-tree mode none
 no spanning-tree vlan-id 4094
 
-interface loopback 0
-    ip address {{ variables.LOOPBACK_IP }}/32
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
 
 interface Management1
    ip address 172.30.52.119/20
    
+vlan 5
+   name CHN
+
 vlan 4094
    trunk group MLAG-Peer
 !
-int Port-Channel1000
- des [MLAG Peer-Link]
+interface Port-Channel1000
+ description [MLAG Peer-Link]
  switchport mode trunk
  switchport trunk group MLAG-Peer
 !
@@ -25,6 +29,7 @@ interface Vlan4094
    description [MLAG Link]
    no autostate
    ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
 !
 
 interface Vlan{{ variables.CHN_VLAN }}
@@ -34,10 +39,10 @@ interface Vlan{{ variables.CHN_VLAN }}
    ip virtual-router address {{ variables.CHN_IP_GATEWAY }}
 ip routing
 
+ip virtual-router mac-address 06:00:00:20:20:20
+
 ip prefix-list HSN seq 10 permit {{ variables.CHN }} ge {{ variables.CHN_PREFIX_LEN }}
 !
-route-map HSN permit 5
-   match ip address prefix-list HSN
 
 mlag configuration
    domain-id edge
@@ -46,21 +51,71 @@ mlag configuration
    peer-address heartbeat 172.30.52.120
    peer-link Port-Channel1000
 
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+{# note: hard coded IPs until we get them added to IPAM/SLS #}
+
+{%- if variables.BGP_CONTROL_PLANE == 'CMN' %}
+{%- for name, ip in variables.NMN_IPs.items() if "ncn-w" in name %}
+{% set sequence = namespace(value=10) %}
+route-map {{ name }}-CHN permit {{ sequence.value }}
+     match ip address prefix-list HSN
+     {%- for CHN_name, CHN_ip in variables.CHN_IPs.items() if name == CHN_name %}
+     set ip next-hop {{ CHN_ip }}
+     {%- endfor %}
+{%- endfor %}
+
 router bgp {{ variables.SWITCH_ASN }}
+   timers bgp 1 3
    distance bgp 20 200 200
-   router-id {{ variables.LOOPBACK_IP }}
+   router-id 10.2.1.194
    maximum-paths 32
-   neighbor {{ variables.EDGE_BGP_IP_SECONDARY }} remote-as {{ variables.SWITCH_ASN }}
-   neighbor {{ variables.EDGE_BGP_IP_SECONDARY }} next-hop-self
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   {%- for name, ip in variables.CMN_IPs.items() if "ncn-w" in name %}
+   neighbor {{ ip }} remote-as {{ variables.CHN_ASN }}
+   neighbor {{ ip }} passive
+   neighbor {{ ip }} ebgp-multihop 5
+   neighbor {{ ip }} update-source Loopback0
+   neighbor {{ ip }} route-map {{ name }}-CHN in
+   neighbor {{ ip }} maximum-routes 12000
+   {%- endfor %}
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+   {%- for name, ip in variables.CMN_IPs.items() if "ncn-w" in name %}
+      neighbor {{ ip }} activate
+   {%- endfor %}
+{%- endif %}
+
+{%- if variables.BGP_CONTROL_PLANE == 'CHN' %}
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp {{ variables.SWITCH_ASN }}
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
    {%- for name, ip in variables.CHN_IPs.items() if "ncn-w" in name %}
    neighbor {{ ip }} remote-as {{ variables.CHN_ASN }}
    neighbor {{ ip }} passive
    neighbor {{ ip }} route-map HSN in
+   neighbor {{ ip }} maximum-routes 12000
    {%- endfor %}
-
-router ospf 1
-   router-id {{ variables.LOOPBACK_IP }}
-   max-lsa 12000
-   default-information originate
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+   {%- for name, ip in variables.CHN_IPs.items() if "ncn-w" in name %}
+      neighbor {{ ip }} activate
+   {%- endfor %}
+{%- endif %}
 
 {#- end edge_router #}

--- a/network_modeling/configs/templates/1.3/arista/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.3/arista/sw-edge.secondary.j2
@@ -4,20 +4,24 @@ transceiver qsfp default-mode 4x10G
 !
 hostname sw-edge-002
 !
-spanning-tree mode rstp
+spanning-tree mode none
 no spanning-tree vlan-id 4094
 
-interface loopback 0
-    ip address {{ variables.LOOPBACK_IP }}/32
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
 
 interface Management1
    ip address 172.30.52.120/20
-   
+
+vlan 5
+   name CHN
+
 vlan 4094
    trunk group MLAG-Peer
 !
-int Port-Channel1000
- des [MLAG Peer-Link]
+interface Port-Channel1000
+ description [MLAG Peer-Link]
  switchport mode trunk
  switchport trunk group MLAG-Peer
 !
@@ -25,6 +29,7 @@ interface Vlan4094
    description [MLAG Link]
    no autostate
    ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
 !
 
 interface Vlan{{ variables.CHN_VLAN }}
@@ -34,11 +39,11 @@ interface Vlan{{ variables.CHN_VLAN }}
    ip virtual-router address {{ variables.CHN_IP_GATEWAY }}
 ip routing
 
+ip virtual-router mac-address 06:00:00:20:20:20
+
 ip prefix-list HSN seq 10 permit {{ variables.CHN }} ge {{ variables.CHN_PREFIX_LEN }}
 !
-route-map HSN permit 5
-   match ip address prefix-list HSN
-   
+
 mlag configuration
    domain-id edge
    local-interface Vlan4094
@@ -46,21 +51,69 @@ mlag configuration
    peer-address heartbeat 172.30.52.119
    peer-link Port-Channel1000
 
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+
+{%- if variables.BGP_CONTROL_PLANE == 'CMN' %}
+{%- for name, ip in variables.NMN_IPs.items() if "ncn-w" in name %}
+{% set sequence = namespace(value=10) %}
+route-map {{ name }}-CHN permit {{ sequence.value }}
+     match ip address prefix-list HSN
+     {%- for CHN_name, CHN_ip in variables.CHN_IPs.items() if name == CHN_name %}
+     set ip next-hop {{ CHN_ip }}
+     {%- endfor %}
+{%- endfor %}
+
 router bgp {{ variables.SWITCH_ASN }}
+   timers bgp 1 3
    distance bgp 20 200 200
-   router-id {{ variables.LOOPBACK_IP }}
+   router-id 10.2.1.195
    maximum-paths 32
-   neighbor {{ variables.EDGE_BGP_IP_PRIMARY }} remote-as {{ variables.SWITCH_ASN }}
-   neighbor {{ variables.EDGE_BGP_IP_PRIMARY }} next-hop-self
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   {%- for name, ip in variables.CMN_IPs.items() if "ncn-w" in name %}
+   neighbor {{ ip }} remote-as {{ variables.CHN_ASN }}
+   neighbor {{ ip }} passive
+   neighbor {{ ip }} ebgp-multihop 5
+   neighbor {{ ip }} update-source Loopback0
+   neighbor {{ ip }} route-map {{ name }}-CHN in
+   neighbor {{ ip }} maximum-routes 12000
+   {%- endfor %}
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+   {%- for name, ip in variables.CMN_IPs.items() if "ncn-w" in name %}
+      neighbor {{ ip }} activate
+   {%- endfor %}
+{%- endif %}
+
+{%- if variables.BGP_CONTROL_PLANE == 'CHN' %}
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp {{ variables.SWITCH_ASN }}
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
    {%- for name, ip in variables.CHN_IPs.items() if "ncn-w" in name %}
    neighbor {{ ip }} remote-as {{ variables.CHN_ASN }}
    neighbor {{ ip }} passive
    neighbor {{ ip }} route-map HSN in
+   neighbor {{ ip }} maximum-routes 12000
    {%- endfor %}
-
-router ospf 1
-   router-id {{ variables.LOOPBACK_IP }}
-   max-lsa 12000
-   default-information originate
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+   {%- for name, ip in variables.CHN_IPs.items() if "ncn-w" in name %}
+      neighbor {{ ip }} activate
+   {%- endfor %}
+{%- endif %}
 
 {#- end edge_router #}

--- a/tests/test_generate_switch_config_aruba_csm_1_2.py
+++ b/tests/test_generate_switch_config_aruba_csm_1_2.py
@@ -25,6 +25,7 @@ from os import path
 from pathlib import Path
 
 from click import testing
+import pkg_resources
 import requests
 import responses
 
@@ -51,10 +52,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version_file = path.join(test_file_directory.resolve().parent, "canu", ".version")
-with open(canu_version_file, "r") as file:
-    canu_version = file.readline()
-canu_version = canu_version.strip()
+canu_version = pkg_resources.get_distribution('canu').version
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_aruba_csm_1_2.py
+++ b/tests/test_generate_switch_config_aruba_csm_1_2.py
@@ -25,7 +25,6 @@ from os import path
 from pathlib import Path
 
 from click import testing
-import pkg_resources
 import requests
 import responses
 
@@ -52,7 +51,10 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version_file = path.join(test_file_directory.resolve().parent, "canu", ".version")
+with open(canu_version_file, "r") as file:
+    canu_version = file.readline()
+canu_version = canu_version.strip()
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"
@@ -637,9 +639,14 @@ def test_switch_config_spine_primary_custom():
         assert sw_spine_to_leaf in str(result.output)
 
         output = (
-            "no ip icmp redirect\n"
-            + "apply access-list ip mgmt control-plane vrf default\n"
-            + "apply access-list ip mgmt control-plane vrf Customer\n"
+            "ip dns server-address 10.92.100.225\n"
+            + "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
+            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
+            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
+            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
+            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
+            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
+            + "ip route 0.0.0.0/0 10.103.15.185\n"
             + "route-map ncn-w001 permit seq 10\n"
             + "    match ip address prefix-list tftp\n"
             + "    match ip next-hop 192.168.4.4\n"
@@ -714,7 +721,10 @@ def test_switch_config_spine_primary_custom():
 
         print(result.output)
         assert (
-            "system interface-group 3 speed 10g\n"
+            "no ip icmp redirect\n"
+            + "apply access-list ip mgmt control-plane vrf default\n"
+            + "apply access-list ip mgmt control-plane vrf Customer\n"
+            + "system interface-group 3 speed 10g\n"
             + "interface loopback 0\n"
             + "    ip address 10.2.0.2/32\n"
             + "    ip ospf 1 area 0.0.0.0\n"
@@ -826,15 +836,7 @@ def test_switch_config_spine_primary_custom():
 
         print(result.output)
         assert (
-            "ip dns server-address 10.92.100.225\n"
-            + "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
-            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
-            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
-            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
-            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
-            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
-            + "ip route 0.0.0.0/0 10.103.15.185\n"
-            + "router ospf 2 vrf Customer\n"
+            "router ospf 2 vrf Customer\n"
             + "    router-id 10.2.0.2\n"
             + "    default-information originate\n"
             + "    area 0.0.0.0\n"
@@ -1050,9 +1052,14 @@ def test_switch_config_spine_secondary_custom():
         assert sw_spine_to_leaf in str(result.output)
 
         output = (
-            "no ip icmp redirect\n"
-            + "apply access-list ip mgmt control-plane vrf default\n"
-            + "apply access-list ip mgmt control-plane vrf Customer\n"
+            "ip dns server-address 10.92.100.225\n"
+            + "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
+            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
+            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
+            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
+            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
+            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
+            + "ip route 0.0.0.0/0 10.103.15.189\n"
             + "route-map ncn-w001 permit seq 10\n"
             + "    match ip address prefix-list tftp\n"
             + "    match ip next-hop 192.168.4.4\n"
@@ -1127,7 +1134,10 @@ def test_switch_config_spine_secondary_custom():
 
         print(result.output)
         assert (
-            "system interface-group 3 speed 10g\n"
+            "no ip icmp redirect\n"
+            + "apply access-list ip mgmt control-plane vrf default\n"
+            + "apply access-list ip mgmt control-plane vrf Customer\n"
+            + "system interface-group 3 speed 10g\n"
             + "interface loopback 0\n"
             + "    ip address 10.2.0.3/32\n"
             + "    ip ospf 1 area 0.0.0.0\n"
@@ -1240,15 +1250,7 @@ def test_switch_config_spine_secondary_custom():
 
         print(result.output)
         assert (
-            "ip dns server-address 10.92.100.225\n"
-            + "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
-            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
-            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
-            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
-            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
-            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
-            + "ip route 0.0.0.0/0 10.103.15.189\n"
-            + "router ospf 2 vrf Customer\n"
+            "router ospf 2 vrf Customer\n"
             + "    router-id 10.2.0.3\n"
             + "    default-information originate\n"
             + "    area 0.0.0.0\n"


### PR DESCRIPTION
### Summary and Scope

- Update Arista BGP templates
- Add feature flag to select either CHN or CMN for BI-CAN BGP control plane traffic.
- Fix ordering of switch configuration when using custom switch configs.

PR checklist (you may replace this section):
- [x] I have run `nox` locally and all tests, linting, and code coverage pass.
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated pyinstaller.py
- [x] I have updated the appropriate Changelog entries in readme.md
- [x] I have incremented the version in the readme.md
- [x] I have incremented the version in `canu/.version` and `.version`

### Issues and Related PRs

CASMNET-1896
CAST-30648
CASMNET-1899

### Testing

Tested on:

surtur
