### PR TITLE
Add missing nodes to v1 architecture and clean up switch and network config generation output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.6.25
+# 🛶 CANU v1.6.26
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1350,6 +1350,12 @@ To run a specific test file:
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.6.26]
+
+- Added gpu and kvm node definitions to v1 arrchitecture.
+- Added logging to `canu generate switch/network config` to clean up output.
+- Provided better messaging about next-step handling of missing configs in generated files.
 
 ## [1.6.25]
 

--- a/canu/cli.py
+++ b/canu/cli.py
@@ -54,7 +54,7 @@ if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cov
 else:
     parent_directory = path.abspath(path.dirname(path.dirname(__file__)))
 
-version = pkg_resources.get_distribution('canu').version
+version = pkg_resources.get_distribution("canu").version
 
 canu_config_file = path.join(parent_directory, "canu", "canu.yaml")
 with open(canu_config_file, "r") as canu_f:

--- a/canu/generate/network/config/config.py
+++ b/canu/generate/network/config/config.py
@@ -62,7 +62,7 @@ else:
 canu_cache_file = path.join(cache_directory(), "canu_cache.yaml")
 canu_config_file = path.join(project_root, "canu", "canu.yaml")
 
-log = logging.getLogger(("generate_network_config"))
+log = logging.getLogger("generate_network_config")
 
 # Import templates
 network_templates_folder = path.join(

--- a/canu/utils/cache.py
+++ b/canu/utils/cache.py
@@ -67,7 +67,7 @@ else:
     project_root = Path(__file__).resolve().parent.parent.parent
 
 canu_cache_file = path.join(cache_directory(), "canu_cache.yaml")
-version = pkg_resources.get_distribution('canu').version
+version = pkg_resources.get_distribution("canu").version
 file_exists = path.isfile(canu_cache_file)
 
 # Open the Cache file, and generate it if it does not exist

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -46,7 +46,7 @@ else:
     prog = __file__
     project_root = Path(__file__).resolve().parent.parent.parent.parent
 
-version = pkg_resources.get_distribution('canu').version
+version = pkg_resources.get_distribution("canu").version
 
 log = logging.getLogger("validate_shcd")
 

--- a/network_modeling/models/cray-network-architecture.yaml
+++ b/network_modeling/models/cray-network-architecture.yaml
@@ -548,6 +548,11 @@ network_v1:
           speed: 1
         - name: "river_bmc_leaf"
           speed: 1
+    - name: "kvm"
+      model: "kvm"
+      connections:
+        - name: "river_bmc_leaf"
+          speed: 1
   lookup_mapper:
     - lookup_name:
         - "mn"
@@ -579,8 +584,12 @@ network_v1:
         - "gn"
       shasta_name: "gn"
       architecture_type: "river_ncn_node_2_port_gigabyte"
+    - lookup_name: 
+        - "gpu"
+      shasta_name: "gpu"
+      architecture_type: "river_ncn_node_4_port_gigabyte"
     - lookup_name:
-        - "sw-cdu"
+        - "cdu"
       shasta_name: "sw-cdu"
       architecture_type: "mountain_compute_leaf"
     - lookup_name:
@@ -617,3 +626,7 @@ network_v1:
     - lookup_name: ["SubRack", "subrack"]
       shasta_name: "SubRack"
       architecture_type: "subrack"
+    - lookup_name:
+        - "kvm"
+      shasta_name: "kvm"
+      architecture_type: "kvm"

--- a/tests/test_generate_switch_config_arista_csm_1_2.py
+++ b/tests/test_generate_switch_config_arista_csm_1_2.py
@@ -51,7 +51,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version = pkg_resources.get_distribution("canu").version
 
 runner = testing.CliRunner()
 

--- a/tests/test_generate_switch_config_aruba_csm_1_0.py
+++ b/tests/test_generate_switch_config_aruba_csm_1_0.py
@@ -52,7 +52,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version = pkg_resources.get_distribution("canu").version
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_aruba_csm_1_2.py
+++ b/tests/test_generate_switch_config_aruba_csm_1_2.py
@@ -52,7 +52,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version = pkg_resources.get_distribution("canu").version
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_dellanox_csm_1_0.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_0.py
@@ -44,7 +44,7 @@ sls_address = "api-gw-service-nmn.local"
 switch_backups = "switch_backups/dellanox"
 switch_backups_folder = path.join(test_file_directory, "data", switch_backups)
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version = pkg_resources.get_distribution("canu").version
 banner_motd = (
     'banner motd "\n'
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_dellanox_csm_1_2.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_2.py
@@ -44,7 +44,7 @@ switch_name = "sw-spine-001"
 cache_minutes = 0
 sls_address = "api-gw-service-nmn.local"
 
-canu_version = pkg_resources.get_distribution('canu').version
+canu_version = pkg_resources.get_distribution("canu").version
 banner_motd = (
     'banner motd "\n'
     "###############################################################################\n"


### PR DESCRIPTION
### Summary and Scope

Description:

* KVM and GPU nodes have been in the v2 architectures fro a long time,  but were missing in the v1 architecture.  These node types have been added to the Dell and Mellanox v1 network architecture.

* Previously, during generation of switch and network configurations, spurious debug messages appeared from the network model and other libraries.  This made the output verbose and unclear.  A `--log` option has been added to `canu generate network config` and `canu generate switch config` and base logging initialized.  This change clears up default output.

* Moved helpful hint warnings about nodes often found on PoR systems but not found on existing system  to `--log WARNING`.  General user feedback were that this was either confusing or misleading.

* Rewrote warning text for missing configurations in generated configs.  Warnings were previously given if a device cabling was specified in the SHCD or CCJ but a configuration template cannot be found.  The text of this warning block was pretty bad and has been rewritten to provide root cause explanations and next-step guidance. 

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [x] I have updated the appropriate Changelog entries in `README.md`
- [ x I have incremented the version in the `README.md`

### Testing

Tested on:

With several test/dev and customer system data.
