### PR TITLE
Fix broken RPM build from #219

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,7 +53,7 @@ pipeline {
             }
             steps {
                 script {
-                    runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
+                    runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                     sh "make prepare"
                 }
             }
@@ -75,10 +75,10 @@ pipeline {
         stage('Publish: RPMs') {
             steps {
                 script {
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
-                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp2", arch: "x86_64", isStable: isStable)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", os: "sle-15sp3", arch: "x86_64", isStable: isStable)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
                 }
             }
         }
@@ -94,7 +94,7 @@ pipeline {
         stage('Publish: Image') {
             steps {
                 script {
-                    publishCsmDockerImage(image: "cray-${env.GIT_REPO_NAME}", tag: env.IMAGE_VERSION, isStable: env.IS_STABLE)
+                    publishCsmDockerImage(image: "cray-${env.NAME}", tag: env.IMAGE_VERSION, isStable: env.IS_STABLE)
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 ifeq ($(NAME),)
-NAME := $(shell basename $(pwd))
+NAME := $(shell basename $(shell pwd))
 endif
 
 ifeq ($(IMAGE_VERSION),)
@@ -41,6 +41,7 @@ all : prepare binary test rpm
 rpm: rpm_package_source rpm_build_source rpm_build
 
 prepare:
+		@echo $(NAME)
 		rm -rf dist
 		mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
 		cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/

--- a/canu.spec
+++ b/canu.spec
@@ -24,7 +24,7 @@
 %global __python /usr/local/bin/python3.10
 %define __pyinstaller /home/jenkins/.local/bin/pyinstaller
 
-Name: canu
+Name: %(echo $NAME)
 BuildArch: x86_64
 License: MIT License
 Summary: CSM Automatic Network Utility


### PR DESCRIPTION
#219 bypassed the RPM build check somehow, and now develop isn't building RPMs. The problem is `env.GIT_REPO_NAME` was renamed to `NAME` but the refactor was not fully complete.
