### PR TITLE
Add py dependency to to enable pytest version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,8 @@ setup(
         ],
         'test': [
             'coverage',
-            'pytest<=7.1.3',
+            'py>==1.11.0',
+            'pytest',
             'pytest-cov',
             'pytest-sugar',
             'testfixtures',


### PR DESCRIPTION
### Summary and Scope

Dependabot would like to bump `pytest` from version 7.1.3 to 7.2.0.  Version 7.2.0 of `pytest` removed `py` from internal loading.  This change adds `py` as a testing dependency.

* Solution suggested here:  https://github.com/Teemu/pytest-sugar/issues/243

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`
- [ ] I have incremented the version in the `README.md`

### Issues and Related PRs

* Relates to: https://github.com/Cray-HPE/canu/pull/226
