### PR TITLE
Relates to #44 - Fixes stable RPM's

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -55,6 +55,7 @@ pipeline {
                 script {
                     runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                     sh "make prepare"
+                    sh "git update-index --assume-unchanged ${env.NAME}.spec"
                 }
             }
         }

--- a/canu.spec
+++ b/canu.spec
@@ -45,8 +45,12 @@ Vendor: Cray HPE
 %{__python} -m pip install -q build
 %{__python} -m build
 %{__python} -m pip install dist/%{name}*.tar.gz
+git status
+git diff-index --name-only HEAD
 
-cp pyinstaller.py pyinstaller.spec
+cp -pv pyinstaller.py pyinstaller.spec
+git status
+git diff-index --name-only HEAD
 %{__pyinstaller} --clean -y --dist ./dist/linux --workpath /tmp pyinstaller.spec
 rm pyinstaller.spec
 chown -R --reference=. ./dist/linux


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->
Stable builds of `canu` are reporting a version string with `dev1` appended to the end, this implies the build was done with a dirty repo (uncommitted changes). This occurs because the CSM metadata we add to the spec file causes the repo to become dirty. This change tells Git to assume that the `.spec` file is clean, thus preventing git from identifying the repo as dirty during the build.

For example, this build was from a stable 1.6.26 git-tag but it resulted in a version string of 1.6.26.dev1 (implying it is unstable and from a dirty repo).
```bash
redbull-ncn-m001-pit:~ # rpm -ivh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/canu/x86_64/canu-1.6.26-1.x86_64.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/canu/x86_64/canu-1.6.26-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:canu-1.6.26-1                    ################################# [100%]
redbull-ncn-m001-pit:~ # canu --version
canu, version 1.6.26.dev1
```

This change fixes that, not building no longer appends `dev1` to every build. For example this feature branch successfully built a `.post1` (indicating this is 1 commit post 1.6.26 stable, as my feature branch is 1 commit ahead of 1.6.26 stable).

```bash
canu-1.6.26.post1
```

PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`
- [ ] I have incremented the version in the `README.md`

### Issues and Related PRs

* Relates to: #44 

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
