### PR TITLE
Relates to #44 - Fix stable Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN     mkdir /files
 COPY    dist/rpmbuild/RPMS/x86_64/ /files
 
 RUN     ls -l /files && \
-        zypper -n in --allow-unsigned-rpm -y /files/canu*.rpm
+        zypper --no-gpg-checks -n in --allow-unsigned-rpm --auto-agree-with-licenses -y /files/canu*.rpm
 
 # set file perms for canu
 RUN      chown -R canu /files /home

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -95,7 +95,7 @@ pipeline {
         stage('Publish: Image') {
             steps {
                 script {
-                    publishCsmDockerImage(image: "cray-${env.NAME}", tag: env.IMAGE_VERSION, isStable: env.IS_STABLE)
+                    publishCsmDockerImage(image: "cray-${env.NAME}", tag: env.IMAGE_VERSION, isStable: isStable)
                 }
             }
         }


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->

Stable Docker images (ones built from git-tags, previously from `main`) were failing due to the Zypper GPG checks. The GPG checks do not have the public key from our repository necessary for accepting signed RPMs.

This bypasses those checks, allowing stable Docker builds to work.

A test 1.6.26 tag was taken from this feature branch (which has been deleted and no longer exists), the test tag yielded a successful build: https://jenkins.algol60.net/job/Cray-HPE/job/canu/view/tags/job/1.6.26/7/console


PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`
- [ ] I have incremented the version in the `README.md`

### Issues and Related PRs

* Relates to: #44 

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
