### PR TITLE
Updating template for `Jenkinsfile`

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,29 +1,37 @@
-// (C) Copyright [2022] Hewlett Packard Enterprise Development LP
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"),
-// to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 
 @Library('csm-shared-library') _
 
 def isStable = env.TAG_NAME != null ? true : false
+def pythonImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 def pythonVersion = '3.10'
 
 pipeline {
+
     agent {
         label "metal-gcp-builder"
     }
@@ -47,16 +55,14 @@ pipeline {
             agent {
                 docker {
                     label 'docker'
-                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${pythonVersion}"
+                    image "${pythonImage}:${pythonVersion}"
                     reuseNode true
                 }
             }
             steps {
-                script {
-                    runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                    sh "make prepare"
-                    sh "git update-index --assume-unchanged ${env.NAME}.spec"
-                }
+                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                sh "make prepare"
+                sh "git update-index --assume-unchanged ${env.NAME}.spec"
             }
         }
 
@@ -64,7 +70,7 @@ pipeline {
             agent {
                 docker {
                     label 'docker'
-                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${pythonVersion}"
+                    image "${pythonImage}:${pythonVersion}"
                     reuseNode true
                 }
             }

--- a/canu.spec
+++ b/canu.spec
@@ -40,17 +40,13 @@ Vendor: Cray HPE
 %setup -q
 
 %build
-# PIP and Setuptools updates.
 %{__python} -m pip install -U pyinstaller
 %{__python} -m pip install -q build
 %{__python} -m build
 %{__python} -m pip install dist/%{name}*.tar.gz
-git status
-git diff-index --name-only HEAD
 
 cp -pv pyinstaller.py pyinstaller.spec
-git status
-git diff-index --name-only HEAD
+
 %{__pyinstaller} --clean -y --dist ./dist/linux --workpath /tmp pyinstaller.spec
 rm pyinstaller.spec
 chown -R --reference=. ./dist/linux


### PR DESCRIPTION
Minor `Jenkinsfile` and license updates. This simplifies some things in the `Jenkinsfile`, and conforms to my current template I'm using for several RPMs used in the PIT and NCN images.