### PR TITLE
Minor update to support Snyk scanning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ from os.path import join
 from os import devnull
 import re
 
+import pkg_resources
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -79,10 +81,14 @@ def get_version():
             version += ".dev1"
 
     else:
-        # Extract the version from the PKG-INFO file.
-        with open(join(d, "PKG-INFO")) as f:
-            version = version_re.search(f.read()).group(1)
-
+        try:
+            # Extract the version from the PKG-INFO file.
+            with open(join(d, "PKG-INFO")) as f:
+                version = version_re.search(f.read()).group(1)
+        except FileNotFoundError:
+            # Maybe this package is already installed, and setup.py is invoked
+            # out of context by a scanner.
+            version = pkg_resources.get_distribution("canu").version
     return version
 
 


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->
If Snyk scanning is ever added, then `setup.py` will be referred to in an isolated environment for dependnecy scanning that does not contain `PKG-INFO` (or `.git/` for that matter). Snyk will fail when invoking `get_version()` unless it reesolves the version from the already installed `canu` app.

This is a very minor follow-up to #234 .

PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`
- [ ] I have incremented the version in the `README.md`

### Issues and Related PRs

* Resolves: `Issue`
* Relates to: `Issue`
* Requires: `Issue`

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
