### PR TITLE
Fixes #237

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ pylintrc
 pylintrc.test
 
 test_data/*
+
+# Shasta Cabling Diagrams
+*.xlsx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,6 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-include README.md
+include network_modeling/mac_vendors
+include network_modeling/models/output.md
 include LICENSE
-global-include *.yaml
+include README.md
+recursive-include canu/ *.y[a]ml *.json *.txt
+recursive-include network_modeling/ *.j2 *.json *.y[a]ml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import re
 
 import pkg_resources
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 from setuptools import setup
 
 version_re = re.compile("^Version: (.+)$", re.M)
@@ -100,7 +100,7 @@ setup(
     long_description=readme(),
     version=get_version(),
     license=LICENSE,
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     include_package_data=True,
     zip_safe=False,
     exclude_package_data={"canu": ["canu_cache.yaml"]},


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->

Fixes local dev environments including necessary data files when installing `canu`, where without the files certain commands will produce a traceback. This wasn't exhibited on a system with the `canu RPM installed because these data files were called out in `pyinstaller.py`, `pyinstaller.py` isn't invoked in local dev environments.

I verified this works by invoking commands locally and via a feature RPM install.

Local Install

```bash
canu, version 1.6.20.post95
canu validate shcd -a V1 --shcd Cray\ Inc-Shasta\ RiverSystemForServiceTraining_SHCD_RevA8.xlsx --tabs 40G_10G,NMN,HMN --corners J28,T54,J15,T31,J20,U58 --json
```

System/RPM Install:

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # canu --version
canu, version 1.6.20.post95
redbull-ncn-m001-pit:/var/www/ephemeral/prep # canu validate shcd -a v1 --shcd ./Shasta\ River\ Redbull\ CCD_RevA10.xlsx --tabs 40G_10G,NMN,HMN --corners I12,S39,I9,S20,I20,S31 --json --out ccj.json
```

PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`
- [ ] I have incremented the version in the `README.md`

### Issues and Related PRs

* Resolves: `Issue`
* Relates to: `Issue`
* Requires: `Issue`

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
