### PR TITLE
CASMNET-1968 dynamic inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🛶 CANU v1.6.28
+# 🛶 CANU v1.6.29
 
 CANU (CSM Automatic Network Utility) will float through a Shasta network and make switch setup and validation a breeze.
 
@@ -1313,6 +1313,20 @@ Version      : GL.10.09.0010
 ^^^^ END netmiko_send_command ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
+## Using `canu-inventory` with Ansible
+
+`canu-inventory` is a dynamic inventory script that queries a `sls_input_file.json` in the working directory, or an API gateway (`$SLS_API_GW`).  It can be called directly to print the information or it can be passed as an argument to `ansible-inventory`.
+
+```bash
+# examples
+ansible-inventory -i canu-inventory --list
+ansible-playbook -i canu-inventory my_play.yml # set hosts in the playbook
+```
+
+If using the API, `$TOKEN` or `$SLS_TOKEN` need to be set.
+
+If running this from outside the cluster over the CMN, `$REQUESTS_CA_BUNDLE` needs to be set
+
 ## Uninstallation
 
 `pip3 uninstall canu`
@@ -1350,6 +1364,11 @@ To run a specific test file:
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 # Changelog
+
+## [1.6.29]
+
+- Added dynamic ansible inventory script, installed as `canu-inventory`.
+- Added a playbook to validate/upload a config.
 
 ## [1.6.28]
 

--- a/canu.spec
+++ b/canu.spec
@@ -54,6 +54,7 @@ chown -R --reference=. ./dist/linux
 %install
 mkdir -p %{buildroot}%{_bindir}
 install -m 755 dist/linux/canu %{buildroot}%{_bindir}/canu
+install -m 755 dist/linux/canu-inventory %{buildroot}%{_bindir}/canu-inventory
 
 %pre
 getent passwd canu >/dev/null || \
@@ -61,6 +62,7 @@ getent passwd canu >/dev/null || \
 
 %files
 %attr(755, canu, canu) %{_bindir}/canu
+%attr(755, canu, canu) %{_bindir}/canu-inventory
 %license LICENSE
 
 %changelog

--- a/canu/inventory/__init__.py
+++ b/canu/inventory/__init__.py
@@ -1,0 +1,22 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""CANU."""

--- a/canu/inventory/ansible.py
+++ b/canu/inventory/ansible.py
@@ -1,0 +1,418 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Generates a dynamic Ansible inventory from SLS data."""
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import sys
+
+import certifi
+import click
+import requests
+
+from canu.utils.inventory import inventory
+
+# Get project root directory
+if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cover
+    project_root = sys._MEIPASS
+else:
+    prog = __file__
+    project_root = Path(__file__).resolve().parent.parent.parent
+
+
+@click.option(
+    "--list",
+    "list_",
+    is_flag=True,
+    help="Dynamic inventory for all hosts.",
+    required=False,
+)
+@click.option(
+    "--host",
+    "host_",
+    help="Dynamic inventory for a specific host.",
+    required=False,
+    type=click.STRING,
+)
+# @pysnooper.snoop()
+@click.command()
+def ansible_inventory(
+    list_,
+    host_,
+):
+    r"""Generate a dynamic Ansible inventory.
+
+    Print an inventory of switches from the SLS API or an sls_input_file.json in the current working directory.
+
+    $SLS_API_GW and $SLS_TOKEN (or $TOKEN) must be set in order to query the API.
+
+    $SWITCH_USERNAME and $SWITCH_PASSWORD must be set in order to execute playbooks.
+
+    The CA certificate on an NCN will be used by default.
+    If running from outside the cluster, the CA certificate can be set using $REQUESTS_CA_BUNDLE.
+
+    To find the HMN or CMN gateway:
+
+      kubectl get svc -n istio-system istio-ingressgateway-hmn \
+        -o jsonpath='{.metadata.external-dns\.alpha\.kubernetes\.io\/hostname}'
+
+      kubectl get svc -n istio-system istio-ingressgateway-cmn \
+        -o jsonpath='{.metadata.external-dns\.alpha\.kubernetes\.io\/hostname}'
+
+    Args:
+        list_ : A full inventory of all hosts.
+        host_ : A specific host to query.
+
+    Returns:
+        None
+    """
+    if is_context_ncn():
+        network = "HMN"
+        # If running on an NCN, use the CA certificate from the NCN
+        # The system python uses it by default, but the python in the venv does
+        # not, nor does this binary version of canu{-inventory}
+        crt_path = "/etc/pki/trust/anchors/platform-ca-certs.crt"
+    else:
+        # If running off an NCN, use the CA certificate defined by the env var
+        # defaultig to what certifi thinks is the right one
+        crt_path = os.getenv("REQUESTS_CA_BUNDLE", certifi.where())
+        network = "CMN"
+
+    sls_file = "./sls_input_file.json"
+    password = os.getenv("SWITCH_PASSWORD")
+    username = os.getenv("SWITCH_USERNAME")
+    sls_address = os.getenv("SLS_API_GW")
+
+    # use a local file if that exists
+    if os.path.exists(sls_file):
+        sls_file = click.open_file(sls_file, mode="r")
+        try:
+            with open(sls_file.name, "r", encoding="utf-8") as f:
+                sls_json = json.load(f)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            click.secho(
+                f"The file {sls_file.name} is not valid JSON.",
+                fg="red",
+            )
+            sys.exit(1)
+        dump = sls_json
+    else:
+        # SLS
+        if sls_address is None:
+            # If the address is not set, use the default
+            sls_address = "api-gw-service-nmn.local"
+        # If a TOKEN var is already set, use that
+        if os.getenv("TOKEN") is not None:
+            token = os.getenv("TOKEN")
+        else:
+            # Otherwise, look for SLS_TOKEN
+            token = os.getenv("SLS_TOKEN")
+        sls_url = "https://" + sls_address + "/apis/sls/v1/dumpstate"
+        try:
+            api_req = requests.get(
+                sls_url,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {token}",
+                },
+                verify=crt_path,
+            )
+            api_req.raise_for_status()
+            dump = api_req.json()
+            sls_file = None
+
+        except requests.exceptions.ConnectionError as e:
+            return click.secho(
+                f"Error connecting to SLS at {sls_url}\n{e}",
+                fg="white",
+                bg="red",
+            )
+        except requests.exceptions.HTTPError:
+            bad_token_reason = "environmental variable 'SLS_TOKEN' is correct."
+            return click.secho(
+                f"Error connecting SLS {sls_url}, check that the $SLS_API_GW and $SLS_TOKEN are correct.\\nn{bad_token_reason}",
+                fg="white",
+                bg="red",
+            )
+
+    switch_inventory, _ = inventory(
+        username,
+        password,
+        network,
+        sls_file=sls_file,
+        sls_inventory=True,
+        dumpstate=dump,
+    )
+
+    # if the --host is passed, return hostvars
+    if host_:
+        ansible_host(
+            datasource=switch_inventory,
+            hostname=host_,
+        )
+
+    # if --list is passed, return a full inventory
+    if list_:
+        ansible_list(
+            datasource=switch_inventory,
+        )
+
+
+# is_context_ncn performs a stupid simple hostname regex to determine if this is
+# running on an NCN.  If not, this returns false and assumes the CMN will be
+# used.  Since there is no canonical way to determine a Shasta system--short of
+# some large, messy checks--this will be put in place for now.
+def is_context_ncn():
+    """Perform a simple hostname check to determine the running context.
+
+    If this is running on an NCN, return True.  If not, return False.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
+    host = socket.gethostname()
+    host_reg = re.compile(r"(ncn|pit.*)-([s,w,m][0-9]{3})", re.VERBOSE)
+    result = re.match(host_reg, host)
+    if result:
+        return True
+    else:
+        return False
+
+
+# Produce json for ansible-inventory
+def ansible_list(datasource=None):
+    """Print entire inventory in JSON.
+
+    Args:
+        datasource : Data from the datasource.
+    """
+    # create an empty inventory object
+    ansible_inventory = {}
+
+    # _meta holds every host/group/vars and acts as a "cache" preventing
+    # consecutive --host calls
+    ansible_inventory["_meta"] = {"hostvars": {}}
+
+    # add the "all" group
+    if "all" not in ansible_inventory:
+        ansible_inventory["all"] = {"children": ["ungrouped"]}
+
+    # add hosts and groups to the inventory
+    for sw in datasource["options"]["hosts"]:
+        # add the host to the _meta hostvars if it doesn't exist
+        if sw not in ansible_inventory["_meta"]["hostvars"]:
+            ansible_inventory["_meta"]["hostvars"][sw] = ansible_hostvars(
+                datasource=datasource,
+                hostname=sw,
+            )
+
+        # get the groups for the host
+        groups = get_groups(datasource=datasource, hostname=sw)
+
+        # add the groups to the inventory
+        # this is a different structure than what might be in a host entry
+        for group in groups["groups"]:
+            # ansible groups cannot have dashes
+            group = group.replace("-", "_")
+            # add the group if it doesn't exist
+            if group not in ansible_inventory:
+                ansible_inventory.update({group: {"hosts": [], "vars": {}}})
+            # add the host to the group if it doesn't exist
+            if sw not in ansible_inventory[group]["hosts"]:
+                ansible_inventory[group]["hosts"].append(sw)
+            # TODO: add group_vars
+
+    # print the inventory
+    click.echo(json.dumps(ansible_inventory, indent=4, ensure_ascii=True))
+
+
+def get_switch_user(datasource=None, hostname=None):
+    """Get the switch username from the datasource.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        dict: The user defined in the datasource.
+    """
+    ansible_user = datasource["options"]["hosts"][hostname]["username"]
+    return {"ansible_user": ansible_user}
+
+
+def get_switch_pass(datasource=None, hostname=None):
+    """Get the switch password from the datasource.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        The password defined in the datasource.
+    """
+    ansible_password = datasource["options"]["hosts"][hostname]["password"]
+    return {"ansible_password": ansible_password}
+
+
+def get_switch_ip(datasource=None, hostname=None):
+    """Get the IP from the datasource and set ansible_host.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        The IP defined in the datasource.
+    """
+    ansible_host = datasource["options"]["hosts"][hostname]["hostname"]
+    return {"ansible_host": ansible_host}
+
+
+def get_groups(datasource=None, hostname=None):
+    """Get groups from the datasource.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        The groups defined in the datasource and others defined by this script.
+    """
+    host_groups = []
+
+    # var for this hosts groups defined in SLS data
+    datasource_groups = datasource["options"]["hosts"][hostname]["groups"]
+    for group in datasource_groups:
+        if group not in host_groups:
+            host_groups.append(group)
+
+    # the type of switch is a group name
+    datasource_type = datasource["options"]["hosts"][hostname]["data"]["type"]
+    if datasource_type not in host_groups:
+        host_groups.append(datasource_type)
+
+    return {"groups": host_groups}
+
+
+def get_aruba_vars(datasource=None, hostname=None):
+    """Get extra variables needed by Aruba ansible modules.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        The ansible user defined in the datasource.
+    """
+    # aruba needs extra variables for ansible community module
+    if "aruba" in datasource["options"]["hosts"][hostname]["groups"]:
+        # arubanetworks.aoscx.aoscx for API
+        # network_cli for CLI/SSH
+        # httpapi legacy
+        ansible_network_os = "arubanetworks.aoscx.aoscx"
+        ansible_connection = "arubanetworks.aoscx.aoscx"
+
+        # Only required for REST API modules) Must always be True as
+        # AOS-CX uses port 443 for REST
+        ansible_httpapi_use_ssl = True
+
+        # (Only required for REST API modules) Set True or False
+        # depending on if Ansible should attempt to validate certificates
+        ansible_httpapi_validate_certs = False
+
+        # Set to True or False depending if Ansible should bypass
+        # environment proxies to connect to AOS-CX, required.
+        ansible_acx_no_proxy = False
+
+        # Set to True or False depending if Ansible should bypass
+        # validating certificates to connect to AOS-CX. Only required
+        # when ansible_connection is set to arubanetworks.aoscx.aoscx
+        ansible_aoscx_validate_certs = False
+
+        # Set to True or False depending if Ansible should bypass
+        # environment proxies to connect to AOS-CX. Only required when
+        # ansible_connection is set to arubanetworks.aoscx.aoscx.
+        ansible_aoscx_use_proxy = False
+
+        return [
+            {"ansible_network_os": ansible_network_os},
+            {"ansible_connection": ansible_connection},
+            {"ansible_httpapi_use_ssl": ansible_httpapi_use_ssl},
+            {"ansible_httpapi_validate_certs": ansible_httpapi_validate_certs},
+            {"ansible_acx_no_proxy": ansible_acx_no_proxy},
+            {"ansible_aoscx_validate_certs": ansible_aoscx_validate_certs},
+            {"ansible_aoscx_use_proxy": ansible_aoscx_use_proxy},
+        ]
+
+
+def ansible_host(datasource=None, hostname=None):
+    """Print a specific host inventory in JSON.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns: None
+    """
+    # create an empty inventory object
+    ansible_inventory = {}
+    # get the hostvars for the host
+    ansible_inventory = ansible_hostvars(datasource=datasource, hostname=hostname)
+
+    # print the inventory
+    click.echo(json.dumps(ansible_inventory, indent=4, ensure_ascii=True))
+
+
+def ansible_hostvars(datasource=None, hostname=None):
+    """Aggregate various hostvars for a specific host.
+
+    Args:
+        datasource : Data from the datasource.
+        hostname : The hostname to query.
+
+    Returns:
+        All the hostvars for the specified host.
+    """
+    # create an empty inventory object
+    ansible_inventory = {}
+
+    # get the hostvars for the host
+    ansible_inventory.update(get_switch_ip(datasource, hostname))
+    ansible_inventory.update(get_switch_user(datasource, hostname))
+    ansible_inventory.update(get_switch_pass(datasource, hostname))
+    ansible_inventory.update(get_groups(datasource, hostname))
+    # add aruba vars if needed
+    if "aruba" in ansible_inventory["groups"]:
+        aruba_vars = get_aruba_vars(datasource, hostname)
+        for var in aruba_vars:
+            ansible_inventory.update(var)
+
+    return ansible_inventory
+
+
+if __name__ == "__main__":
+    ansible_inventory()

--- a/canu/inventory/ansible.py
+++ b/canu/inventory/ansible.py
@@ -55,7 +55,6 @@ else:
     required=False,
     type=click.STRING,
 )
-# @pysnooper.snoop()
 @click.command()
 def ansible_inventory(
     list_,

--- a/canu/inventory/plays/aruba-aoscx.yml
+++ b/canu/inventory/plays/aruba-aoscx.yml
@@ -1,11 +1,13 @@
 ---
-- hosts: sw-leaf-bmc-001
+- hosts: aruba
   collections:
     - arubanetworks.aoscx
   gather_facts: true
   vars:
     # This should be a template but for now, pass is an extra var path to whatever config is needed
-    leaf_config: "{{ leaf_bmc_config }}"
+    # pass in the folder containing the switch configs or be in the same directory
+    config_folder: ""
+    switch_config: "{{ config_folder }}/{{ inventory_hostname }}.cfg"
     login_url: "https://{{ ansible_host }}/rest/v1/login"
     dryrun_url: "https://{{ ansible_host }}/rest/v1/configs/running-config?dryrun"
     checkpoint_name: "ac_{{ ansible_date_time.year }}_{{ ansible_date_time.month }}_{{ ansible_date_time.day }}_{{ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
@@ -13,14 +15,14 @@
     configs_url: "https://{{ ansible_host }}/rest/v1/fullconfigs"
     munged_banner: "Adjusted by Ansible for checkpoint: {{ checkpoint_name }}"
     pseudo_checkpoint_url: "https://{{ ansible_host }}/rest/v1/fullconfigs/{{ checkpoint_name }}"
-    validated_config_json: "{{ playbook_dir }}/{{ checkpoint_name }}.json"
+    validated_config_json: "{{ playbook_dir }}/{{ inventory_hostname }}_{{ checkpoint_name }}.json"
     logout_url: "https://{{ ansible_host }}/rest/v1/logout"
   tasks:
     - name: get running config as json
       arubanetworks.aoscx.aoscx_backup_config:
-        config_name: 'running-config'
-        output_file: '{{ inventory_hostname }}.json'
-    
+        config_name: "running-config"
+        output_file: "{{ inventory_hostname }}.json"
+
     # put the dryun tasks in a block to handle failures
     - name: dryrun config
       block:
@@ -46,8 +48,8 @@
             method: POST
             return_content: true
             # config to validate with dryun
-            src: "{{ leaf_config }}"
-            # per Ansible: should be used with force_basic_auth to ensure 
+            src: "{{ switch_config }}"
+            # per Ansible: should be used with force_basic_auth to ensure
             # success when the remote end sends a 401
             force_basic_auth: true
             follow_redirects: all
@@ -80,7 +82,7 @@
           loop: "{{ _result.json.errors }}"
           when: _result.json.state == "error"
           failed_when: _result.json.state == "error"
-        
+
         # Begin munging operations
         # Per the aruba docs, it's not possible to have two checkpoints with the same configuration
         # Thus, a checkpoint with this exact JSON cannot be used as a new checkpoint or it is detected as a duplicate
@@ -89,35 +91,12 @@
         - name: begin munging by setting facts using the existing config
           ansible.builtin.set_fact:
             original_config: "{{ _result.json.configs.json }}"
-            munge_me: "{{ _result.json.configs.json }}"
 
-        - name: munge the ansible fact to update the banner to create a new config
-          ansible.utils.update_fact:
-            updates:
-              - path: munge_me.System.other_config.banner_exec
-                value: "{{ munged_banner }}"
-          register: munged_config
-
-        # TODO: Technically, we should do another dry run here to validate there is no garbage in the config
+        # # TODO: Technically, we should do another dry run here to validate there is no garbage in the config
         - name: write jsonified config to a local file
           ansible.builtin.copy:
-            content: "{{ munged_config.munge_me | to_json(indent=4) }}"
+            content: "{{ original_config | to_json(indent=4) }}"
             dest: "{{ validated_config_json }}"
-          
-        # also set the banner on the running-config so it is different
-        # this seems to allow the checkpoint to be 
-        - name: add or update the banner to make the config harmlessly different allowing for a checkpoint to be made
-          aoscx_banner:
-            banner_type: banner
-            banner: "{{ munged_banner }}"
-
-        # Without making a modification such as the harmless banner change above, the aoscx_checkpoint module
-        # fails with:
-        #     'GENERIC OPERATION ERROR: Checkpoint already exists in the database or it is a duplicate checkpoint.'
-        - name: create checkpoint from running-config
-          arubanetworks.aoscx.aoscx_checkpoint:
-            source_config: 'running-config'
-            destination_config: "{{ checkpoint_name }}"
 
         # Finally, upload the new config as the running-config
         - name: upload local json config to the running-config

--- a/canu/inventory/plays/aruba-aoscx.yml
+++ b/canu/inventory/plays/aruba-aoscx.yml
@@ -4,8 +4,8 @@
     - arubanetworks.aoscx
   gather_facts: true
   vars:
-    # This should be a template
-    leaf_config: files/sw-leaf-bmc-001.cfg
+    # This should be a template but for now, pass is an extra var path to whatever config is needed
+    leaf_config: "{{ leaf_bmc_config }}"
     login_url: "https://{{ ansible_host }}/rest/v1/login"
     dryrun_url: "https://{{ ansible_host }}/rest/v1/configs/running-config?dryrun"
     checkpoint_name: "ac_{{ ansible_date_time.year }}_{{ ansible_date_time.month }}_{{ ansible_date_time.day }}_{{ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"

--- a/canu/inventory/plays/aruba-aoscx.yml
+++ b/canu/inventory/plays/aruba-aoscx.yml
@@ -1,0 +1,140 @@
+---
+- hosts: sw-leaf-bmc-001
+  collections:
+    - arubanetworks.aoscx
+  gather_facts: true
+  vars:
+    # This should be a template
+    leaf_config: files/sw-leaf-bmc-001.cfg
+    login_url: "https://{{ ansible_host }}/rest/v1/login"
+    dryrun_url: "https://{{ ansible_host }}/rest/v1/configs/running-config?dryrun"
+    checkpoint_name: "ac_{{ ansible_date_time.year }}_{{ ansible_date_time.month }}_{{ ansible_date_time.day }}_{{ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
+    checkpoint_url: "https://{{ ansible_host }}/rest/v1/fullconfigs/{{ checkpoint_name }}?from=/rest/v1/fullconfigs/running-config"
+    configs_url: "https://{{ ansible_host }}/rest/v1/fullconfigs"
+    munged_banner: "Adjusted by Ansible for checkpoint: {{ checkpoint_name }}"
+    pseudo_checkpoint_url: "https://{{ ansible_host }}/rest/v1/fullconfigs/{{ checkpoint_name }}"
+    validated_config_json: "{{ playbook_dir }}/{{ checkpoint_name }}.json"
+    logout_url: "https://{{ ansible_host }}/rest/v1/logout"
+  tasks:
+    - name: get running config as json
+      arubanetworks.aoscx.aoscx_backup_config:
+        config_name: 'running-config'
+        output_file: '{{ inventory_hostname }}.json'
+    
+    # put the dryun tasks in a block to handle failures
+    - name: dryrun config
+      block:
+        # log in and register the cookie
+        - name: login to api
+          ansible.builtin.uri:
+            url: "{{ login_url }}"
+            validate_certs: false
+            force_basic_auth: true
+            use_proxy: false
+            method: POST
+            body_format: raw
+            body: username={{ ansible_user }}&password={{ ansible_password }}
+            return_content: true
+          register: login
+
+        # upload the new config in dryrun mode
+        - name: upload new config in dryrun mode
+          ansible.builtin.uri:
+            url: "{{ dryrun_url }}"
+            validate_certs: false
+            use_proxy: false
+            method: POST
+            return_content: true
+            # config to validate with dryun
+            src: "{{ leaf_config }}"
+            # per Ansible: should be used with force_basic_auth to ensure 
+            # success when the remote end sends a 401
+            force_basic_auth: true
+            follow_redirects: all
+            headers:
+              Content-Type: "text/plain"
+              Cookie: "{{ login.set_cookie }}"
+            # success returns Accepted
+            status_code: 202
+          register: this
+
+        # loop on the status until no longer pending
+        - name: check dry run status
+          ansible.builtin.uri:
+            url: "{{ dryrun_url }}"
+            validate_certs: false
+            use_proxy: false
+            method: GET
+            return_content: true
+            headers:
+              Cookie: "{{ login.set_cookie }}"
+          register: _result
+          until: _result.json.state != "pending"
+          retries: 125
+          delay: 5 # Every 5 seconds
+
+        # fail if the config is bad
+        - name: show errors and fail if needed
+          debug:
+            msg: "{{ item }}"
+          loop: "{{ _result.json.errors }}"
+          when: _result.json.state == "error"
+          failed_when: _result.json.state == "error"
+        
+        # Begin munging operations
+        # Per the aruba docs, it's not possible to have two checkpoints with the same configuration
+        # Thus, a checkpoint with this exact JSON cannot be used as a new checkpoint or it is detected as a duplicate
+        # As a workaround, one semi-harmless key is modified--the banner
+        # Changing this makes the config different from the running config without any operational side-effects
+        - name: begin munging by setting facts using the existing config
+          ansible.builtin.set_fact:
+            original_config: "{{ _result.json.configs.json }}"
+            munge_me: "{{ _result.json.configs.json }}"
+
+        - name: munge the ansible fact to update the banner to create a new config
+          ansible.utils.update_fact:
+            updates:
+              - path: munge_me.System.other_config.banner_exec
+                value: "{{ munged_banner }}"
+          register: munged_config
+
+        # TODO: Technically, we should do another dry run here to validate there is no garbage in the config
+        - name: write jsonified config to a local file
+          ansible.builtin.copy:
+            content: "{{ munged_config.munge_me | to_json(indent=4) }}"
+            dest: "{{ validated_config_json }}"
+          
+        # also set the banner on the running-config so it is different
+        # this seems to allow the checkpoint to be 
+        - name: add or update the banner to make the config harmlessly different allowing for a checkpoint to be made
+          aoscx_banner:
+            banner_type: banner
+            banner: "{{ munged_banner }}"
+
+        # Without making a modification such as the harmless banner change above, the aoscx_checkpoint module
+        # fails with:
+        #     'GENERIC OPERATION ERROR: Checkpoint already exists in the database or it is a duplicate checkpoint.'
+        - name: create checkpoint from running-config
+          arubanetworks.aoscx.aoscx_checkpoint:
+            source_config: 'running-config'
+            destination_config: "{{ checkpoint_name }}"
+
+        # Finally, upload the new config as the running-config
+        - name: upload local json config to the running-config
+          aoscx_upload_config:
+            config_name: "running-config"
+            config_json: "{{ validated_config_json }}"
+
+      # always log out so no session is left open
+      always:
+        - name: always logout of api
+          ansible.builtin.uri:
+            url: "{{ logout_url }}"
+            validate_certs: false
+            force_basic_auth: true
+            use_proxy: true
+            method: POST
+            headers:
+              Cookie: "{{ login.set_cookie }}"
+            return_content: true
+          register: logout

--- a/canu/utils/inventory.py
+++ b/canu/utils/inventory.py
@@ -28,12 +28,16 @@ import click
 from canu.utils.sls import pull_sls_hardware, pull_sls_networks
 
 
-def inventory(username, password, network, sls_file=None, sls_inventory=None):
+def inventory(username, password, network, sls_file=None, sls_inventory=None, dumpstate=None):
     """Build Nornir inventory from sls_input."""
     inventory = {"groups": {}, "hosts": {}}
     if sls_file:
         try:
-            sls_json = json.load(sls_file)
+            if dumpstate:
+                with open(sls_file.name, 'r', encoding='utf-8') as f:
+                    sls_json = json.load(f)
+            else:
+                sls_json = json.load(sls_file)
         except (json.JSONDecodeError, UnicodeDecodeError):
             click.secho(
                 f"The file {sls_file.name} is not valid JSON.",
@@ -42,6 +46,9 @@ def inventory(username, password, network, sls_file=None, sls_inventory=None):
             sys.exit(1)
         sls_variables = pull_sls_networks(sls_json)
         sls_hardware = pull_sls_hardware(sls_json)
+    elif dumpstate:
+        sls_variables = pull_sls_networks(dumpstate)
+        sls_hardware = pull_sls_hardware(dumpstate)
     else:
         sls_variables = pull_sls_networks()
         sls_hardware = pull_sls_hardware()

--- a/canu/utils/sls.py
+++ b/canu/utils/sls.py
@@ -112,9 +112,16 @@ def pull_sls_networks(sls_file=None):
         #
         # Get an auth token by using the secret
         #
-        token = None
+        if os.getenv("SLS_TOKEN") == "":
+            token = None
+        else:
+            token = os.getenv("SLS_TOKEN")
         sls_cache = None
-        sls_url = "http://cray-sls.services.svc.cluster.local/v1/networks"
+
+        if os.getenv("SLS_API_GW") == "":
+            sls_url = "http://cray-sls.services.svc.cluster.local/v1/networks"
+        else:
+            sls_url = "https://" + os.getenv("SLS_API_GW") + "/apis/sls/v1/networks"
         if cenv != "k8s":
             sls_url = "https://api-gw-service-nmn.local/apis/sls/v1/networks"
             try:
@@ -396,9 +403,15 @@ def pull_sls_hardware(sls_file=None):
         #
         # Get an auth token by using the secret
         #
-        token = None
+        if os.getenv("SLS_TOKEN") == "":
+            token = None
+        else:
+            token = os.getenv("SLS_TOKEN")
         sls_cache = None
-        sls_url = "http://cray-sls.services.svc.cluster.local/v1/hardware"
+        if os.getenv("SLS_API_GW") == "":
+            sls_url = "http://cray-sls.services.svc.cluster.local/v1/hardware"
+        else:
+            sls_url = "https://" + os.getenv("SLS_API_GW") + "/apis/sls/v1/hardware"
         if cenv != "k8s":
             sls_url = "https://api-gw-service-nmn.local/apis/sls/v1/hardware"
             try:

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -436,14 +436,14 @@ def validate_shcd_port_data(cell, sheet, warnings, is_src_port=False, node_type=
         if re.search(r"\D", port) is not None:
             click.secho(
                 "Port numbers must be integers. "
-                + f'Please correct in the SHCD for cell {sheet}:{location} with value "{port}"',
+                + f'Please correct in the SHCD for cell {sheet}:{location} with value "{port!r}"',
                 fg="red",
             )
             sys.exit(1)
         if int(port) < 1:
             click.secho(
                 "Ports numbers must be greater than 1. Port numbering must begin at 1. "
-                + f'Please correct in the SHCD for cell {sheet}:{location} with value "{port}"',
+                + f'Please correct in the SHCD for cell {sheet}:{location} with value "{port!r}"',
                 fg="red",
             )
             sys.exit(1)

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -97,13 +97,22 @@ added_files = [
         "network_modeling/configs/templates/1.3/dellmellanox/full/*.j2",
         "network_modeling/configs/templates/1.3/dellmellanox/full",
     ),
-    ("canu/test/aruba/test_suite.yaml", "canu/test/aruba"),
-    ("canu/test/dellanox/test_suite.yaml", "canu/test/dellanox"),
+    (
+        "canu/test/aruba/test_suite.yaml", 
+        "canu/test/aruba"
+    ),
+    (
+        "canu/test/dellanox/test_suite.yaml",
+        "canu/test/dellanox"
+    ),
     (
         "canu/generate/switch/config/ttp_templates/*.txt",
         "canu/generate/switch/config/ttp_templates",
     ),
-    ("canu/utils/sls_utils/schemas/*.json", "canu/utils/sls_utils/schemas"),
+    (
+        "canu/utils/sls_utils/schemas/*.json",
+        "canu/utils/sls_utils/schemas"
+    ),
 ]
 a = Analysis(
     ["canu/cli.py"],
@@ -119,9 +128,9 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
-exe = EXE(
-    pyz,
+a_pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+a_exe = EXE(
+    a_pyz,
     a.scripts,
     a.binaries,
     a.zipfiles,
@@ -129,10 +138,57 @@ exe = EXE(
     [],
     name="canu",
     debug=False,
-    bootloader_ignore_signals=False,
+    bootloader_ignore_signal=False,
     strip=False,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,
     console=True,
 )
+
+
+b = Analysis(
+    ["canu/inventory/ansible.py"],
+    pathex=["canu"],
+    binaries=[],
+    datas=added_files,
+    hiddenimports=["network_modeling"],
+    hookspath=["./pyinstaller_hooks"],
+    runtime_hooks=[],
+    excludes=["tests"],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+b_pyz = PYZ(b.pure, b.zipped_data, cipher=block_cipher)
+b_exe = EXE(
+    b_pyz,
+    b.scripts,
+    b.binaries,
+    b.zipfiles,
+    b.datas,
+    [],
+    name="canu-inventory",
+    debug=False,
+    bootloader_ignore_signal=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+)
+
+coll = COLLECT(
+    b_exe,
+    b.binaries,
+    b.zipfiles,
+    b.datas,
+    a_exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name="canupkg",
+)
+

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,9 @@ setup(
         'yamale<=4.0.2',
     ],
     entry_points={
-        "console_scripts": ["canu=canu.cli:cli"],
+        "console_scripts": [
+          "canu=canu.cli:cli",
+          "canu-inventory=canu.inventory.ansible:ansible_inventory"
+          ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
         ],
         "test": [
             "coverage",
+            "mock",
             "py>==1.11.0",
             "pytest<7.2.1",
             "pytest-cov",

--- a/tests/test_ansible.py
+++ b/tests/test_ansible.py
@@ -1,0 +1,266 @@
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test canu-inventory."""
+import json
+import os
+
+from click import testing
+import mock
+import responses
+
+import canu.inventory.ansible as ansible
+from canu.inventory.ansible import ansible_inventory
+
+sls_file = "./sls_input_file.json"
+sls_address = "api-gw-service-nmn.local"
+dumpstate_url = "https://{sls_address}/apis/sls/v1/dumpstate"
+runner = testing.CliRunner()
+
+# mock datasource switch_inventory
+datasource = {
+    "plugin": "DictInventory",
+    "options": {
+        "hosts": {
+            "sw-spine-001": {
+                "hostname": "127.1.2.3",
+                "username": "admin",
+                "password": "",
+                "data": {"type": "spine"},
+                "groups": ["aruba"],
+            },
+            "sw-spine-002": {
+                "hostname": "127.4.5.6",
+                "username": "admin",
+                "password": "",
+                "data": {"type": "spine"},
+                "groups": ["aruba"],
+            },
+            "sw-leaf-bmc-001": {
+                "hostname": "127.7.8.9",
+                "username": "admin",
+                "password": "",
+                "data": {"type": "leaf-bmc"},
+                "groups": ["aruba"],
+            },
+        },
+        "groups": {
+            "aruba": {
+                "platform": "aruba_aoscx",
+                "connection_options": {
+                    "scrapli": {"extras": {"auth_strict_key": False}},
+                },
+            },
+            "dell": {"platform": "dell_os10"},
+            "mellanox": {"platform": "mellanox"},
+        },
+        "defaults": {},
+    },
+}
+
+dumpstate = {
+    "Hardware": {
+        "x3000c0h12s1": {
+            "Parent": "x3000c0h12",
+            "Xname": "x3000c0h12s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "LastUpdated": 1669049199,
+            "LastUpdatedTime": "2022-11-21 16:46:39.615062 +0000 +0000",
+            "ExtraProperties": {
+                "Aliases": ["sw-spine-001"],
+                "Brand": "Aruba",
+                "IP4addr": "127.127.127.1",
+            },
+        },
+        "x3000c0h13s1": {
+            "Parent": "x3000c0h13",
+            "Xname": "x3000c0h13s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "LastUpdated": 1669049199,
+            "LastUpdatedTime": "2022-11-21 16:46:39.615062 +0000 +0000",
+            "ExtraProperties": {
+                "Aliases": ["sw-spine-002"],
+                "Brand": "Aruba",
+                "IP4addr": "127.127.127.2",
+            },
+        },
+    },
+    "Networks": {
+        "CMN": {
+            "Name": "CMN",
+            "FullName": "Customer Management Network",
+            "IPRanges": ["127.1.0.0/16"],
+            "Type": "ethernet",
+            "LastUpdated": 1669049199,
+            "LastUpdatedTime": "2022-11-21 16:46:39.675539 +0000 +0000",
+            "ExtraProperties": {
+                "CIDR": "127.1.0.0/16",
+                "MTU": 9000,
+                "MyASN": 65532,
+                "PeerASN": 65533,
+                "Subnets": [
+                    {
+                        "CIDR": "127.1.0.0/16",
+                        "FullName": "CMN Management Network Infrastructure",
+                        "Gateway": "127.1.1.1",
+                        "IPReservations": [
+                            {
+                                "Comment": "x3000c0h12s1",
+                                "IPAddress": "127.1.2.3",
+                                "Name": "sw-spine-001",
+                            },
+                            {
+                                "Comment": "x3000c0h13s1",
+                                "IPAddress": "127.4.5.6",
+                                "Name": "sw-spine-002",
+                            },
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 7,
+                    },
+                ],
+                "VlanRange": [7],
+            },
+        },
+    },
+}
+
+
+def test_canu_inventory():
+    """Run canu-inventory with no errors."""
+    result = runner.invoke(ansible.ansible_inventory)
+    assert result.exit_code == 0
+
+
+@mock.patch("socket.gethostname")
+def test_is_context_ncn_true(mock_get):
+    """Test is_context_ncn with True."""
+    mock_get.return_value = mock.Mock(ok=True)
+    mock_get.return_value = "ncn-m001"
+    assert ansible.is_context_ncn() is True
+
+
+@mock.patch("socket.gethostname")
+def test_is_context_ncn_false(mock_get):
+    """Test is_context_ncn with False."""
+    mock_get.return_value = mock.Mock(ok=True)
+    mock_get.return_value = "bologna"
+    assert ansible.is_context_ncn() is False
+
+
+def test_get_switch_user(datasource=datasource, hostname="sw-spine-001"):
+    """Test get_switch_user."""
+    assert ansible.get_switch_user(datasource, hostname) == {"ansible_user": "admin"}
+
+
+def test_get_switch_pass(datasource=datasource, hostname="sw-spine-001"):
+    """Test get_switch_password."""
+    assert ansible.get_switch_pass(datasource, hostname) == {"ansible_password": ""}
+
+
+def test_get_switch_ip(datasource=datasource, hostname="sw-spine-001"):
+    """Test get_switch_ip."""
+    assert ansible.get_switch_ip(datasource, hostname) == {"ansible_host": "127.1.2.3"}
+
+
+def test_get_groups(datasource=datasource, hostname="sw-spine-001"):
+    """Test get_groups."""
+    assert ansible.get_groups(datasource, hostname) == {"groups": ["aruba", "spine"]}
+
+
+def test_get_aruba_vars(datasource=datasource, hostname="sw-spine-001"):
+    """Test get_aruba_vars."""
+    try:
+        assert ansible.get_aruba_vars(datasource, hostname) == [
+            {"ansible_network_os": "arubanetworks.aoscx.aoscx"},
+            {"ansible_connection": "arubanetworks.aoscx.aoscx"},
+            {"ansible_httpapi_use_ssl": True},
+            {"ansible_httpapi_validate_certs": False},
+            {"ansible_acx_no_proxy": False},
+            {"ansible_aoscx_validate_certs": False},
+            {"ansible_aoscx_use_proxy": False},
+        ]
+    except TypeError:
+        raise AssertionError("get_aruba_vars() should return a list") from TypeError
+
+
+def test_ansible_hostvars(datasource=datasource, hostname="sw-spine-001"):
+    """Test ansible_hostvars."""
+    assert ansible.ansible_hostvars(datasource, hostname) == {
+        "ansible_host": "127.1.2.3",
+        "ansible_user": "admin",
+        "ansible_password": "",
+        "groups": ["aruba", "spine"],
+        "ansible_network_os": "arubanetworks.aoscx.aoscx",
+        "ansible_connection": "arubanetworks.aoscx.aoscx",
+        "ansible_httpapi_use_ssl": True,
+        "ansible_httpapi_validate_certs": False,
+        "ansible_acx_no_proxy": False,
+        "ansible_aoscx_validate_certs": False,
+        "ansible_aoscx_use_proxy": False,
+    }
+
+
+def mockenv(**envvars):
+    """Allow more than one envvar to be mocked at once."""
+    return mock.patch.dict(os.environ, envvars)
+
+
+@mockenv(LANG="C.UTF-8", LC_ALL="C.UTF-8", SLS_API_GW=sls_address)
+@mock.patch("requests.get")
+@responses.activate
+def test_mock_api_dumpstate(mock_get):
+    """Run canu-inventory using the API."""
+    mock_get.return_value = mock.Mock(ok=True)
+    result = mock_get.return_value.json.return_value = dumpstate
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            ansible_inventory,
+            [
+                "--host",
+                "sw-spine-001",
+            ],
+        )
+
+    assert "127.1.2.3" in result.stdout
+    assert result.exit_code == 0
+
+
+@mockenv(LANG="C.UTF-8", LC_ALL="C.UTF-8")
+def test_mock_file_dumpstate():
+    """Run canu-inventory using a local file."""
+    with runner.isolated_filesystem():
+        # Generate junk data in what should be a json file
+        with open(sls_file, "w") as f:
+            f.write(json.dumps(dumpstate))
+        result = runner.invoke(
+            ansible_inventory,
+            [
+                "--host",
+                "sw-spine-002",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "127.4.5.6" in result.output


### PR DESCRIPTION
### Summary and Scope

Description:

- adds a standalone `canu-inventory` command for use with ansible (CASMNET-1968)
- adds a playbook (CASMNET-1982) that 
  - validates a plain-text config
  - creates a checkpoint from the running-config*
  - uploads the new config to the switch and sets it as the running config

*this needed a slight workaround that changes the banner on the running-config.  Without that task, the play fails:

> 'GENERIC OPERATION ERROR: Checkpoint already exists in the database or it is a duplicate checkpoint'

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have updated the appropriate Changelog entries in `README.md`
- [x] I have incremented the version in the `README.md`

### Issues and Related PRs

* Resolves: `CASMNET-1968
* Resolves: `CASMNET-1982

### Testing

Tested on:

- Local
- `#surtur`
