### PR TITLE
Stable Build Needs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -160,7 +160,7 @@ pipeline {
 
                         agent {
                             docker {
-                                args '-u root' // Build Python RPMs as root for Python rpm macros to build with the right sitelib.
+                                args '-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /home/jenkins/.ssh:/root/.ssh -v /home/jenkins/.ssh:/home/jenkins/.ssh --group-add 999'
                                 label "metal-gcp-builder"
                                 reuseNode true
                                 image "${pythonImage}:${PYTHON_VERSION}"


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->
Fixes Docker-in-Docker publishing; since a Docker container is used to provide `os-release` for determining where to publish the RPMs, the ClamAV `Docker` container needs `docker.sock` mounted so it can run Docker-in-Docker.

Additionally, the SSH public keys on the node are not available to the Docker container for sending RPMs to DST for signing. This mounts the SSH keys for the Docker container to successfully sign the RPM.
