### PR TITLE
Better LLDP data checking and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1457,6 +1457,9 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 
 ### [1.6.36]
 
+- Add better LLDP data error handling for `canu report network cabling` and `canu validate network cabling`.
+- Refine error messaging for failed logins.
+- Detect and respond to a rare condition where LLDP queries to Mellanox switches succeed, but the return data is not JSON.
 
 ### [1.6.35]
 

--- a/README.md
+++ b/README.md
@@ -1451,10 +1451,6 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 
 ## Changelog
 
-- Add better LLDP data error handling for `canu report network cabling` and `canu validate network cabling`.
-- Refine error messaging for failed logins.
-- Detect and respond to a rare condition where LLDP queries to Mellanox switches succeed, but the return data is not JSON.
-
 ### [1.6.36]
 
 - Add better LLDP data error handling for `canu report network cabling` and `canu validate network cabling`.

--- a/README.md
+++ b/README.md
@@ -1196,7 +1196,7 @@ Interface Lag:                   1  |
 
 Errors
 ----------------------------------------------------------------------------------------------------
-192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the IP address and try again.
+192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the entered username, IP address and password.
 ```
 
 #### File Output and JSON
@@ -1450,6 +1450,13 @@ To run a specific test file:
 To reuse a session without reinstalling dependencies use the `-rs` flag instead of `-s`.
 
 ## Changelog
+
+- Add better LLDP data error handling for `canu report network cabling` and `canu validate network cabling`.
+- Refine error messaging for failed logins.
+- Detect and respond to a rare condition where LLDP queries to Mellanox switches succeed, but the return data is not JSON.
+
+### [1.6.36]
+
 
 ### [1.6.35]
 

--- a/canu/report/switch/firmware/firmware.py
+++ b/canu/report/switch/firmware/firmware.py
@@ -280,7 +280,7 @@ def get_firmware_aruba(ip, credentials, return_error=False, cache_minutes=10):
                     f"Error connecting to switch {ip}, check the username or password"
                 )
             elif exception_type == "ConnectionError":
-                error_message = f"Error connecting to switch {ip}, check the IP address and try again"
+                error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password"
             else:  # pragma: no cover
                 error_message = f"Error connecting to switch {ip}."
 
@@ -501,7 +501,7 @@ def get_firmware_mellanox(ip, credentials, return_error=False, cache_minutes=10)
         exception_type = type(err).__name__
 
         if exception_type == "NetmikoTimeoutException":
-            error_message = f"Timeout error connecting to switch {ip}, check the IP address and try again."
+            error_message = f"Timeout error connecting to switch {ip}, check the entered username, IP address and password."
         elif exception_type == "NetmikoAuthenticationException":
             error_message = f"Authentication error connecting to switch {ip}, check the credentials or IP address and try again."
         else:

--- a/canu/utils/vendor.py
+++ b/canu/utils/vendor.py
@@ -140,7 +140,7 @@ def switch_vendor(
         exception_type = type(err).__name__
 
         if exception_type == "NetmikoTimeoutException":
-            error_message = f"Timeout error connecting to switch {ip}, check the IP address and try again."
+            error_message = f"Timeout error connecting to switch {ip}, check the entered username, IP address and password."
         elif exception_type == "NetmikoAuthenticationException":
             error_message = f"Authentication error connecting to switch {ip}, check the credentials or IP address and try again."
         else:

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -285,7 +285,7 @@ def get_bgp_neighbors_aruba(ip, credentials, asn, network):
             )
         elif exception_type == "ConnectionError":
             error_message = (
-                f"Error connecting to switch {ip}, check the IP address and try again."
+                f"Error connecting to switch {ip}, check the entered username, IP address and password."
             )
         else:
             error_message = f"Error connecting to switch {ip}."

--- a/canu/validate/paddle_cabling/paddle_cabling.py
+++ b/canu/validate/paddle_cabling/paddle_cabling.py
@@ -210,7 +210,7 @@ def paddle_cabling(
                     if exception_type == "HTTPError":
                         error_message = f"Error connecting to switch {ip}, check the IP, username, or password."
                     elif exception_type == "ConnectionError":
-                        error_message = f"Error connecting to switch {ip}, check the IP address and try again."
+                        error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password."
                     elif exception_type == "NetmikoTimeoutException":
                         error_message = f"Timeout error connecting to {ip}. Check the IP address and try again."
                     elif exception_type == "NetmikoAuthenticationException":

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -997,7 +997,7 @@ def node_list_warnings(node_list, warnings, out="-"):
         click.secho("\nWarnings", fg="red", file=out)
         if warnings["node_type"]:
             click.secho(
-                "\nNode type could not be determined for the following."
+                "\nNode type or port number could not be determined for the following."
                 + "\nThese nodes are not currently included in the model."
                 + "\n(This may be a missing architectural definition/lookup or a spelling error)",
                 fg="red",

--- a/canu/validate/shcd_cabling/shcd_cabling.py
+++ b/canu/validate/shcd_cabling/shcd_cabling.py
@@ -245,7 +245,7 @@ def shcd_cabling(
                     if exception_type == "HTTPError":
                         error_message = f"Error connecting to switch {ip}, check the IP, username, or password."
                     elif exception_type == "ConnectionError":
-                        error_message = f"Error connecting to switch {ip}, check the IP address and try again."
+                        error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password."
                     elif exception_type == "NetmikoTimeoutException":
                         error_message = f"Timeout error connecting to {ip}. Check the IP address and try again."
                     elif exception_type == "NetmikoAuthenticationException":

--- a/docs/network_configuration_and_upgrade/checks_and_validations.md
+++ b/docs/network_configuration_and_upgrade/checks_and_validations.md
@@ -20,7 +20,7 @@ Critically, the Warnings output will contain a section headed “Node type could
 
  
 ```text
-Node type could not be determined for the following. 
+Node type or port number could not be determined for the following. 
 These nodes are not currently included in the model. 
 (This may be a missing architectural definition/lookup or a spelling error) 
 ---------------------------------------------------------------------------

--- a/docs/templates/validate_network_config.md
+++ b/docs/templates/validate_network_config.md
@@ -37,7 +37,7 @@ Interface Lag:                   1  |
 
 Errors
 ----------------------------------------------------------------------------------------------------
-192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the IP address and try again.
+192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the entered username, IP address and password.
 ```
 
 ![](/images/canu_validate_switch_config.png)

--- a/docs/validate_network_config.md
+++ b/docs/validate_network_config.md
@@ -112,7 +112,7 @@ Interface Lag:                   1  |
 
 Errors
 ----------------------------------------------------------------------------------------------------
-192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the IP address and try again.
+192.168.1.3      - Timeout error connecting to switch 192.168.1.3, check the entered username, IP address and password.
 ```
 
 

--- a/tests/test_report_network_cabling.py
+++ b/tests/test_report_network_cabling.py
@@ -539,7 +539,7 @@ def test_network_cabling_bad_ip(get_lldp, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -580,7 +580,7 @@ def test_network_cabling_bad_ip_file(get_lldp, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -615,7 +615,7 @@ def test_network_cabling_bad_password(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Error connecting to switch 192.168.1.1, check the IP address and try again."
+            "Error connecting to switch 192.168.1.1, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -681,7 +681,7 @@ def test_network_cabling_dell_timeout(netmiko_commands, switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Timeout error connecting to switch 192.168.1.2, check the IP address and try again."
+            "Timeout error connecting to switch 192.168.1.2, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -712,7 +712,7 @@ def test_network_cabling_dell_auth(netmiko_commands, switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Auth error connecting to switch 192.168.1.2, check the credentials or IP address and try again."
+            "Auth error connecting to switch 192.168.1.2, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -819,7 +819,7 @@ def test_network_cabling_mellanox_connection_error(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Error connecting to switch 192.168.1.3, check the IP address and try again."
+            "Error connecting to switch 192.168.1.3, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -859,7 +859,7 @@ def test_network_cabling_mellanox_exception(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Error connecting to switch 192.168.1.3, check the IP address and try again."
+            "Error connecting to switch 192.168.1.3, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -894,7 +894,7 @@ def test_network_cabling_mellanox_bad_login(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Error connecting to switch 192.168.1.3, check the IP address and try again."
+            "Error connecting to switch 192.168.1.3, check the entered username, IP address and password."
             in str(result.output)
         )
 

--- a/tests/test_report_switch_cabling.py
+++ b/tests/test_report_switch_cabling.py
@@ -250,7 +250,7 @@ def test_switch_cabling_invalid_ip():
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -286,7 +286,7 @@ def test_switch_cabling_bad_ip(switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -389,7 +389,7 @@ def test_switch_cabling_dell_timeout(netmiko_commands, switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Timeout error connecting to switch 192.168.1.2, check the IP address and try again."
+            "Timeout error connecting to switch 192.168.1.2, check the entered username, IP address and password."
             in str(result.output)
         )
 
@@ -561,7 +561,7 @@ def test_switch_cabling_mellanox_connection_error(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Error connecting to switch 192.168.1.3, check the IP address and try again."
+            "Error connecting to switch 192.168.1.3, check the entered username, IP address and password."
             in str(result.output)
         )
 

--- a/tests/test_report_switch_firmware.py
+++ b/tests/test_report_switch_firmware.py
@@ -298,7 +298,7 @@ def test_switch_firmware_invalid_ip():
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.firmware.firmware.switch_vendor")
@@ -337,7 +337,7 @@ def test_switch_firmware_bad_ip(switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.firmware.firmware.switch_vendor")
@@ -820,7 +820,7 @@ def test_switch_firmware_mellanox_timeout(netmiko_commands, switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "Timeout error connecting to switch 192.168.1.3, check the IP address and try again."
+            "Timeout error connecting to switch 192.168.1.3, check the entered username, IP address and password."
             in str(result.output)
         )
 

--- a/tests/test_validate_network_cabling.py
+++ b/tests/test_validate_network_cabling.py
@@ -424,7 +424,7 @@ def test_validate_cabling_bad_ip(switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -465,7 +465,7 @@ def test_validate_cabling_bad_ip_file(switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")

--- a/tests/test_validate_paddle_cabling.py
+++ b/tests/test_validate_paddle_cabling.py
@@ -140,7 +140,7 @@ def test_validate_paddle_cabling(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -281,7 +281,7 @@ def test_validate_paddle_cabling_file(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -466,7 +466,7 @@ def test_validate_paddle_cabling_bad_ip(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -511,7 +511,7 @@ def test_validate_paddle_cabling_bad_ip_file(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")

--- a/tests/test_validate_shcd_cabling.py
+++ b/tests/test_validate_shcd_cabling.py
@@ -146,7 +146,7 @@ def test_validate_shcd_cabling(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -329,7 +329,7 @@ def test_validate_shcd_cabling_full_architecture(netmiko_command, switch_vendor)
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -448,7 +448,7 @@ def test_validate_shcd_cabling_file(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -656,7 +656,7 @@ def test_validate_shcd_cabling_bad_ip(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -706,7 +706,7 @@ def test_validate_shcd_cabling_bad_ip_file(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "check the IP address and try again" in str(result.output)
+        assert "check the entered username, IP address and password" in str(result.output)
 
 
 @patch("canu.report.switch.cabling.cabling.switch_vendor")
@@ -918,7 +918,7 @@ def test_validate_shcd_cabling_missing_tabs(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"
@@ -1096,7 +1096,7 @@ def test_validate_shcd_cabling_corner_prompt(netmiko_command, switch_vendor):
         ) in str(result.output)
 
         assert (
-            "Node type could not be determined for the following.\n"
+            "Node type or port number could not be determined for the following.\n"
             + "These nodes are not currently included in the model.\n"
             + "(This may be a missing architectural definition/lookup or a spelling error)\n"
             + "--------------------------------------------------------------------------------\n"


### PR DESCRIPTION
### Summary and Scope

This bugfix addresses the following commands:

* `canu validate network cabling`
* `canu validate shcd-cabling`
* `canu validate paddle-cabling`

LLDP data is queried from the switches for these commands.  This data is then transformed into usable information both for reporting and entering into the CANU model.  Some times either LLDP is not running on the device connected to the switch or the LLDP information does not reduce to a singular physical port (in the case of bond0 for instance).  In these cases the port number was None in Python and while this is great for error checks in Python, loading None as a port number into the CANU model caused exceptions to be thrown.  The bugfix (CASMNET-2034) adds the detected node to the model where possible, but does not connect the node to the switch. This allows the run to succeed and alerts the user that the node exists, but port cabling information can't be determined.

Also added and remediated:

* Added debug logging to `report network cabling`.
* Added guidance to check username and password (as well as IP) when auth fails to a switch.
* Added the ability to detect Arista edge switch port numbers.
* Added error handling to Mellanox LLDP data queries.  In rare cases the API call succeeds but the return is not valid JSON (CASMNET-2051).

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [x] I have updated the appropriate Changelog entries in `README.md`

### Issues and Related PRs

* Resolves: CASMNET-2034
* Resolves: CASMNET-2051

### Testing

Tested on:

* Physical Mellanox system
* Physical Aruba system