### PR TITLE
Fixed broken link to generate_switch_config.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ If any of the spine switch neighbors for a connection other than **Established**
 
 ### Generate Switch Config
 
-**[Details](docs/switch_config.md)**<br>
+**[Details](docs/generate_switch_config.md)**<br>
 To see all the lags that are generated, see [lags](docs/lags.md)
 
 CANU can be used to generate switch config.

--- a/README.md
+++ b/README.md
@@ -1451,6 +1451,10 @@ To reuse a session without reinstalling dependencies use the `-rs` flag instead 
 
 ## Changelog
 
+### [1.6.37]
+
+- Fix link to generate switch configuration documentation.
+
 ### [1.6.36]
 
 - Add better LLDP data error handling for `canu report network cabling` and `canu validate network cabling`.


### PR DESCRIPTION
Fixes a broken docs link to the generate switch config details.