### PR TITLE
fix sonarcloud bugs

### DIFF
--- a/canu/backup/backup.py
+++ b/canu/backup/backup.py
@@ -21,15 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU backup commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.backup.network import network
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def backup(ctx):

--- a/canu/backup/network/network.py
+++ b/canu/backup/network/network.py
@@ -201,7 +201,12 @@ def network(
             "replace": r"\1 <removed>",
         },
     ]
-    with click_spinner.spinner():
+    with click_spinner.spinner(
+        beep=False,
+        disable=False,
+        force=False,
+        stream=sys.stdout,
+    ):
         print(
             "  Connecting",
             end="\r",

--- a/canu/cache/cache.py
+++ b/canu/cache/cache.py
@@ -24,9 +24,9 @@ from os import path, remove
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand, HelpColorsGroup
 from ruamel.yaml import YAML
 
+from canu.style import Style
 from canu.utils.cache import cache_directory
 
 
@@ -34,9 +34,7 @@ yaml = YAML()
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def cache(ctx):
@@ -44,9 +42,7 @@ def cache(ctx):
 
 
 @cache.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.pass_context
 def location(ctx):
@@ -55,9 +51,7 @@ def location(ctx):
 
 
 @cache.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.pass_context
 def delete(ctx):
@@ -68,9 +62,7 @@ def delete(ctx):
 
 
 @cache.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.pass_context
 def print(ctx):

--- a/canu/cli.py
+++ b/canu/cli.py
@@ -27,8 +27,6 @@ import sys
 
 import certifi
 import click
-from click_help_colors import HelpColorsCommand
-from click_help_colors import HelpColorsGroup
 import pkg_resources
 import requests
 from ruamel.yaml import YAML
@@ -40,6 +38,7 @@ from canu.config import config
 from canu.generate import generate
 from canu.report import report
 from canu.send import send
+from canu.style import Style
 from canu.test import test
 from canu.utils.cache import cache_switch
 from canu.validate import validate
@@ -70,9 +69,7 @@ CONTEXT_SETTING = {
 
 @click.group(
     context_settings=CONTEXT_SETTING,
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.option(
     "--cache",
@@ -101,9 +98,7 @@ cli.add_command(test.test)
 
 
 @cli.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--sls-file",

--- a/canu/config/config.py
+++ b/canu/config/config.py
@@ -21,13 +21,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU Commands that configure switches on the network."""
 import click
-from click_help_colors import HelpColorsGroup
+
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def config(ctx):

--- a/canu/generate/generate.py
+++ b/canu/generate/generate.py
@@ -21,16 +21,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU generate commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.generate.network import network
 from canu.generate.switch import switch
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def generate(ctx):

--- a/canu/generate/network/config/config.py
+++ b/canu/generate/network/config/config.py
@@ -27,7 +27,6 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from network_modeling.NetworkNodeFactory import NetworkNodeFactory
@@ -41,6 +40,7 @@ from canu.generate.switch.config.config import (
     parse_sls_for_config,
     rename_sls_hostnames,
 )
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.paddle.paddle import node_model_from_paddle
 from canu.validate.shcd.shcd import node_model_from_shcd, shcd_to_sheets
@@ -84,9 +84,7 @@ csm_options = canu_config["csm_versions"]
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/generate/network/network.py
+++ b/canu/generate/network/network.py
@@ -21,15 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU generate network commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
+from canu.style import Style
 from .config import config
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def network(ctx):

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -31,7 +31,6 @@ import re
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup
 from click_option_group import RequiredMutuallyExclusiveOptionGroup
 from hier_config import HConfig
@@ -49,6 +48,7 @@ from ruamel.yaml import YAML
 from ttp import ttp
 import urllib3
 
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.utils.yaml_load import load_yaml
 from canu.validate.paddle.paddle import node_model_from_paddle
@@ -125,9 +125,7 @@ dash = "-" * 60
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -614,12 +614,11 @@ def generate_switch_config(
     }
 
     if node_shasta_name is None:
-        return Exception(
-            click.secho(
-                f"For switch {switch_name}, the type cannot be determined. Please check the switch name and try again.",
-                fg="red",
-            ),
-        )
+        click.secho(
+            f"For switch {switch_name}, the type cannot be determined. Please check the switch name and try again.",
+            fg="red",
+        ),
+        return Exception()
     elif node_shasta_name == "sw-edge" and float(csm) >= 1.2:
         templates["sw-edge"] = {
             "primary": f"{csm}/{edge.lower()}/sw-edge.primary.j2",
@@ -631,12 +630,11 @@ def generate_switch_config(
         "sw-leaf",
         "sw-spine",
     ]:
-        return Exception(
-            click.secho(
-                f"{switch_name} is not a switch. Only switch config can be generated.",
-                fg="red",
-            ),
-        )
+        click.secho(
+            f"{switch_name} is not a switch. Only switch config can be generated.",
+            fg="red",
+        ),
+        return Exception()
 
     if preserve:
         try:

--- a/canu/generate/switch/switch.py
+++ b/canu/generate/switch/switch.py
@@ -21,13 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU generate switch commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.generate.switch.config import config
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
+    cls=Style.CanuHelpColorsGroup,
     help_headers_color="yellow",
     help_options_color="blue",
 )

--- a/canu/report/network/cabling/cabling.py
+++ b/canu/report/network/cabling/cabling.py
@@ -26,7 +26,6 @@ import logging
 import re
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -34,14 +33,13 @@ from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 import requests
 
 from canu.report.switch.cabling.cabling import get_lldp, print_lldp
+from canu.style import Style
 
 log = logging.getLogger("report_cabling")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @optgroup.group(
     "Network cabling IPv4 input sources",

--- a/canu/report/network/cabling/cabling.py
+++ b/canu/report/network/cabling/cabling.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 import ipaddress
 import logging
 import re
+import sys
 
 import click
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
@@ -143,7 +144,12 @@ def cabling(ctx, ips, ips_file, username, password, out, view, log_):
     errors = []
     ips_length = len(ips)
     if ips:
-        with click_spinner.spinner():
+        with click_spinner.spinner(
+            beep=False,
+            disable=False,
+            force=False,
+            stream=sys.stdout,
+        ):
             for i, ip in enumerate(ips, start=1):
                 print(
                     f"  Connecting to {ip} - Switch {i} of {ips_length}        ",

--- a/canu/report/network/firmware/firmware.py
+++ b/canu/report/network/firmware/firmware.py
@@ -29,7 +29,6 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -44,6 +43,7 @@ from canu.report.switch.firmware.firmware import (
     get_firmware_dell,
     get_firmware_mellanox,
 )
+from canu.style import Style
 from canu.utils.cache import cache_switch
 from canu.utils.vendor import switch_vendor
 
@@ -68,9 +68,7 @@ csm_options = canu_config["csm_versions"]
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/report/network/network.py
+++ b/canu/report/network/network.py
@@ -21,17 +21,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU commands report on the switch network."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.report.network.cabling import cabling
 from canu.report.network.firmware import firmware
 from canu.report.network.version import version
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def network(ctx):

--- a/canu/report/network/version/version.py
+++ b/canu/report/network/version/version.py
@@ -23,7 +23,6 @@
 import logging
 
 import click
-from click_help_colors import HelpColorsCommand
 import click_spinner
 from nornir import InitNornir
 from nornir.core.filter import F
@@ -31,14 +30,13 @@ from nornir_salt.plugins.tasks import netmiko_send_commands
 from nornir_scrapli.tasks import send_command
 from ttp import ttp
 
+from canu.style import Style
 from canu.utils.host_alive import host_alive
 from canu.utils.inventory import inventory
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--sls-file",

--- a/canu/report/network/version/version.py
+++ b/canu/report/network/version/version.py
@@ -21,6 +21,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU commands that report the configuration version."""
 import logging
+import sys
 
 import click
 import click_spinner
@@ -126,7 +127,12 @@ def version(ctx, username, password, sls_file, sls_address, network, log_):
     dell_hosts = online_hosts.filter(F(platform="dell_os10"))
 
     # run the version check
-    with click_spinner.spinner():
+    with click_spinner.spinner(
+        beep=False,
+        disable=False,
+        force=False,
+        stream=sys.stdout,
+    ):
         print(
             "  Running version check on switches...",
             end="\r",

--- a/canu/report/report.py
+++ b/canu/report/report.py
@@ -21,16 +21,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU report commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.report.network import network
 from canu.report.switch import switch
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def report(ctx):

--- a/canu/report/switch/cabling/cabling.py
+++ b/canu/report/switch/cabling/cabling.py
@@ -28,12 +28,12 @@ import sys
 from urllib.parse import unquote
 
 import click
-from click_help_colors import HelpColorsCommand
 import natsort
 from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 import requests
 import urllib3
 
+from canu.style import Style
 from canu.utils.cache import cache_switch
 from canu.utils.mac import find_mac
 from canu.utils.ssh import netmiko_command, netmiko_commands
@@ -44,9 +44,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option("--ip", required=True, help="The IP address of the switch")
 @click.option("--username", default="admin", show_default=True, help="Switch username")

--- a/canu/report/switch/firmware/firmware.py
+++ b/canu/report/switch/firmware/firmware.py
@@ -27,13 +27,13 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 import emoji
 from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 import requests
 from ruamel.yaml import YAML
 import urllib3
 
+from canu.style import Style
 from canu.utils.cache import (
     cache_switch,
     firmware_cached_recently,
@@ -66,9 +66,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/report/switch/switch.py
+++ b/canu/report/switch/switch.py
@@ -21,16 +21,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU report switch commands."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.report.switch.cabling import cabling
 from canu.report.switch.firmware import firmware
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def switch(ctx):

--- a/canu/send/command/command.py
+++ b/canu/send/command/command.py
@@ -129,5 +129,10 @@ def command(
             )
         return results
 
-    with click_spinner.spinner():
+    with click_spinner.spinner(
+        beep=False,
+        disable=False,
+        force=False,
+        stream=sys.stdout,
+    ):
         print_result(send_command())

--- a/canu/send/send.py
+++ b/canu/send/send.py
@@ -21,15 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU Commands that are sent to switches on the network."""
 import click
-from click_help_colors import HelpColorsGroup
 
 from canu.send.command import command
+from canu.style import Style
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def send(ctx):

--- a/canu/style/Style.py
+++ b/canu/style/Style.py
@@ -19,29 +19,42 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-"""CANU Commands that validate the Shasta switch network."""
-import click
+"""Style to keep styling in one place."""
 
-from canu.style import Style
-from canu.validate.network import network
-from canu.validate.paddle import paddle
-from canu.validate.paddle_cabling import paddle_cabling
-from canu.validate.shcd import shcd
-from canu.validate.shcd_cabling import shcd_cabling
-from canu.validate.switch import switch
+from click_help_colors import HelpColorsCommand, HelpColorsGroup
 
 
-@click.group(
-    cls=Style.CanuHelpColorsGroup,
-)
-@click.pass_context
-def validate(ctx):
-    """CANU validate commands."""
+class CanuHelpColorsCommand(HelpColorsCommand):
+    """A class for customizing the help colors in a command.
+
+    Attributes
+    ----------
+    help_headers_color : string
+        A color for the help headers.
+    help_options_color : string
+        A color for the help options.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Set the header and option colors."""
+        super().__init__(*args, **kwargs)
+        self.help_headers_color = "blue"
+        self.help_options_color = "yellow"
 
 
-validate.add_command(network.network)
-validate.add_command(paddle.paddle)
-validate.add_command(paddle_cabling.paddle_cabling)
-validate.add_command(shcd.shcd)
-validate.add_command(shcd_cabling.shcd_cabling)
-validate.add_command(switch.switch)
+class CanuHelpColorsGroup(HelpColorsGroup):
+    """A class for customizing the help colors in a group.
+
+    Attributes
+    ----------
+    help_headers_color : string
+        A color for the help headers.
+    help_options_color : string
+        A color for the help options.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Set the header and option colors."""
+        super().__init__(*args, **kwargs)
+        self.help_headers_color = "blue"
+        self.help_options_color = "yellow"

--- a/canu/style/__init__.py
+++ b/canu/style/__init__.py
@@ -19,29 +19,4 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-"""CANU Commands that validate the Shasta switch network."""
-import click
-
-from canu.style import Style
-from canu.validate.network import network
-from canu.validate.paddle import paddle
-from canu.validate.paddle_cabling import paddle_cabling
-from canu.validate.shcd import shcd
-from canu.validate.shcd_cabling import shcd_cabling
-from canu.validate.switch import switch
-
-
-@click.group(
-    cls=Style.CanuHelpColorsGroup,
-)
-@click.pass_context
-def validate(ctx):
-    """CANU validate commands."""
-
-
-validate.add_command(network.network)
-validate.add_command(paddle.paddle)
-validate.add_command(paddle_cabling.paddle_cabling)
-validate.add_command(shcd.shcd)
-validate.add_command(shcd_cabling.shcd_cabling)
-validate.add_command(switch.switch)
+"""CANU style."""

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -21,6 +21,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU commands that validate the network bgp."""
 from collections import defaultdict
+import sys
 
 import click
 import click_spinner
@@ -91,7 +92,12 @@ def bgp(ctx, username, password, verbose, network):
         sls_cache["HMN_IPs"]["sw-spine-001"],
         sls_cache["HMN_IPs"]["sw-spine-002"],
     ]
-    with click_spinner.spinner():
+    with click_spinner.spinner(
+        beep=False,
+        disable=False,
+        force=False,
+        stream=sys.stdout,
+    ):
         for ip in spine_switches:
             print(
                 "  Connecting",

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -23,20 +23,18 @@
 from collections import defaultdict
 
 import click
-from click_help_colors import HelpColorsCommand
 import click_spinner
 import natsort
 from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 import requests
 
+from canu.style import Style
 from canu.utils.sls import pull_sls_networks
 from canu.utils.vendor import switch_vendor
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option("--username", default="admin", show_default=True, help="Switch username")
 @click.option(

--- a/canu/validate/network/cabling/cabling.py
+++ b/canu/validate/network/cabling/cabling.py
@@ -28,7 +28,6 @@ import re
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -39,6 +38,7 @@ import requests
 from ruamel.yaml import YAML
 
 from canu.report.switch.cabling.cabling import get_lldp
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.shcd.shcd import node_list_warnings, print_node_list
 
@@ -50,9 +50,7 @@ log = logging.getLogger("validate_cabling")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--architecture",

--- a/canu/validate/network/cabling/cabling.py
+++ b/canu/validate/network/cabling/cabling.py
@@ -139,7 +139,12 @@ def cabling(ctx, architecture, ips, ips_file, username, password, log_, out):
     ips_length = len(ips)
 
     if ips:
-        with click_spinner.spinner():
+        with click_spinner.spinner(
+            beep=False,
+            disable=False,
+            force=False,
+            stream=sys.stdout,
+        ):
             for i, ip in enumerate(ips, start=1):
                 print(
                     f"  Connecting to {ip} - Switch {i} of {ips_length}        ",
@@ -494,13 +499,12 @@ def node_model_from_canu(factory, canu_cache, ips):
                             strict=False,
                         )
                     except Exception:
-                        log.fatal(
-                            click.secho(
-                                f"Failed to connect {src_node.common_name()} "
-                                + f"to {dst_node.common_name()}",
-                                fg="red",
-                            ),
-                        )
+                        err_connect = f"Failed to connect {src_node.common_name()} to {dst_node.common_name()}"
+                        log.fatal(err_connect)
+                        click.secho(
+                            err_connect,
+                            fg="red",
+                        ),
                         sys.exit(1)
                     if connected:
                         log.info(

--- a/canu/validate/network/config/config.py
+++ b/canu/validate/network/config/config.py
@@ -194,7 +194,12 @@ def config(
 
         credentials = {"username": username, "password": password}
         ips_length = len(ips)
-        with click_spinner.spinner():
+        with click_spinner.spinner(
+            beep=False,
+            disable=False,
+            force=False,
+            stream=sys.stdout,
+        ):
             for i, ip in enumerate(ips, start=1):
                 if not json_:
                     print(

--- a/canu/validate/network/config/config.py
+++ b/canu/validate/network/config/config.py
@@ -29,7 +29,6 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -37,6 +36,7 @@ from hier_config import HConfig, Host
 from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 from ruamel.yaml import YAML
 
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.switch.config.config import (
     compare_config,
@@ -78,9 +78,7 @@ host = Host("example.rtr", "aoscx", options)
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/validate/network/network.py
+++ b/canu/validate/network/network.py
@@ -21,17 +21,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU Commands that validate the network."""
 import click
-from click_help_colors import HelpColorsGroup
 
+from canu.style import Style
 from canu.validate.network.bgp import bgp
 from canu.validate.network.cabling import cabling
 from canu.validate.network.config import config
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def network(ctx):

--- a/canu/validate/paddle/paddle.py
+++ b/canu/validate/paddle/paddle.py
@@ -25,11 +25,11 @@ import json
 import logging
 
 import click
-from click_help_colors import HelpColorsCommand
 from network_modeling.NetworkNodeFactory import NetworkNodeFactory
 from network_modeling.NetworkPort import NetworkPort
 from network_modeling.NodeLocation import NodeLocation
 
+from canu.style import Style
 from canu.validate.shcd.shcd import (
     node_list_warnings,
     print_node_list,
@@ -39,9 +39,7 @@ log = logging.getLogger("validate_paddle")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--ccj",

--- a/canu/validate/paddle_cabling/paddle_cabling.py
+++ b/canu/validate/paddle_cabling/paddle_cabling.py
@@ -28,7 +28,6 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -38,6 +37,7 @@ import requests
 from ruamel.yaml import YAML
 
 from canu.report.switch.cabling.cabling import get_lldp
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.network.cabling.cabling import node_model_from_canu
 from canu.validate.paddle.paddle import node_model_from_paddle
@@ -70,9 +70,7 @@ log = logging.getLogger("validate_paddle_cabling")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -32,7 +32,6 @@ import re
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 import natsort
 from network_modeling.NetworkNodeFactory import NetworkNodeFactory
 from network_modeling.NetworkPort import NetworkPort
@@ -40,6 +39,7 @@ from network_modeling.NodeLocation import NodeLocation
 from openpyxl import load_workbook
 import pkg_resources
 
+from canu.style import Style
 
 # Get project root directory
 if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cover
@@ -54,9 +54,7 @@ log = logging.getLogger("validate_shcd")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--architecture",

--- a/canu/validate/shcd_cabling/shcd_cabling.py
+++ b/canu/validate/shcd_cabling/shcd_cabling.py
@@ -29,7 +29,6 @@ import re
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -40,6 +39,7 @@ import requests
 from ruamel.yaml import YAML
 
 from canu.report.switch.cabling.cabling import get_lldp
+from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.network.cabling.cabling import node_model_from_canu
 from canu.validate.shcd.shcd import (
@@ -71,9 +71,7 @@ log = logging.getLogger("validate_shcd_cabling")
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @click.option(
     "--csm",

--- a/canu/validate/shcd_cabling/shcd_cabling.py
+++ b/canu/validate/shcd_cabling/shcd_cabling.py
@@ -29,6 +29,7 @@ import re
 import sys
 
 import click
+from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS, Ipv4AddressListParamType
 import click_spinner
@@ -39,7 +40,6 @@ import requests
 from ruamel.yaml import YAML
 
 from canu.report.switch.cabling.cabling import get_lldp
-from canu.style import Style
 from canu.utils.cache import cache_directory
 from canu.validate.network.cabling.cabling import node_model_from_canu
 from canu.validate.shcd.shcd import (
@@ -71,7 +71,9 @@ log = logging.getLogger("validate_shcd_cabling")
 
 
 @click.command(
-    cls=Style.CanuHelpColorsCommand,
+    cls=HelpColorsCommand,
+    help_headers_color="yellow",
+    help_options_color="blue",
 )
 @click.option(
     "--csm",

--- a/canu/validate/switch/config/config.py
+++ b/canu/validate/switch/config/config.py
@@ -216,7 +216,12 @@ def config(
 
         credentials = {"username": username, "password": password}
 
-        with click_spinner.spinner():
+        with click_spinner.spinner(
+            beep=False,
+            disable=False,
+            force=False,
+            stream=sys.stdout,
+        ):
             print(
                 f"  Connecting to {ip}...",
                 end="\r",

--- a/canu/validate/switch/config/config.py
+++ b/canu/validate/switch/config/config.py
@@ -26,7 +26,6 @@ from pathlib import Path
 import sys
 
 import click
-from click_help_colors import HelpColorsCommand
 from click_option_group import optgroup, RequiredMutuallyExclusiveOptionGroup
 from click_params import IPV4_ADDRESS
 import click_spinner
@@ -34,6 +33,7 @@ from hier_config import HConfig, Host
 from netmiko import NetmikoAuthenticationException, NetmikoTimeoutException
 from ruamel.yaml import YAML
 
+from canu.style import Style
 from canu.utils.ssh import netmiko_command, netmiko_commands
 from canu.utils.vendor import switch_vendor
 
@@ -117,9 +117,7 @@ with open(mellanox_options_file, "r") as options_f:
 
 
 @click.command(
-    cls=HelpColorsCommand,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsCommand,
 )
 @optgroup.group(
     "Running config source",

--- a/canu/validate/switch/switch.py
+++ b/canu/validate/switch/switch.py
@@ -21,15 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU Commands that validate a switch."""
 import click
-from click_help_colors import HelpColorsGroup
 
+from canu.style import Style
 from canu.validate.switch.config import config
 
 
 @click.group(
-    cls=HelpColorsGroup,
-    help_headers_color="yellow",
-    help_options_color="blue",
+    cls=Style.CanuHelpColorsGroup,
 )
 @click.pass_context
 def switch(ctx):

--- a/network_modeling/NetworkModel.py
+++ b/network_modeling/NetworkModel.py
@@ -53,19 +53,22 @@ class NetworkModel:  # pragma: no cover
             factory: factory
 
         Raises:
-            Exception: A list of NetworkNode(s) is required
+            NetworkNodeFactoryRequiredError: A list of NetworkNodeFactory(s) is required
+            NetworkNodeRequiredError: A list of NetworkNode(s) is required
         """
         if factory:
             self.__factory = factory
         else:
-            raise Exception(click.secho("A NetworkNodeFactory is required", fg="red"))
+            err_nnf_req = "A NetworkNodeFactory is required"
+            click.secho(err_nnf_req, fg="red")
+            raise NetworkNodeFactoryRequiredError(err_nnf_req)
 
         if isinstance(nodes, list):
             self.__nodes = nodes
         else:
-            raise Exception(
-                click.secho("A list of NetworkNode(s) is required", fg="red"),
-            )
+            err_node_req = "A list of NetworkNode(s) is required"
+            click.secho(err_node_req, fg="red")
+            raise NetworkNodeRequiredError(err_node_req)
 
         self.__leafs = []
         self.__spines = []
@@ -190,3 +193,15 @@ class NetworkModel:  # pragma: no cover
     def assign_ports(self):
         """Not implemented."""
         pass
+
+
+class NetworkNodeFactoryRequiredError(Exception):
+    """Exception when a NetworkNodeFactory is required."""
+
+    pass
+
+
+class NetworkNodeRequiredError(Exception):
+    """Exception when a NetworkNode is required."""
+
+    pass


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->

Addresses several sonarcloud bugs:

It replaces these:

```
@click.group(
     cls=HelpColorsGroup,
     help_headers_color="yellow",
     help_options_color="blue",
 )
```
with a custom class.  This not only fixes the bugs, but also allows the styling to be in one place keeping things consistent.

```
from canu.style import Style
...
@click.command(
    cls=Style.CanuHelpColorsCommand,
)
```

This also reorganizes some `click.secho`s with `Exception`s per python:S3699.  

Finally, missing arguments are added to `click.spinner`s

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have updated the appropriate Changelog entries in `README.md`

### Issues and Related PRs

* Resolves: 54 sonar cloud bugs: 
* python:S930
* python:S3699


### Testing

Tested on:

local canu accessing `#surtur`.

Checked that the spinner functioned as expected (I saw it spinning):

```
Enter the switch password: 
sw-spine-001 is not reachable via SSH, skipping backup.
sw-spine-002 is not reachable via SSH, skipping backup.
sw-leaf-bmc-001 is not reachable via SSH, skipping backup.
-  Connecting
Running Configs Saved
---------------------
canu ~$ canu backup network --sls-file mounted/sls_input_file.json --network CMN
Folder for configs: mounted/netbak
Enter the switch password: 
|  Connecting
```

Checked that colors were still displayed on a handful of command helps, including `canu --help`, `canu report network cabling --help`, `canu config --help`.



Verified the error still appears when calling `canu generate switch config` with a junk name

```
% canu generate switch config --sls-file sls_input_file.json --ccj surtur-ccj.json --csm 1.3 -a full                                                                            10:46
Switch Name: junk
For switch junk, the type cannot be determined. Please check the switch name and try again.'
```

<!-- List of virtual or physical systems used. --->
