### PR TITLE
relax version pinning in the Dockerfile.  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,18 @@ USER        root
 WORKDIR     /root
 VOLUME      [ "/root/mounted" ]
 RUN         apk add --no-cache \
-              cmake=3.24.3-r0 \
-              g++=12.2.1_git20220924-r4 \
-              gcc=12.2.1_git20220924-r4 \
-              git=2.38.4-r0 \
-              libffi-dev=3.4.4-r0 \
-              make=4.3-r1 \
-              musl-dev=1.2.3-r4 \
-              openssl=3.0.8-r0 \
-              py3-pip=22.3.1-r1 \
-              py3-virtualenv=20.16.7-r0 \
-              python3=3.10.10-r0 \
-              python3-dev=3.10.10-r0
+              cmake~=3.24 \
+              g++~=12.2 \
+              gcc~=12.2 \
+              git~=2.38 \
+              libffi-dev~=3.4 \
+              make~=4.3 \
+              musl-dev~=1.2 \
+              openssl~=3.0 \
+              py3-pip~=22.3 \
+              py3-virtualenv~=20.16 \
+              python3~=3.10 \
+              python3-dev~=3.10
 ENV         VIRTUAL_ENV=/opt/venv
 RUN         python -m venv $VIRTUAL_ENV
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -50,7 +50,7 @@ VOLUME      [ "/root/mounted", "/ssh-agent" ]
 ENV         VIRTUAL_ENV=/opt/venv \
             SSH_AUTH_SOCK=/ssh-agent
 RUN         apk --update add \
-              openssh-client=9.1_p1-r2
+              openssh-client~=9.1
 RUN         source $VIRTUAL_ENV/bin/activate
 COPY        .flake8 ./.flake8
 COPY        .git/ ./.git
@@ -114,7 +114,7 @@ FROM        ${ALPINE_IMAGE} AS prod
 USER        root
 # ssh is needed for 'canu test' command
 RUN         apk --update add \
-              openssh-client=9.1_p1-r2
+              openssh-client~=9.1
 # must mount ${SSH_AUTH_SOCK} to /ssh-agent to use host ssh
 VOLUME      [ "/home/canu/mounted", "/ssh-agent" ]
 ENV         VIRTUAL_ENV=/opt/venv \


### PR DESCRIPTION
The existing strict versions cause issues when an upstream update is pushed.  This commit fixes when it fails with a message like:

```
[2023-03-03T20:31:56.707Z] #8 0.884 ERROR: unable to select packages:
[2023-03-03T20:31:56.707Z] #8 0.920   git-2.38.4-r1:
[2023-03-03T20:31:56.707Z] #8 0.920     breaks: world[git=2.38.4-r0]
```

### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->

PR checklist (you may replace this section):

- [x] I have run `nox` locally and all tests, linting, and code coverage pass
- [x] I have added new tests to cover the new code
- [x] My code follows the style guidelines of this project
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have updated the appropriate Changelog entries in `README.md`

### Issues and Related PRs

* Resolves: a broken Dockerfile

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
