### PR TITLE
Add Kea, SLS, SMD and heuristic lookup tables to fill out LLDP data for cabling reports and validation

### DIFF
--- a/canu/report/network/cabling/cabling.py
+++ b/canu/report/network/cabling/cabling.py
@@ -255,7 +255,7 @@ def cabling(
                         add_smd_metadata_to_lldp(switch_dict, smd_json)
                     # Annotate LLDP data with heuristics
                     if heuristic_lookups:
-                        add_heuristic_metadata_to_lldp(switch_dict)
+                        add_heuristic_metadata_to_lldp(switch_info, switch_dict)
 
                     switch_data.append(
                         [
@@ -272,7 +272,7 @@ def cabling(
                     NetmikoAuthenticationException,
                 ) as err:
                     exception_type = type(err).__name__
-
+                    error_message = "Unchecked"
                     if exception_type == "HTTPError":
                         error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password."
                     if exception_type == "ConnectionError":
@@ -292,7 +292,7 @@ def cabling(
                     )
 
         if view == "switch":
-            switch_table(switch_data, out)
+            switch_table(switch_data, heuristic_lookups, out)
         elif view == "equipment":
             equipment_json = equipment_table(switch_data)
             print_equipment(equipment_json, out)
@@ -510,7 +510,7 @@ def print_equipment(equipment_json, out="-"):
         click.echo("\n", file=out)
 
 
-def switch_table(switch_data, out="-"):
+def switch_table(switch_data, heuristic_lookups, out="-"):
     """Print a table for each switch.
 
     Args:
@@ -518,7 +518,8 @@ def switch_table(switch_data, out="-"):
             switch_data[i][0] -> Dictionary with switch platform_name, hostname and IP address
             switch_data[i][1] -> Dictionary with LLDP information
             switch_data[i][2] -> ARP dictionary
+        heuristic_lookups: Table of educated guesses about normal configurations
         out: Defaults to stdout, but will print to the file name passed in
     """
     for i in range(len(switch_data)):
-        print_lldp(switch_data[i][0], switch_data[i][1], switch_data[i][2], out)
+        print_lldp(switch_data[i][0], switch_data[i][1], switch_data[i][2], heuristic_lookups, out)

--- a/canu/report/switch/cabling/cabling.py
+++ b/canu/report/switch/cabling/cabling.py
@@ -263,7 +263,6 @@ def get_lldp(ip, credentials, return_error=False):
         log.debug("Adding ARP metadata to switch LLDP data")
         for _, port in switch_dict.items():
             for index, _ in enumerate(port):
-                arp_list = []
                 arp_list = [
                     f"{arp[mac]['ip_address']}:{list(arp[mac]['port'])[0]}"
                     for mac in arp

--- a/canu/report/switch/cabling/cabling.py
+++ b/canu/report/switch/cabling/cabling.py
@@ -521,7 +521,7 @@ def get_lldp_dell(ip, credentials, return_error):
 
             neighbors_dict[port]["port_id_subtype"] = "if_name"
             interface = neighbors_dict[port]["local_port_id"]
-
+            neighbors_dict[port]["data_sources"] = "LLDP"
             lldp_dict[interface].append(neighbors_dict[port])
 
         # Get the mac-address-table to help fill in port data if not reported over LLDP
@@ -752,6 +752,7 @@ def get_lldp_mellanox(ip, credentials, return_error):
             if "chassis_name" not in port_info.keys():
                 port_info["chassis_name"] = ""
             port_info["port_id_subtype"] = "if_name"
+            port_info["data_sources"] = "LLDP"
             interface = port_info["local_port_id"]
             lldp_dict[interface].append(port_info)
 

--- a/canu/utils/heuristics.py
+++ b/canu/utils/heuristics.py
@@ -1,0 +1,68 @@
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""heuristic_loookups: Table of educated guesses about normal configurations."""
+
+# TODO add more Dell, Mellanox, Gigabyte and Intel heuristics
+heuristic_lookup = {
+    "14:02:ec": {
+        "sw-spine-0": {
+            "hint": "OCP Port",
+            "port": "ocp:[12]",
+        },
+        "leaf-0": {
+            "hint": "OCP Port",
+            "port": "ocp:[12]",
+        },
+    },
+    "94:40:c9": {
+        "sw-spine-0": {
+            "hint": "PCIe Port",
+            "port": "pcie:[12]",
+        },
+        "leaf-0": {
+            "hint": "PCIe Port",
+            "port": "pcie:[12]",
+        },
+        "leaf-bmc-0": {
+            "hint": "iLO Port",
+            "port": "bmc:1",
+        },
+    },
+    "ec:eb:b8": {
+        "leaf-bmc-0": {
+            "hint": "PDU",
+            "port": "bmc:1",
+        },
+    },
+    "b4:2e:99": {
+        "leaf-bmc-0": {
+            "hint": "River Compute",
+            "port": "onboard:1",
+        },
+    },
+    "00:40:a6": {
+        "leaf-bmc-0": {
+            "hint": "Slingshot Switch",
+            "port": "mgmt:1",
+        },
+    },
+}

--- a/tests/test_report_network_cabling.py
+++ b/tests/test_report_network_cabling.py
@@ -99,7 +99,7 @@ def test_network_cabling(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "1/1/1   ==> sw-test02      1/1/1" in str(result.output)
+        assert "1/1/1      ==> sw-test02       1/1/1" in str(result.output)
         remove_switch_from_cache(ip)
 
 
@@ -156,7 +156,7 @@ def test_network_cabling_file(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "1/1/1   ==> sw-test02      1/1/1" in str(result.output)
+        assert "1/1/1      ==> sw-test02       1/1/1" in str(result.output)
         remove_switch_from_cache(ip)
 
 
@@ -242,7 +242,7 @@ def test_network_cabling_file_bidirectional(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "1/1/1   ==> sw-test02      1/1/1" in str(result.output)
+        assert "1/1/1      ==> sw-test02       1/1/1" in str(result.output)
         remove_switch_from_cache(ip)
 
 
@@ -647,10 +647,13 @@ def test_network_cabling_dell(netmiko_commands, switch_vendor):
                 password,
             ],
         )
+        print(result.output)
         assert result.exit_code == 0
         assert (
-            "1/1/1   ==> sw-test01      1/1/15             sw-test01                                             Test Switch 1\n"
-            "1/1/2   ==> sw-test02      1/1/15             sw-test02                                             Test Switch 2\n"
+            "1/1/1      ==> sw-test01       1/1/15             00:40:a6:00:44:55  sw-test01"
+        ) in str(result.output)
+        assert (
+            "1/1/2      ==> sw-test02       1/1/15             00:40:a6:00:00:00  sw-test02"
         ) in str(result.output)
         remove_switch_from_cache(ip_dell)
 
@@ -783,8 +786,10 @@ def test_network_cabling_mellanox(switch_vendor):
         )
         assert result.exit_code == 0
         assert (
-            "1/1/1   ==> sw-test03      1/1/11             sw-test03                                             Test Switch 3\n"
-            "1/1/2   ==> sw-test04      1/1/12             sw-test04                                             Test Switch 4\n"
+            "1/1/1      ==> sw-test03       1/1/11             00:40:a6:00:44:55  sw-test03"
+        ) in str(result.output)
+        assert (
+            "1/1/2      ==> sw-test04       1/1/12             00:40:a6:00:00:33  sw-test04"
         ) in str(result.output)
         remove_switch_from_cache(ip_mellanox)
 

--- a/tests/test_report_switch_cabling.py
+++ b/tests/test_report_switch_cabling.py
@@ -203,7 +203,7 @@ def test_switch_cabling(netmiko_command, switch_vendor):
             ],
         )
         assert result.exit_code == 0
-        assert "1/1/1   ==> sw-test01      1/1/1" in str(result.output)
+        assert "1/1/1      ==> sw-test01       1/1/1" in str(result.output)
         remove_switch_from_cache(ip)
 
 
@@ -352,14 +352,9 @@ def test_switch_cabling_dell(netmiko_commands, switch_vendor):
         assert (
             "Switch: sw-test-dell (192.168.1.2)                       \n"
             + "Dell S3048-ON\n"
-            + "---------------------------------------------------------------------------------------------------------------"
-            + "---------------------------------------\n"
-            + "PORT        NEIGHBOR       NEIGHBOR PORT      PORT DESCRIPTION                                      DESCRIPTION\n"
-            + "---------------------------------------------------------------------------------------------------------------"
-            + "---------------------------------------\n"
-            + "1/1/1   ==> sw-test01      1/1/15             sw-test01                                             Test Switch 1\n"
-            + "1/1/2   ==> sw-test02      1/1/15             sw-test02                                             Test Switch 2\n"
         ) in str(result.output)
+        assert ("1/1/1      ==> sw-test01       1/1/15") in str(result.output)
+        assert ("1/1/2      ==> sw-test02       1/1/15") in str(result.output)
         remove_switch_from_cache(ip)
 
 
@@ -488,11 +483,12 @@ def test_switch_cabling_mellanox(switch_vendor):
                 password,
             ],
         )
+        print(result.output)
+
         assert result.exit_code == 0
-        assert (
-            "1/1/1   ==> sw-test03      1/1/11             sw-test03                                             Test Switch 3\n"
-            + "1/1/2   ==> sw-test04      1/1/12             sw-test04                                             Test Switch 4\n"
-        ) in str(result.output)
+        assert ("1/1/1      ==> sw-test03       1/1/11") in str(result.output)
+        assert ("1/1/2      ==> sw-test04       1/1/12") in str(result.output)
+
         remove_switch_from_cache(ip_mellanox)
 
 


### PR DESCRIPTION
### Summary and Scope

Description:

Originally the `canu report switch cabling` and `canu report network cabling` commands used LLDP, ARP and MAC address table data from switches, with LLDP data being canonical.  This posed a problem when a device did not run LLDP or LLDP data didn't return anything particularly useful.

This change allows the addition of system metadata and "heuristics" of typical device use to annotate the LLDP data.  The following lookup data can be used and is listed in priority order:

- If Kea lease data is available it is used to match an LLDP MAC with a system hostname, then
- If SLS data is available it is used to match ARP IP data with a system hostname, then
- If SMD data is available it is used to match LLDP MAC addresses with a system hostname, then
- Heuristic lookups of the MAC are used to annotate the LLDP and ARP data with hostnames, slots, ports and lags that are valid for Plan of Record systems and devices.  Heuristics are a Pareto's rule.

None of the new lookup tables or flags are required, but are used in the above order if applied.

The new command line often looks like:

```
 canu report network cabling --ips 10.103.11.2,10.103.11.3,10.103.11.4 --kea-lease-file kea.json --sls-file sls.json --smd-file smd.json --heuristic-lookups
```

To obtain the Kea lease JSON file after obtaining a token:
```
curl -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" -d '{ "command": "lease4-get-all",  "service": [ "dhcp4" ] }' https://api_gw_service.local/apis/dhcp-kea | jq -S . > kea.json
```

To obtain the SLS JSON file:
```
cray sls dumpstate list --format json | jq -S . > sls.json
```

To obtain the SMD JSON file:
```
cray hsm inventory ethernetInterfaces list --format json | jq -S . > smd.json
```


Original report:
```
$ canu report switch cabling --ip 10.103.11.2 
Password: 
Switch: sw-spine-001 (10.103.11.2)                       
Aruba 8325
------------------------------------------------------------------------------------------------------------------------------------------------------
PORT        NEIGHBOR       NEIGHBOR PORT      PORT DESCRIPTION                                      DESCRIPTION
------------------------------------------------------------------------------------------------------------------------------------------------------
1/1/1   ==>                14:02:ec:da:b9:98  No LLDP data, check ARP vlan info.                    Hewlett Packard Enterprise10.252.1.12:vlan2, 10.254.1.20:vlan4
1/1/3   ==>                14:02:ec:da:b8:18  No LLDP data, check ARP vlan info.                    Hewlett Packard Enterprise10.252.1.11:vlan2, 10.254.1.18:vlan4
1/1/5   ==>                14:02:ec:d9:79:e8  No LLDP data, check ARP vlan info.                    Hewlett Packard Enterprise10.252.1.10:vlan2
1/1/7   ==> ncn-w001       14:02:ec:d9:7c:40  bond0                                                 Linux ncn-w001 5.3.18-150300.59.87-default #1 SMP Thu 
1/1/8   ==> ncn-w002       14:02:ec:d9:76:b8  bond0                                                 Linux ncn-w002 5.3.18-150300.59.87-default #1 SMP Thu 
1/1/10  ==>                14:02:ec:d9:7c:9b                                                        Hewlett Packard Enterprise
1/1/11  ==>                14:02:ec:d9:7c:88  No LLDP data, check ARP vlan info.                    Hewlett Packard Enterprise10.252.1.3:vlan2, 10.252.1.6:vlan2, 10.254.1.8:vlan4
1/1/12  ==>                14:02:ec:d9:7b:db                                                        Hewlett Packard Enterprise
1/1/13  ==>                14:02:ec:d9:7b:c8  No LLDP data, check ARP vlan info.                    Hewlett Packard Enterprise10.252.1.5:vlan2, 10.254.1.6:vlan4
1/1/14  ==>                14:02:ec:d9:76:9b                                                        Hewlett Packard Enterprise
1/1/15  ==>                14:02:ec:d9:76:9a                                                        Hewlett Packard Enterprise
1/1/19  ==>                14:02:ec:e1:bd:ba                                                        Hewlett Packard Enterprise
1/1/47  ==> sw-spine-002   1/1/47             VSX keepalive                                         Aruba JL635A  GL.10.09.0010
1/1/48  ==> sw-leaf-bmc-0011/1/49             sw-spine-001:48<==sw-leaf-bmc-001                     Aruba JL663A  FL.10.11.1005
1/1/51  ==> sw-spine-002   1/1/51             vsx isl                                               Aruba JL635A  GL.10.09.0010
1/1/52  ==> sw-spine-002   1/1/52             vsx isl                                               Aruba JL635A  GL.10.09.0010
1/1/55  ==> sw-edge-002    Ethernet1/1                                                              Arista Networks EOS version 4.23.0F running on an Aris
1/1/56  ==> sw-edge-001    Ethernet1/1                                                              Arista Networks EOS version 4.23.0F running on an Aris
```

New report with metadata from Kea, SMD, SLS and general general heuristic hints:

```
canu report network cabling --ips 10.103.11.2,10.103.11.3,10.103.11.4 --kea-lease-file kea.json --sls-file tsls.json --smd-file smd.json --heuristic-lookups

Switch: sw-spine-001 (10.103.11.2)                       
Aruba 8325
------------------------------------------------------------------------------------------------------------------------------------------------------
PORT        NEIGHBOR       NEIGHBOR PORT      PORT DESCRIPTION                                      DESCRIPTION
------------------------------------------------------------------------------------------------------------------------------------------------------
1/1/1   ==> ncn-m001       14:02:ec:da:b9:98  Kea data: Hostname from MAC                           Hewlett Packard Enterprise
1/1/3   ==> ncn-m002       14:02:ec:da:b8:18  Kea data: Hostname from MAC                           Hewlett Packard Enterprise
1/1/5   ==> ncn-m003       14:02:ec:d9:79:e8  Kea data: Hostname from MAC                           Hewlett Packard Enterprise
1/1/7   ==> ncn-w001       14:02:ec:d9:7c:40  bond0                                                 Linux ncn-w001 5.3.18-150300.59.87-default #1 SMP Thu 
1/1/8   ==> ncn-w002       14:02:ec:d9:76:b8  bond0                                                 Linux ncn-w002 5.3.18-150300.59.87-default #1 SMP Thu 
1/1/10  ==>                14:02:ec:d9:7c:9b  Heuristic data: Often a OCP card port                 Hewlett Packard Enterprise
1/1/11  ==> ncn-s001       14:02:ec:d9:7c:88  Kea data: Hostname from MAC                           Hewlett Packard Enterprise
1/1/12  ==>                14:02:ec:d9:7b:db  Heuristic data: Often a OCP card port                 Hewlett Packard Enterprise
1/1/13  ==> ncn-s002       14:02:ec:d9:7b:c8  Kea data: Hostname from MAC                           Hewlett Packard Enterprise
1/1/14  ==>                14:02:ec:d9:76:9b  Heuristic data: Often a OCP card port                 Hewlett Packard Enterprise
1/1/15  ==>                14:02:ec:d9:76:9a  Heuristic data: Often a OCP card port                 Hewlett Packard Enterprise
1/1/19  ==>                14:02:ec:e1:bd:ba  Heuristic data: Often a OCP card port                 Hewlett Packard Enterprise
1/1/47  ==> sw-spine-002   1/1/47             VSX keepalive                                         Aruba JL635A  GL.10.09.0010
1/1/48  ==> sw-leaf-bmc-0011/1/49             sw-spine-001:48<==sw-leaf-bmc-001                     Aruba JL663A  FL.10.11.1005
1/1/51  ==> sw-spine-002   1/1/51             vsx isl                                               Aruba JL635A  GL.10.09.0010
1/1/52  ==> sw-spine-002   1/1/52             vsx isl                                               Aruba JL635A  GL.10.09.0010
1/1/55  ==> sw-edge-002    Ethernet1/1                                                              Arista Networks EOS version 4.23.0F running on an Aris
1/1/56  ==> sw-edge-001    Ethernet1/1                                                              Arista Networks EOS version 4.23.0F running on an Aris
```

Additional changes:
- Added logging to `canu report switch cabling`

PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`

### Issues and Related PRs

* Resolves: `Issue`
* Relates to: `Issue`
* Requires: `Issue`

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
