### PR TITLE
Optimize Jenkins and Fix `--build-arg` in `Dockerfile`

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# hadoint is a Dockerfile linter written in Haskell
+# that helps you build best practice Docker images.
+# More details at https://github.com/hadolint/hadolint
+name: Hadolint
+
+on:
+  push:
+    branches: [ "main", release/* ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Run hadolint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ./Dockerfile
+          format: sarif
+          output-file: hadolint-results.sarif
+          no-fail: true # Always allow uploading to GitHub, allow retroactive fixing.
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: hadolint-results.sarif
+          wait-for-processing: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ FROM        dev AS build
 USER        root
 WORKDIR     /root
 RUN         source $VIRTUAL_ENV/bin/activate
-RUN         python -m pip install --no-cache --disable-pip-version-check . pyinstaller
+RUN         python -m pip install --no-cache-dir --disable-pip-version-check . pyinstaller
 RUN         cp -pv pyinstaller.py pyinstaller.spec
 RUN         pyinstaller --clean -y --dist ./dist/linux --workpath /tmp pyinstaller.spec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY        mkdocs.yml ./mkdocs.yml
 COPY        noxfile.py ./noxfile.py
 COPY        pyinstaller.py ./pyinstaller.py
 COPY        pyproject.toml ./pyproject.toml
-RUN         python -m pip install --editable .[ci,docs]
+RUN         python -m pip install --no-cache-dir --disable-pip-version-check --editable .[ci,docs]
 RUN         nox -e docs
 
 # STAGE 3 - documentation image
@@ -105,7 +105,7 @@ FROM        dev AS build
 USER        root
 WORKDIR     /root
 RUN         source $VIRTUAL_ENV/bin/activate
-RUN         python -m pip install . pyinstaller
+RUN         python -m pip install --no-cache --disable-pip-version-check . pyinstaller
 RUN         cp -pv pyinstaller.py pyinstaller.spec
 RUN         pyinstaller --clean -y --dist ./dist/linux --workpath /tmp pyinstaller.spec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 # STAGE 1 - install build dependencies and activate virtualenv
-ARG         ALPINE_IMAGE
+ARG         ALPINE_IMAGE="artifactory.algol60.net/docker.io/library/alpine:3.17"
 FROM        ${ALPINE_IMAGE} AS deps
-ARG         PYTHON_VERSION
+ARG         PYTHON_VERSION='3.10'
 USER        root
 WORKDIR     /root
 VOLUME      [ "/root/mounted" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 # STAGE 1 - install build dependencies and activate virtualenv
-ARG         ALPINE_IMAGE=artifactory.algol60.net/docker.io/library/alpine:3.17
+ARG         ALPINE_IMAGE
 FROM        ${ALPINE_IMAGE} AS deps
+ARG         PYTHON_VERSION
 USER        root
 WORKDIR     /root
 VOLUME      [ "/root/mounted" ]
@@ -36,8 +37,8 @@ RUN         apk add --no-cache \
               openssl~=3.0 \
               py3-pip~=22.3 \
               py3-virtualenv~=20.16 \
-              python3~=3.10 \
-              python3-dev~=3.10
+              python3~=${PYTHON_VERSION} \
+              python3-dev~=${PYTHON_VERSION}
 ENV         VIRTUAL_ENV=/opt/venv
 RUN         python -m venv $VIRTUAL_ENV
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -81,8 +82,8 @@ ENV         VIRTUAL_ENV=/opt/venv
 RUN         apk add --no-cache \
               py3-pip=22.3.1-r1 \
               py3-virtualenv=20.16.7-r0 \
-              python3=3.10.10-r0 \
-              python3-dev=3.10.10-r0
+              python3~=${PYTHON_VERSION} \
+              python3-dev~=${PYTHON_VERSION}
 COPY        --from=dev --chown=root:root $VIRTUAL_ENV $VIRTUAL_ENV
 RUN         addgroup -S canu && \
               adduser \
@@ -97,7 +98,7 @@ COPY        --from=dev --chown=canu:canu /root/docs /home/canu/docs
 COPY        --from=dev --chown=canu:canu /root/mkdocs.yml /home/canu/mkdocs.yml
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN         source $VIRTUAL_ENV/bin/activate
-EXPOSE      8000       
+EXPOSE      8000
 CMD         [ "mkdocs", "serve", "-a", "0.0.0.0:8000", "--config-file", "mkdocs.yml"]
 
 # STAGE 4 - build the binaries with pyinstaller

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN         apk add --no-cache \
               openssl~=3.0 \
               py3-pip~=22.3 \
               py3-virtualenv~=20.16 \
+              py3-wheel~=0.38 \
               python3~=${PYTHON_VERSION} \
               python3-dev~=${PYTHON_VERSION}
 ENV         VIRTUAL_ENV=/opt/venv
@@ -82,6 +83,7 @@ ENV         VIRTUAL_ENV=/opt/venv
 RUN         apk add --no-cache \
               py3-pip=22.3.1-r1 \
               py3-virtualenv=20.16.7-r0 \
+              py3-wheel~=0.38 \
               python3~=${PYTHON_VERSION} \
               python3-dev~=${PYTHON_VERSION}
 COPY        --from=dev --chown=root:root $VIRTUAL_ENV $VIRTUAL_ENV

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -38,6 +38,7 @@ if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
 // The ==~ operator performs an exact match.
 def stableToken = ~/v?\d+\.\d+\.\d+/
 def isStable = (env.TAG_NAME != null & env.TAG_NAME ==~ stableToken) ? true : false
+def version
 pipeline {
     agent {
         label "metal-gcp-builder"
@@ -56,7 +57,16 @@ pipeline {
 
     stages {
 
-        stage('Image: Build & Publish') {
+        stage('Prepare') {
+            steps {
+                script {
+                    sh "python3 -m pip install setuptools_scm[toml]"
+                    version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
+                }
+            }
+        }
+
+        stage('Container Image') {
 
             agent {
                 node {
@@ -64,54 +74,37 @@ pipeline {
                 }
             }
 
+            environment {
+                VERSION = "${version}"
+            }
+
             stages {
-
-                stage('Build dev image') {
-                  steps {
-                      script {
-                          sh "python3 -m pip install setuptools_scm[toml]"
-                          version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
-                          sh "make dev_image"
-                      }
-                  }
+                stage('Build') {
+                    parallel {
+                        stage('Develop image') {
+                            steps {
+                                sh "make dev_image"
+                            }
+                        }
+                        stage('Production image') {
+                            steps {
+                                sh "make prod_image"
+                            }
+                        }
+                    }
                 }
-
-                stage('Publish dev image') {
-                  steps {
-                      script {
-                          // Use setuptools_scm to resolve the version(s) to use for the build.
-                          sh "python3 -m pip install setuptools_scm[toml]"
-                          version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
-                          publishCsmDockerImage(image: "${env.NAME}", tag: "${version}-dev", isStable: isStable)
-                      }
-                  }
+                stage('Publish') {
+                    steps {
+                        script {
+                            // Use setuptools_scm to resolve the version(s) to use for the build.
+                            publishCsmDockerImage(image: "${env.NAME}", tag: "${version}-dev", isStable: isStable)
+                            publishCsmDockerImage(image: "${env.NAME}", tag: "${version}", isStable: isStable)
+                        }
+                    }
                 }
-
-                stage('Build prod image') {
-                  steps {
-                      script {
-                          sh "python3 -m pip install setuptools_scm[toml]"
-                          version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
-                          sh "make prod_image"
-                      }
-                  }
-                }
-
-                stage('Publish prod image') {
-                  steps {
-                      script {
-                          // Use setuptools_scm to resolve the version(s) to use for the build.
-                          sh "python3 -m pip install setuptools_scm[toml]"
-                          version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
-                          publishCsmDockerImage(image: "${env.NAME}", tag: "${version}", isStable: isStable)
-                      }
-                  }
-                }
-
             }
         }
-
-        stage('RPM: Build & Publish') {
+        stage('RPM') {
 
             matrix {
 
@@ -138,7 +131,7 @@ pipeline {
 
                 stages {
 
-                    stage('Prepare: RPMs') {
+                    stage('Prepare') {
 
                         agent {
                             docker {
@@ -149,10 +142,6 @@ pipeline {
                         }
                         steps {
                             script {
-                                // Use setuptools_scm to resolve the version(s) to use for the build.
-                                sh "python3 -m pip install setuptools_scm[toml]"
-                                version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
-
                                 // Inject distro-specific metadata (e.g. which distro and service pack).
                                 runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                                 sh "make prepare"
@@ -161,7 +150,7 @@ pipeline {
                         }
                     }
 
-                    stage('Build: RPMs') {
+                    stage('Build') {
 
                         environment {
                             VERSION = "${version}"
@@ -169,7 +158,8 @@ pipeline {
 
                         agent {
                             docker {
-                                args '-u root' // Build Python RPMs as root for Python rpm macros to build with the right sitelib.
+                                args '-u root'
+                                // Build Python RPMs as root for Python rpm macros to build with the right sitelib.
                                 label "metal-gcp-builder"
                                 reuseNode true
                                 image "${pythonImage}:${PYTHON_VERSION}"
@@ -179,14 +169,12 @@ pipeline {
                         steps {
                             script {
                                 // Use setuptools_scm to resolve the version(s) to use for the build.
-                                sh "python3 -m pip install setuptools_scm[toml]"
-                                version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
                                 sh "make rpm"
                             }
                         }
                     }
 
-                    stage('Publish: RPMs') {
+                    stage('Publish') {
 
                         agent {
                             docker {

--- a/Makefile
+++ b/Makefile
@@ -83,19 +83,19 @@ image: prod_image
 	docker tag '${NAME}:${VERSION}' '${NAME}:${VERSION}-p${PYTHON_VERSION}'
 
 deps_image:
-	docker build --progress plain --no-cache --pull --build-arg PYTHON_VERSION='${PYTHON_VERSION}' --build-arg ALPINE_IMAGE='${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-deps' -f Dockerfile --target deps .
+	docker build --progress plain --no-cache --pull --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-deps' -f Dockerfile --target deps .
 
 dev_image:
-	docker build --progress plain --no-cache --pull --build-arg PYTHON_VERSION='${PYTHON_VERSION}' --build-arg ALPINE_IMAGE='${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-dev' -f Dockerfile --target dev .
+	docker build --progress plain --no-cache --pull --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-dev' -f Dockerfile --target dev .
 
 docs_image:
-	docker build --progress plain --no-cache --pull --build-arg PYTHON_VERSION='${PYTHON_VERSION}' --build-arg ALPINE_IMAGE='${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-docs' -f Dockerfile --target docs .
+	docker build --progress plain --no-cache --pull --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-docs' -f Dockerfile --target docs .
 
 build_image:
-	docker build --progress plain --no-cache --pull --build-arg PYTHON_VERSION='${PYTHON_VERSION}' --build-arg ALPINE_IMAGE='${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-build' -f Dockerfile --target build .
+	docker build --progress plain --no-cache --pull --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}-build' -f Dockerfile --target build .
 
 prod_image:
-	docker build --progress plain --no-cache --pull --build-arg PYTHON_VERSION='${PYTHON_VERSION}' --build-arg ALPINE_IMAGE='${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}' -f Dockerfile --target prod .
+	docker build --progress plain --no-cache --pull --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --tag '${NAME}:${VERSION}' -f Dockerfile --target prod .
 
 dev:
 	./canuctl -d


### PR DESCRIPTION
### Summary and Scope

Description:

<!-- What does this change do? Use examples of new options and output changes when possible. If other changes were made list these as well in a list. --->

This does a few things:
- Speeds up the Jenkins build, building the two Docker images in parallel before publishing them at the same time.
  ![image](https://user-images.githubusercontent.com/7772179/223948349-a9bcbf56-0341-4c2a-a647-2d6c371b1772.png)
- Leveraged `PYTHON_VERSION` `ARG` in the `Dockerfile`, replacing occurances of `3.10` with `${PYTHON_VERSION}`
- `--build-arg` was not actually passing a value for `PYTHON_VERSION` and `ALPINE_IMAGE`, each `--build-arg` needed to be surrounded in single quotes
- Removed redundant definition of the alpine image in the `FROM`, now it is supplied by the fixed `--build-arg`
- Added Hadolint, a `Dockerfile` scanner that provides optimization and lint suggestions that will show up here: https://github.com/Cray-HPE/canu/security/code-scanning?query=
- Added `py3-wheel` to the `Dockerfile` to suppress warnings from `pip` when dependencies that lack a `setup.py` or `pyproject.toml` are installed
- Fixes some trailing whitespace

PR checklist (you may replace this section):

- [ ] I have run `nox` locally and all tests, linting, and code coverage pass
- [ ] I have added new tests to cover the new code
- [ ] My code follows the style guidelines of this project
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have updated the appropriate Changelog entries in `README.md`

### Issues and Related PRs

* Relates to: #152 

### Testing

Tested on:

<!-- List of virtual or physical systems used. --->
