### PR TITLE
Relates to 288 - Fix return code

### DIFF
--- a/.github/actions/prepare-artifacts/action.yml
+++ b/.github/actions/prepare-artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
 
           # Wait for our RPM(s) to finish building.
           echo Looking for "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}"
-          while ! jf rt s "${REPOSITORY}/${ORG}/${STREAM}/" --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src" 2>&1; do
+          while ! jf rt s --fail-no-op=true "${REPOSITORY}/${ORG}/${STREAM}/" --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src" 2>&1; do
            echo "Waiting for artifacts to be available; retrying in ${WAIT} seconds ... " >&2
            sleep ${WAIT}
           done


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
This fixes the promotion workflow logic for waiting on artifacts.

The `jf` command does not return a non-zero return code if no artifacts are found, unless `--fail-no-op=true` is set. Since this argument was missing, the wait condition fails.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
