### PR TITLE
288 Fix race condition

### DIFF
--- a/.github/actions/prepare-artifacts/action.yml
+++ b/.github/actions/prepare-artifacts/action.yml
@@ -12,16 +12,19 @@ runs:
           REPOSITORY: csm-rpms
           ORG: hpe
           STREAM: ${{ inputs.STREAM }}
-          WAIT: 10
+          WAIT: 30
       run: |
           sudo apt-get install -y rename
 
-          # Wait for our RPM(s) to finish building.
+          # Wait for our RPM(s) to finish building and publishing.
           echo Looking for "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}"
-          while ! jf rt s --fail-no-op=true "${REPOSITORY}/${ORG}/${STREAM}/" --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src" 2>&1; do
+          while ! jf rt s --fail-no-op=true "${REPOSITORY}/${ORG}/${STREAM}/" --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/}" --exclude-props "rpm.metadata.arch=src"; do
            echo "Waiting for artifacts to be available; retrying in ${WAIT} seconds ... " >&2
            sleep ${WAIT}
           done
+
+          # Give parallel builds a chance incase they published at slightly different times.
+          sleep ${WAIT}
 
           # Make a workspace
           DIR_DOWNLOAD=$(mktemp -d)
@@ -50,6 +53,15 @@ runs:
 
           # Cleanup ... prepare to work on src RPMs.
           rm -rf ${DIR_DOWNLOAD}/${ORG}/${STREAM}/
+
+          # Wait for our source RPMs to finish publishing.
+          while ! jf rt s --fail-no-op=true "${REPOSITORY}/${ORG}/${STREAM}/" --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/};rpm.metadata.arch=src"; do
+           echo "Waiting for artifacts to be available; retrying in ${WAIT} seconds ... " >&2
+           sleep ${WAIT}
+          done
+
+          # Give parallel builds a chance incase they published at slightly different times.
+          sleep ${WAIT}
 
           # Rename src RPMs
           jf rt download "${REPOSITORY}/${ORG}/${STREAM}/" ${DIR_DOWNLOAD}/ --props "rpm.metadata.version=${{ github.ref_name }};rpm.metadata.name=${GITHUB_REPOSITORY#*/};rpm.metadata.arch=src";

--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
+          allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
           generateReleaseNotes: true
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: true

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
+          allowUpdates: true # if the job is re-ran to catch missed artifacts, allow updates
           generateReleaseNotes: true
           artifacts: ${{ env.DIR_UPLOAD }}/*
           prerelease: false


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
There's a race condition when moving onto the `src` RPMs, in some cases the `src` and non-`src` RPMs publish ahead of one another and/or a few seconds apart. The workflow will try fetching `src.rpm`s before they're published. Add another wait before the `src` RPM move.

Also add another wait before downloading anything incase parallel builds are at play, they likely are finishing within seconds of each other.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
