### PR TITLE
Canuctl rebuild

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Changelog
 
+## [UNRELEASED]
+
+- 
+
 ## [1.7.0]
 
+- adjusted canuctl script to work with ALPINE_IMAGE/ALPINE_VERSION vars in the Dockerfile
 - By default, do not auth to artifactory for image when using `canuctl`
 - Add canu docs in three formats
 - Remove drawing code and dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,14 +147,15 @@ RUN         addgroup -S canu && \
 USER        canu
 WORKDIR     /home/canu
 RUN         mkdir -p /home/canu/mounted
-ENV         CANU_NET="HMN" \
-            KUBECONFIG="/etc/kubernetes/admin.conf" \
+ENV         CANU_NET=HMN \
+            KUBECONFIG=/etc/kubernetes/admin.conf \
+            PATH=$VIRTUAL_ENV/bin:$PATH \
             PS1="canu \w$ " \
             REQUESTS_CA_BUNDLE="" \
-            SLS_API_GW="api-gw-service.local" \
+            SLS_API_GW=api-gw-service.local \
             SLS_FILE="" \
             SLS_TOKEN="" \
             SSH_AUTH_SOCK=/ssh-agent \
-            SWITCH_USERNAME="admin" \
+            SWITCH_USERNAME=admin \
             SWITCH_PASSWORD=""
 CMD         [ "sh" ]

--- a/canuctl
+++ b/canuctl
@@ -33,7 +33,8 @@ trap 'die ${LINENO} "$BASH_COMMAND"' ERR
 CANU_IMAGE="artifactory.algol60.net/csm-docker/stable/canu"
 CANU_TAG="latest"
 # Use the publicly available alpine image so users do not need to log in
-ALPINE_IMAGE="alpine:3.17"
+ALPINE_IMAGE="alpine"
+ALPINE_VERSION="3.17"
 PYTHON_VERSION="3.10"
 
 # die prints the line number and command that failed
@@ -170,6 +171,7 @@ main() {
     if "${PLATFORM}" build \
       --build-arg ALPINE_IMAGE="${ALPINE_IMAGE}" \
       --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+      --build-arg ALPINE_VERSION="${ALPINE_VERSION}" \
       --tag "${CONTAINER_NAME}:${CANU_TAG}" \
       -f Dockerfile \
       --target "${TARGET}" .; then

--- a/canuctl
+++ b/canuctl
@@ -92,9 +92,17 @@ set_mount_options() {
 run_container() {
   # if the ssh socket is not set, then   do not mount it into the container
   if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
-    cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${K8S_DIR}:${K8S_MOUNT_DIR}:${MOUNTOPTS_KUBE} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    if [[ -d "${K8S_DIR}" ]]; then
+      cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${K8S_DIR}:${K8S_MOUNT_DIR}:${MOUNTOPTS_KUBE} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    else 
+      cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    fi
   else
-    cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${K8S_DIR}:${K8S_MOUNT_DIR}:${MOUNTOPTS_KUBE} -v ${SSH_AUTH_SOCK}:/ssh-agent:${MOUNTOPTS_SSH} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    if [[ -d "${K8S_DIR}" ]]; then
+      cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${K8S_DIR}:${K8S_MOUNT_DIR}:${MOUNTOPTS_KUBE} -v ${SSH_AUTH_SOCK}:/ssh-agent:${MOUNTOPTS_SSH} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    else
+      cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${SSH_AUTH_SOCK}:/ssh-agent:${MOUNTOPTS_SSH} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
+    fi
   fi
   
   $cmd


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->

- I neglected to adjust `canuctl` for the `ALPINE_IMAGE`/`ALPINE_VERSION` flow after yesterday's merges.  This allows the rebuilding of the image to work properly.
- only mounts `/etc/kubernetes` if it exists

- [x] I have added new tests to cover the new code
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Introduced by: #310 
* Overlooked in: #305 

### Testing

<!-- How was this change tested? --->

`canuctl -r -p` on `#surtur`