### PR TITLE
Stop building Py 3.9 RPMs and Docker Images

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -124,7 +124,7 @@ pipeline {
 
                     axis {
                         name 'PYTHON_VERSION'
-                        values '3.10', '3.9'
+                        values '3.10'
                     }
 
                 }


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
It is useful to have python 3.9 and 3.10 building in our GitHub actions, but as far as deliverables go our RPM installs a compiled binary and it doesn't need to ship different Python flavors.

Since our matrix of builds often has an Artifactory failure on one or the other, it would do us good to just build the RPM for _one_ Python flavor (thus reducing our matrix to one).

The matrix is staying, incase we do want to build for multiple Python versions again but also for enabling us to build canu for aarch64 if/when that time comes.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
