### PR TITLE
Optimize Jenkins, Build multi-arch Docker Image, and Tidy `Makefile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@ canu_cache.yaml
 files/*
 nornir.log
 pyinstaller.spec
+Jenkinsfile.github
+canu.spec
 
 # Build artifacts
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,16 @@ ARG         PYTHON_VERSION='3.10'
 # hadolint ignore=DL3002
 USER        root
 WORKDIR     /root
-ENV         PYTHON_VERSION=${PYTHON_VERSION}
 # To use the virtualenv, all that is needed are these two vars
 # The 'activate' command is not even necessary
 # Since ENVs can transfer beween layers, the virtualenv can always be in use
-ENV         VIRTUAL_ENV=/opt/venv
+ENV         PYTHON_VERSION=${PYTHON_VERSION} \
+            VIRTUAL_ENV=/opt/venv
+
+# Must be set by itself or it won't stick around when the container runs.
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN         apk add --no-cache \
+              bash~=5.2.15 \
               cmake~=3.24 \
               g++~=12.2 \
               gcc~=12.2 \
@@ -52,6 +55,25 @@ RUN         apk add --no-cache \
               python3~=${PYTHON_VERSION} \
               python3-dev~=${PYTHON_VERSION}
 
+COPY        .darglint ./.darglint
+COPY        .flake8 ./.flake8
+COPY        .git/ ./.git
+COPY        Dockerfile ./Dockerfile
+COPY        LICENSE ./LICENSE
+COPY        MANIFEST.in ./MANIFEST.in
+COPY        Makefile ./Makefile
+COPY        README.md ./README.md
+COPY        canu/ ./canu
+COPY        canuctl ./canuctl
+COPY        docs/ ./docs
+COPY        entry_points.ini ./entry_points.ini
+COPY        mkdocs.yml ./mkdocs.yml
+COPY        network_modeling/ ./network_modeling
+COPY        noxfile.py ./noxfile.py
+COPY        pyinstaller.py ./pyinstaller.py
+COPY        pyinstaller_hooks/ ./pyinstaller_hooks
+COPY        pyproject.toml ./pyproject.toml
+COPY        tests/ ./tests
 
 ##########################
 #
@@ -64,16 +86,20 @@ USER        root
 WORKDIR     /root
 # These two vars are all that is needed to use the virtualenv
 ENV         VIRTUAL_ENV=/opt/venv \
-            PATH="$VIRTUAL_ENV/bin:$PATH"
+            PYTHONDONTWRITEBYTECODE=1 \
+            PYTHONUNBUFFERED=1
+
+# Must be set by itself or it won't stick around when the container runs.
+ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # Create the virtualenv and install ansible
 RUN         python -m venv $VIRTUAL_ENV
 # hadolint ignore=DL3059
-RUN         PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 python -m pip install --no-cache-dir ansible~=7.3.0
+RUN         python -m pip install --no-cache-dir ansible~=7.3.0
 # hadolint ignore=DL3059
-RUN         PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 python -m pip install --no-cache-dir -r https://raw.githubusercontent.com/aruba/aoscx-ansible-collection/a2ee40a937d8d6da1740adca434cbb59b04011d0/requirements.txt
+RUN         python -m pip install --no-cache-dir -r https://raw.githubusercontent.com/aruba/aoscx-ansible-collection/a2ee40a937d8d6da1740adca434cbb59b04011d0/requirements.txt
 # hadolint ignore=DL3059
 RUN         ansible-galaxy collection install --no-cache --no-deps arubanetworks.aoscx
-
 
 ##########################
 #
@@ -87,51 +113,41 @@ WORKDIR     /root
 #           must mount ${SSH_AUTH_SOCK} to /ssh-agent to use host ssh
 RUN         mkdir -p /root/mounted
 ENV         VIRTUAL_ENV=/opt/venv \
-            SSH_AUTH_SOCK=/ssh-agent
+            SSH_AUTH_SOCK=/ssh-agent \
+            PYTHONDONTWRITEBYTECODE=1 \
+            PYTHONUNBUFFERED=1
+
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY        --from=ansible $VIRTUAL_ENV $VIRTUAL_ENV
 RUN         apk --no-cache add \
               openssh-client~=9.1
-COPY        .flake8 ./.flake8
-COPY        .git/ ./.git
-COPY        .darglint ./.darglint
-COPY        canu/ ./canu
-COPY        docs/ ./docs
-COPY        network_modeling/ ./network_modeling
-COPY        pyinstaller_hooks/ ./pyinstaller_hooks
-COPY        tests/ ./tests
-COPY        canu.spec ./canu.spec
-COPY        canuctl ./canuctl
-COPY        Dockerfile ./Dockerfile
-COPY        entry_points.ini ./entry_points.ini
-COPY        LICENSE ./LICENSE
-COPY        Makefile ./Makefile
-COPY        MANIFEST.in ./MANIFEST.in
-COPY        mkdocs.yml ./mkdocs.yml
-COPY        noxfile.py ./noxfile.py
-COPY        pyinstaller.py ./pyinstaller.py
-COPY        pyproject.toml ./pyproject.toml
-RUN         PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 python -m pip install --no-cache-dir --editable '.[ci,docs]'
+RUN         python -m pip install --no-cache-dir --editable '.[docs]'
 # hadolint ignore=DL3059
-RUN         nox -e docs
+RUN         sphinx-build -M markdown docs/templates docs/_build -a
 
 ##########################
 #
 # STAGE 3 - documentation image
 #
 ##########################
+ARG         ALPINE_IMAGE="artifactory.algol60.net/docker.io/library/alpine"
+ARG         ALPINE_VERSION="3.17"
 FROM        ${ALPINE_IMAGE}:${ALPINE_VERSION} AS docs
 ARG         PYTHON_VERSION='3.10'
 USER        root
 WORKDIR     /root
 ENV         VIRTUAL_ENV=/opt/venv
-ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Must be set by itself or it won't stick around when the container runs.
+ENV          PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # hadolint ignore=SC2086
 RUN         apk add --no-cache \
               py3-pip~=22.3 \
               py3-virtualenv~=20.16 \
               python3~=${PYTHON_VERSION} \
               python3-dev~=${PYTHON_VERSION}
+
 # The dev stage has the docs built and has mkdocs installed
 COPY        --from=dev --chown=root:root $VIRTUAL_ENV $VIRTUAL_ENV
 # Since this is an end-user image, it will run rootless
@@ -157,51 +173,54 @@ CMD         [ "mkdocs", "serve", "-a", "0.0.0.0:8000", "--config-file", "mkdocs.
 ##########################
 FROM        ansible AS prod_build
 USER        root
-ENV         VIRTUAL_ENV=/opt/venv
+ENV         VIRTUAL_ENV=/opt/venv \
+            PYTHONDONTWRITEBYTECODE=1 \
+            PYTHONUNBUFFERED=1
+
+# Must be set by itself or it won't stick around when the container runs.
 ENV         PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # Get the canu installation files
-COPY        --from=dev /root /root
+COPY        --from=ansible /root /root
 WORKDIR     /root
+
 # install canu in prod mode so the canu user can use it in the final image
-RUN         PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 pip install --no-cache-dir .
+RUN         pip install --no-cache-dir .
 
 ##########################
 #
 # STAGE 6 - final production image
 #
 ##########################
+ARG         ALPINE_IMAGE="artifactory.algol60.net/docker.io/library/alpine"
+ARG         ALPINE_VERSION="3.17"
 FROM        ${ALPINE_IMAGE}:${ALPINE_VERSION} AS prod
 ARG         PYTHON_VERSION='3.10'
 USER        root
 WORKDIR     /root
-ENV         VIRTUAL_ENV=/opt/venv
-ENV         PATH=$VIRTUAL_ENV/bin:$PATH
+
+#           must mount ${SSH_AUTH_SOCK} to /ssh-agent to use host ssh
 RUN         apk --no-cache add \
+              bash~=5.2.15 \
               py3-pip~=22.3 \
               py3-virtualenv~=20.16 \
               python3~=${PYTHON_VERSION} \
               python3-dev~=${PYTHON_VERSION} \
               openssh-client~=9.1
-#           must mount ${SSH_AUTH_SOCK} to /ssh-agent to use host ssh
-ENV         SSH_AUTH_SOCK=/ssh-agent
-RUN         addgroup -S canu && \
-              adduser \
+
+RUN         addgroup -S canu \
+            && adduser \
               -S canu \
               -G canu \
               -h /home/canu \
               -s /bin/bash \
               -D
+
 USER        canu
 WORKDIR     /home/canu
-# get the virtualenv with only ansible and collections installed
-# if it is installed from the dev stage, things are owned by root in editable mode and is not useable
-COPY        --from=prod_build --chown=canu:canu $VIRTUAL_ENV $VIRTUAL_ENV
-COPY        --from=ansible --chown=canu:canu /root/.ansible /home/canu/.ansible
-# hadolint ignore=DL3059
-RUN         echo PS1="'canu \w$ '" >> /home/canu/.profile
-# hadolint ignore=DL3059
-RUN         mkdir -p /home/canu/mounted
-ENV         CANU_NET=HMN \
+ENV         VIRTUAL_ENV=/opt/venv \
+            SSH_AUTH_SOCK=/ssh-agent \
+            CANU_NET=HMN \
             KUBECONFIG=/etc/kubernetes/admin.conf \
             PS1="canu \w$ " \
             REQUESTS_CA_BUNDLE="" \
@@ -211,4 +230,16 @@ ENV         CANU_NET=HMN \
             SSH_AUTH_SOCK=/ssh-agent \
             SWITCH_USERNAME=admin \
             SWITCH_PASSWORD=""
+
+# Must be set by itself or it won't stick around when the container runs.
+ENV         PATH=$VIRTUAL_ENV/bin:$PATH
+
+RUN         echo PS1="${PS1}" >> /home/canu/.profile \
+            && mkdir -p /home/canu/mounted
+
+# get the virtualenv with only ansible and collections installed
+# if it is installed from the dev stage, things are owned by root in editable mode and is not useable
+COPY        --from=prod_build --chown=canu:canu $VIRTUAL_ENV $VIRTUAL_ENV
+COPY        --from=ansible --chown=canu:canu /root/.ansible /home/canu/.ansible
+
 CMD         [ "sh", "-l" ]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -82,7 +82,14 @@ pipeline {
             }
 
             stages {
-                stage('Build') {
+                stage('Build: Base Image') {
+                    steps {
+                        // All targets require the ansible and deps target, so build those first so parallel builds
+                        // don't duplicate effort.
+                        sh "make image_ansible"
+                    }
+                }
+                stage('Build: Development and Production Images') {
                     parallel {
                         stage('Develop image') {
                             steps {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -66,6 +66,9 @@ pipeline {
                 script {
                     sh "python3 -m pip install setuptools_scm[toml]"
                     version = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
+
+                    // lock .git for writing - otherwise getting "content has changed" error while preparing tar.bz2 for RPM
+                    sh "chmod -R a-w .git"
                 }
             }
         }
@@ -102,84 +105,52 @@ pipeline {
                 }
             }
         }
+
         stage('RPM') {
-
             matrix {
-
                 agent {
-                    node {
-                        label "metal-gcp-builder"
-                        customWorkspace "${env.WORKSPACE}/${ARCH}/${PYTHON_VERSION}"
+                    docker {
+                        // args "-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /home/jenkins/.ssh:/root/.ssh -v /home/jenkins/.ssh:/home/jenkins/.ssh --group-add 999"
+                        reuseNode true
+                        image "${pythonImage}:${PYTHON_VERSION}"
+                        // image "artifactory.algol60.net/csm-docker/unstable/csm-docker-sle-python:3.10-5a3de28-20230323192859"
                     }
                 }
-
                 axes {
-
                     axis {
                         name 'ARCH'
                         values 'x86_64'
                     }
-
                     axis {
                         name 'PYTHON_VERSION'
-                        values '3.10'
+                        values '3.10', '3.9'
                     }
-
                 }
-
+                environment {
+                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/${PYTHON_VERSION}"
+                    VERSION = "${version}"
+                }
                 stages {
-
                     stage('Prepare') {
-
-                        agent {
-                            docker {
-                                reuseNode true
-                                image "${pythonImage}:${PYTHON_VERSION}"
-                            }
-                        }
-                        steps {
-                            script {
-                                // Inject distro-specific metadata (e.g. which distro and service pack).
-                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                                sh "make prepare"
-                                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-                            }
-                        }
-                    }
-
-                    stage('Build') {
-
-                        environment {
-                            VERSION = "${version}"
-                        }
-
-                        agent {
-                            docker {
-                                args '-u root'
-                                // Build Python RPMs as root for Python rpm macros to build with the right sitelib.
-                                reuseNode true
-                                image "${pythonImage}:${PYTHON_VERSION}"
-                            }
-                        }
-
                         steps {
                             script {
                                 // Use setuptools_scm to resolve the version(s) to use for the build.
-                                sh "make rpm"
+                                sh "python3 -m pip install setuptools setuptools_scm[toml]"
+                                sh "make prepare"
+                                // Inject distro-specific metadata (e.g. which distro and service pack).
+                                runLibraryScript("addRpmMetaData.sh", "${env.BUILD_DIR}/SPECS/${env.NAME}.spec")
                             }
                         }
                     }
-
-                    stage('Publish') {
-
-                        agent {
-                            docker {
-                                args '-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /home/jenkins/.ssh:/root/.ssh -v /home/jenkins/.ssh:/home/jenkins/.ssh --group-add 999'
-                                reuseNode true
-                                image "${pythonImage}:${PYTHON_VERSION}"
+                    stage('Build') {
+                        steps {
+                            script {
+                                // Use setuptools_scm to resolve the version(s) to use for the build.
+                                sh 'PATH=/home/jenkins/.local/bin:$PATH make rpm'
                             }
                         }
-
+                    }
+                    stage('Publish') {
                         steps {
                             script {
                                 def sleVersion = sh(returnStdout: true, script: 'awk -F= \'/VERSION_ID/{gsub(/["]/,""); print \$NF}\' /etc/os-release').trim()
@@ -191,14 +162,14 @@ pipeline {
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/${ARCH}/*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${PYTHON_VERSION}/RPMS/${ARCH}/*.rpm",
                                 )
                                 publishCsmRpms(
                                         arch: "src",
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${PYTHON_VERSION}/SRPMS/*.rpm",
                                 )
                             }
                         }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -123,12 +123,12 @@ pipeline {
                     }
                     axis {
                         name 'PYTHON_VERSION'
-                        values '3.10', '3.9'
+                        values '3.10'
                     }
                 }
                 environment {
                     BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/${PYTHON_VERSION}"
-                    VERSION = "${version}"
+                    VERSION = ""
                 }
                 stages {
                     stage('Prepare') {
@@ -136,6 +136,10 @@ pipeline {
                             script {
                                 // Use setuptools_scm to resolve the version(s) to use for the build.
                                 sh "python3 -m pip install setuptools setuptools_scm[toml]"
+
+                                // Set env.VERSION here incase just the RPM stage is being re-ran without the starting stages.
+                                env.VERSION = sh(returnStdout: true, script: "python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//'").trim()
+
                                 sh "make prepare"
                                 // Inject distro-specific metadata (e.g. which distro and service pack).
                                 runLibraryScript("addRpmMetaData.sh", "${env.BUILD_DIR}/SPECS/${env.NAME}.spec")

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -45,7 +45,7 @@ def isStable = (env.TAG_NAME != null & env.TAG_NAME ==~ stableToken) ? true : fa
 def version
 pipeline {
     agent {
-        label "metal-gcp-builder"
+        label "metal-gcp-builder-large"
     }
 
     options {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -57,6 +57,8 @@ pipeline {
 
     environment {
         NAME = getRepoName()
+        DOCKER_ARGS = getDockerBuildArgs(name: getRepoName(), description: 'canu sandbox environment.')
+        MUTLI_ARCH = 1
     }
 
     stages {
@@ -84,12 +86,12 @@ pipeline {
                     parallel {
                         stage('Develop image') {
                             steps {
-                                sh "make dev_image"
+                                sh "make image_dev"
                             }
                         }
                         stage('Production image') {
                             steps {
-                                sh "make prod_image"
+                                sh "make image_prod"
                             }
                         }
                     }
@@ -98,8 +100,8 @@ pipeline {
                     steps {
                         script {
                             // Use setuptools_scm to resolve the version(s) to use for the build.
-                            publishCsmDockerImage(image: "${env.NAME}", tag: "${version}-dev", isStable: isStable)
-                            publishCsmDockerImage(image: "${env.NAME}", tag: "${version}", isStable: isStable)
+                            publishCsmDockerImage(image: "${env.NAME}", multiArch: env.MULTI_ARCH, tag: "${version}-dev", isStable: isStable)
+                            publishCsmDockerImage(image: "${env.NAME}", multiArch: env.MULTI_ARCH, tag: "${version}", isStable: isStable)
                         }
                     }
                 }
@@ -110,10 +112,8 @@ pipeline {
             matrix {
                 agent {
                     docker {
-                        // args "-u root -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v /home/jenkins/.ssh:/root/.ssh -v /home/jenkins/.ssh:/home/jenkins/.ssh --group-add 999"
                         reuseNode true
                         image "${pythonImage}:${PYTHON_VERSION}"
-                        // image "artifactory.algol60.net/csm-docker/unstable/csm-docker-sle-python:3.10-5a3de28-20230323192859"
                     }
                 }
                 axes {

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ cdocs:
 	docker run -it --rm -p 8000:8000 '${NAME}:${VERSION}-docs'
 
 prepare:
-		@echo $(NAME)
-		rm -rf dist
-		mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
-		cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
+	@echo $(NAME)
+	rm -rf $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
+	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
 
 image: prod_image
 	docker tag '${NAME}:${VERSION}' '${NAME}:${VERSION}-p${PYTHON_VERSION}'

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+#############################################################################
+# Variables
+#############################################################################
+
 ifeq ($(NAME),)
 export NAME := $(shell basename $(shell pwd))
 endif
@@ -30,7 +35,7 @@ export ARCH := x86_64
 endif
 
 ifeq ($(IMAGE_VERSION),)
-export IMAGE_VERSION := $(shell python3 -m setuptools_scm | tr -s '+' '_' | sed 's/^v//')
+export IMAGE_VERSION := $(shell python3 -m setuptools_scm 2>/dev/null | tr -s '+' '_' | sed 's/^v//')
 endif
 
 ifeq ($(PYTHON_VERSION),)
@@ -48,31 +53,76 @@ endif
 export PYTHON_BIN := python$(PYTHON_VERSION)
 
 ifeq ($(VERSION),)
-export VERSION := $(shell python3 -m setuptools_scm | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//')
+export VERSION := $(shell python3 -m setuptools_scm 2>/dev/null | tr -s '-' '~' | tr -s '+' '_' | sed 's/^v//')
 endif
 
 ifeq ($(DOCKER_BUILDKIT),)
 export DOCKER_BUILDKIT := 1
 endif
 
-BUILD_ARGS ?= --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --build-arg 'ALPINE_VERSION=${ALPINE_VERSION}'
+ifeq ($(BUILD_ARGS),)
+export BUILD_ARGS ?= --build-arg 'PYTHON_VERSION=${PYTHON_VERSION}' --build-arg 'ALPINE_IMAGE=${ALPINE_IMAGE}' --build-arg 'ALPINE_VERSION=${ALPINE_VERSION}'
+endif
 
+ifeq ($(PLATFORMS),)
 PLATFORMS := linux/amd64,linux/arm64
+endif
 
-SPEC_FILE := ${NAME}.spec
-SOURCE_NAME := ${NAME}-${VERSION}
+ifeq ($(VERSION),)
+$(error VERSION not set! Verify setuptools_scm[toml] is installed and try again.)
+endif
 
-BUILD_DIR := $(PWD)/dist/rpmbuild
-SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
+.PHONY: \
+	clean \
+	cdocs \
+	dev \
+	docs \
+	help \
+	prepare \
+	prod \
+	rpm \
+	rpm_build \
+	rpm_build_source \
+	rpm_package_source \
+	synk
 
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+all : image rpm
 
-BUILDER ?= canu_builder
+help:
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@echo '    help               	Show this help screen.'
+	@echo
+	@echo '    image_deps           Build the base/dependency environment image.'
+	@echo '    image_ansible        Build the Ansible equipped image.'
+	@echo '    image_dev            Build the development \(editable\) image.'
+	@echo '    image_docs           Build the docs image.'
+	@echo '    image_prod_build     Build the build environment used for the production image.'
+	@echo '    image_prod			Build the production image.'
+	@echo
+	@echo '    image     			Build the canu \(production\) image.'
+	@echo '    rpm                	Build a YUM/SUSE RPM.'
+	@echo '    all 					Build both canu \(production\) image and YUM/SUSE RPM.'
+	@echo
+	@echo '    docs					Make and serve the docs locally.'
+	@echo '    cdocs				Make and serve the docs image.'
+	@echo
+	@echo '    dev					Run the wrapper script in development mode.'
+	@echo '    prod					Run the wrapper script in prod mode.'
+	@echo
+	@echo '    synk					Runs a snyk scan on the production container.'
+	@echo
+	@echo '    prepare              Prepare for making an RPM.'
+	@echo '    rpm_build            Builds the RPM.'
+	@echo '    rpm_build_source		Builds the SRPM.'
+	@echo '    rpm_package_source   Creates the RPM source tarball.'
+	@echo ''
 
-.PHONY: docs
-
-all : prepare binary test rpm
-rpm: rpm_package_source rpm_build_source rpm_build
+#############################################################################
+# Doc targets
+#############################################################################
 
 # docs are deployed with mike, but we can build them locally with mkdocs
 # mike can also serve local docs, but requires a bit more setup
@@ -80,14 +130,16 @@ rpm: rpm_package_source rpm_build_source rpm_build
 docs:
 	mkdocs serve --config-file mkdocs.yml
 
-cdocs:
+cdocs: image_docs
 	docker run -it --rm -p 8000:8000 '${NAME}:${VERSION}-docs'
 
-prepare:
-	@echo $(NAME)
-	rm -rf $(BUILD_DIR)
-	mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
-	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
+#############################################################################
+# Docker image targets
+#############################################################################
+
+BUILDER ?= canu_builder
+
+image: image_prod
 
 image_%:
 	@echo Building $@ ...
@@ -104,6 +156,38 @@ image_%:
 		docker buildx build --platform linux/amd64 --pull --progress plain --load --builder $(BUILDER) ${BUILD_ARGS} ${DOCKER_ARGS} -t '${NAME}:${VERSION}-p${PYTHON_VERSION}' --target $(@:image_%=%) . ;\
 	fi
 
+#############################################################################
+# RPM targets
+#############################################################################
+
+SPEC_FILE := ${NAME}.spec
+SOURCE_NAME := ${NAME}-${VERSION}
+
+BUILD_DIR ?= $(PWD)/dist/rpmbuild
+SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
+rpm: rpm_package_source rpm_build_source rpm_build
+
+prepare:
+	@echo $(NAME)
+	rm -rf $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
+	cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
+
+# touch the archive before creating it to prevent 'tar: .: file changed as we read it' errors
+rpm_package_source:
+	touch $(SOURCE_PATH)
+	tar --transform 'flags=r;s,^,/$(SOURCE_NAME)/,' --exclude .nox --exclude dist/rpmbuild --exclude ${SOURCE_NAME}.tar.bz2 -cvjf $(SOURCE_PATH) .
+
+rpm_build_source:
+	rpmbuild -vv -ts $(SOURCE_PATH) --target ${ARCH} --define "_topdir $(BUILD_DIR)"
+
+rpm_build:
+	rpmbuild -vv -ba $(SPEC_FILE) --target ${ARCH} --define "_topdir $(BUILD_DIR)"
+
+#############################################################################
+# Run targets
+#############################################################################
+
 dev:
 	./canuctl -d
 
@@ -112,14 +196,3 @@ prod:
 
 snyk:
 	snyk container test --severity-threshold=high --file=Dockerfile --fail-on=all --docker ${NAME}:${VERSION}
-
-# touch the archive before creating it to prevent 'tar: .: file changed as we read it' errors
-rpm_package_source:
-		touch $(SOURCE_PATH)
-		tar --transform 'flags=r;s,^,/$(SOURCE_NAME)/,' --exclude .nox --exclude dist/rpmbuild --exclude ${SOURCE_NAME}.tar.bz2 -cvjf $(SOURCE_PATH) .
-
-rpm_build_source:
-		rpmbuild -vv -ts $(SOURCE_PATH) --target ${ARCH} --define "_topdir $(BUILD_DIR)"
-
-rpm_build:
-		rpmbuild -vv -ba $(SPEC_FILE) --target ${ARCH} --define "_topdir $(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,12 @@ ifeq ($(VERSION),)
 $(error VERSION not set! Verify setuptools_scm[toml] is installed and try again.)
 endif
 
+#############################################################################
+# General targets
+#############################################################################
+
 .PHONY: \
+	all \
 	clean \
 	cdocs \
 	dev \
@@ -86,7 +91,7 @@ endif
 	rpm_package_source \
 	synk
 
-all : image rpm
+all: image prepare rpm
 
 help:
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
@@ -94,6 +99,7 @@ help:
 	@echo 'Available targets are:'
 	@echo ''
 	@echo '    help               	Show this help screen.'
+	@echo '    clean               	Remove build files.'
 	@echo
 	@echo '    image_deps           Build the base/dependency environment image.'
 	@echo '    image_ansible        Build the Ansible equipped image.'
@@ -104,7 +110,7 @@ help:
 	@echo
 	@echo '    image     			Build the canu \(production\) image.'
 	@echo '    rpm                	Build a YUM/SUSE RPM.'
-	@echo '    all 					Build both canu \(production\) image and YUM/SUSE RPM.'
+	@echo '    all 					Build all production artifacts.'
 	@echo
 	@echo '    docs					Make and serve the docs locally.'
 	@echo '    cdocs				Make and serve the docs image.'
@@ -112,13 +118,16 @@ help:
 	@echo '    dev					Run the wrapper script in development mode.'
 	@echo '    prod					Run the wrapper script in prod mode.'
 	@echo
-	@echo '    synk					Runs a snyk scan on the production container.'
+	@echo '    synk					Runs a snyk scan.'
 	@echo
 	@echo '    prepare              Prepare for making an RPM.'
 	@echo '    rpm_build            Builds the RPM.'
 	@echo '    rpm_build_source		Builds the SRPM.'
 	@echo '    rpm_package_source   Creates the RPM source tarball.'
 	@echo ''
+
+clean:
+	rm -rf build dist
 
 #############################################################################
 # Doc targets
@@ -165,6 +174,7 @@ SOURCE_NAME := ${NAME}-${VERSION}
 
 BUILD_DIR ?= $(PWD)/dist/rpmbuild
 SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
+
 rpm: rpm_package_source rpm_build_source rpm_build
 
 prepare:

--- a/canuctl
+++ b/canuctl
@@ -94,7 +94,7 @@ run_container() {
   if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
     if [[ -d "${K8S_DIR}" ]]; then
       cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${K8S_DIR}:${K8S_MOUNT_DIR}:${MOUNTOPTS_KUBE} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
-    else 
+    else
       cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
     fi
   else
@@ -104,7 +104,7 @@ run_container() {
       cmd="${PLATFORM} run -it --rm --net=host -v ${PWD}:${MOUNTED}:${MOUNTOPTS} -v ${SSH_AUTH_SOCK}:/ssh-agent:${MOUNTOPTS_SSH} --name ${CONTAINER_NAME} ${IMAGE_AND_TAG}"
     fi
   fi
-  
+
   $cmd
 }
 
@@ -138,9 +138,9 @@ main() {
     esac
   done
   shift $((OPTIND - 1))
-  
+
   set_mount_options
-  
+
   # Set mounted directory depending on dev or prod
   if [[ "${DEV:-false}" == "true" ]];then
     # if dev is set, then prod is false explicitly
@@ -174,7 +174,7 @@ main() {
     fi
   fi
 
-    # if that fails, try to build it and tag the image
+  # if that fails, try to build it and tag the image
   if [[ "${REBUILD:-}" == "true" ]]; then
     if BUILDKIT=1 "${PLATFORM}" build \
       --build-arg ALPINE_IMAGE="${ALPINE_IMAGE}" \


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
This PR does a few build related things:

- Per @mtupitsyn's directions, this modifies our `Jenkinsfile` to lighten the load on Jenkins. Presently we request multiple hosts and run one Docker container on each of those hosts, this puts a high-demand on Jenkins. Now only one host is requested, and then the matrix of builds (as well as the Docker builds) all run on that single host.
- The Docker image now has multi-arch support by switching to use the `docker buildx build` system. Now the published image tags support the  linux/arm64 and linux/amd64 platforms. When building images, users can override this multi-arch by setting `PLATFORMS=linux/amd64` or `PLATFORMS=linux/arm64` in their environment
- `make *_image` commands in the `Makefile` are all consolidated to a single `make image_$` command; `make image_$name` will make the respective image. To do this, all the image tags had to match their `--target` and I had to make "image" a prefix so it was easier to do string manipulation with. There were two images that didn't match their `--target`; `prod_build`, and `ansible`. Below is the conversion table for how the `make` command has changed:

    ```bash
    was: make deps_image
    now: make image_deps


    was: make ansible_image
    now: make image_ansible


    was: make dev_image
    now: make image_dev


    was: make docs_image
    now: make image_docs


    was: make build_image
    now: make image_build


    was: make prod_build_image
    now: make image_prod_build


    was: make prod_image
    now: make image_prod
    ```

#### Minor Changes

- Includes `DOCKER_ARGS` in the `docker build` commands, these contain various helpful Docker labels for the CSM ecosystem.
- Removes `BUILDKIT=1`, `DOCKER_BUILDKIT=1` is set and is sufficient for enabling Docker's Buildkit.
- Builds out the `Makefile`; defines all the `PHONY` targets, adds a `make help`, exits early if `setuptools_scm` `is missing, and more.
- This adds `--target ${ARCH}` to the RPM build, this means whenever someone adds aarch64 to our `Jenkinsfile` matrix our RPM will cross-compile. We should remember that if we rid ourselves of Pyinstaller, that our RPM will become noarch.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
