### PR TITLE
Check `canu`'s built binary works before merging

### DIFF
--- a/canu.spec
+++ b/canu.spec
@@ -68,6 +68,10 @@ rm pyinstaller.spec
 chown -R --reference=. ./dist/linux
 mkdir -p %{buildroot}%{_bindir}
 install -m 755 dist/linux/canu %{buildroot}%{_bindir}/canu
+
+# Test our installed binary.
+%{buildroot}%{_bindir}/canu --version
+
 install -m 755 dist/linux/canu-inventory %{buildroot}%{_bindir}/canu-inventory
 
 # install the 'canu' wrapper script to the bindir


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
Invoke `canu --version` before finishing the RPM build to make sure the built binary even starts up. Prevent the need for #354 ever happening again.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
