### PR TITLE
Allow up to 10 dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     labels:
       - "pip"
       - "dependencies"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     # Look for `.github/workflows` in the `root` directory
     directory: "/"


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
`canu` has so many dependencies that going through only 5 weekly will never get us caught up. If we go through 10 weekly (the maximum dependabot will manage) then we can catch up faster.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
