### PR TITLE
CASMNET-2136 | storage node vrf

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,6 +25,10 @@
 - added very basic integration tests via shellspec for local and github actions
 - Fix storage node lag configuration in Aruba templates to prevent loop
 
+## [1.7.4]
+
+- Add storage node VRF to support intenal sync and storage node restoration.
+
 ## [1.7.3]
 
 - Add `force` option to generated Mellanox web and ntp configuration.

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-spine.primary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -90,6 +91,8 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-spine.secondary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -100,6 +101,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}

--- a/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.primary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -104,6 +105,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}

--- a/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.secondary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -94,6 +95,8 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-spine.primary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -100,6 +101,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-spine.secondary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -100,6 +101,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}

--- a/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.primary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -104,6 +105,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}

--- a/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.secondary.j2
@@ -5,6 +5,7 @@ hostname {{ variables.HOSTNAME }}
 no ip icmp redirect
 vrf Customer
 vrf keepalive
+vrf Storage
 ntp server {{ variables.NCN_W001 }}
 ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
@@ -104,6 +105,8 @@ interface vlan {{ variables.CAN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CAN_IP_GATEWAY }}
     ip ospf 2 area 0.0.0.0
+interface vlan 10
+    vrf attach Storage
 {%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }}
 {% include variables.CSM_VERSION+'/aruba/common/prefix-list.j2' %}


### PR DESCRIPTION
### Summary and Scope

Isolate storage node sync and restoration traffic to their own VRF. 

Supports the project of doing storage sync on their own vlan isolated from other traffic. 

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

Resolves: 'CASMNET-2136'
<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

Tested locally and in git with nox
<!-- How was this change tested? --->
