### PR TITLE
CASMNET-2146 add 1.5 dellanox, fix aruba templates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 ## [UNRELEASED]
 
+- Add CSM 1.5 dell/mellanox configs
 - Update BGP to use 32 max paths
 - Add CSM 1.5 configs
 - Increase Dell netmiko timeout when using nornir

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -138,6 +138,14 @@ added_files += [
         "network_modeling/configs/templates/1.4/dellmellanox/full",
     ),
     (
+        "network_modeling/configs/templates/1.5/arista/*.j2",
+        "network_modeling/configs/templates/1.5/arista",
+    ),
+    (
+        "network_modeling/configs/templates/1.5/aruba/common/*.j2",
+        "network_modeling/configs/templates/1.5/aruba/common",
+    ),
+    (
         "network_modeling/configs/templates/1.5/aruba/*.j2",
         "network_modeling/configs/templates/1.5/aruba/",
     ),
@@ -148,6 +156,14 @@ added_files += [
     (
         "network_modeling/configs/templates/1.5/aruba/tds/*.j2",
         "network_modeling/configs/templates/1.5/aruba/tds",
+    ),
+    (
+        "network_modeling/configs/templates/1.5/dellmellanox/common/*.j2",
+        "network_modeling/configs/templates/1.5/dellmellanox/common",
+    ),
+    (
+        "network_modeling/configs/templates/1.5/dellmellanox/full/*.j2",
+        "network_modeling/configs/templates/1.5/dellmellanox/full",
     ),
 ]
 a = Analysis(


### PR DESCRIPTION
### Summary and Scope
- Add 1.5 dellanox templates
- Add missing aruba 1.5 templates
<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

CASMNET-2146

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
