### PR TITLE
CASMNET-2154 disable aruba central in templates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [UNRELEASED]
 
+- Disable Aruba Central in templates
 - Fix CSM 1.5 templates
-- Use CSM version variable in templates.
-- Fix cmn ACL template.
-- Bump Pyyaml.
+- Use CSM version variable in templates
+- Fix cmn ACL template
+- Bump Pyyaml
 
 ## [1.7.4]
 

--- a/network_modeling/configs/templates/1.3/aruba/common/sw-cdu.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/common/sw-cdu.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.3/aruba/common/sw-cdu.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/common/sw-cdu.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-leaf.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-leaf.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.3/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/full/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.3/aruba/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/sw-edge.primary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.3/aruba/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/sw-edge.secondary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.3/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.3/aruba/tds/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.3/aruba/tds/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/common/sw-cdu.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/common/sw-cdu.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/common/sw-cdu.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/common/sw-cdu.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-leaf.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-leaf.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/full/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/sw-edge.primary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.4/aruba/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/sw-edge.secondary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.4/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.4/aruba/tds/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.4/aruba/tds/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/common/sw-cdu.primary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/common/sw-cdu.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/common/sw-cdu.secondary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/common/sw-cdu.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.5/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-leaf.primary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.5/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-leaf.secondary.j2
@@ -11,7 +11,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.5/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/sw-edge.primary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.5/aruba/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/sw-edge.secondary.j2
@@ -10,6 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf keepalive
 ssh server vrf mgmt

--- a/network_modeling/configs/templates/1.5/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.5/aruba/tds/sw-leaf-bmc.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W003 }}
 ntp enable
 
 
-
+aruba-central
+    disable
 ssh server vrf default
 ssh server vrf mgmt
 ssh server vrf Customer

--- a/network_modeling/configs/templates/1.5/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/tds/sw-spine.primary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive

--- a/network_modeling/configs/templates/1.5/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.5/aruba/tds/sw-spine.secondary.j2
@@ -10,7 +10,8 @@ ntp server {{ variables.NCN_W002 }}
 ntp server {{ variables.NCN_W003 }}
 ntp enable
 
-
+aruba-central
+    disable
 ssh server vrf Customer
 ssh server vrf default
 ssh server vrf keepalive


### PR DESCRIPTION
### Summary and Scope

disable aruba central in templates

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs
CASMNET-2154
<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing
Tested this change on surtur.
<!-- How was this change tested? --->
