### PR TITLE
CASMNET-2017 Fix CANU exit code on BGP validation 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Fix CANU exit code on BGP validation
 - Disable Aruba Central in templates
 - Fix CSM 1.5 templates
 - Use CSM version variable in templates

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -151,7 +151,12 @@ def bgp(ctx, username, password, verbose, network):
 
             if neighbor_status != "Established":
                 data[switch]["status"] = "FAIL"
-                errors.append(f"{hostname} ===> {neighbor}: {neighbor_status}")
+                errors.append(
+                    [
+                        neighbor,
+                        neighbor_status,
+                    ],
+                )
                 if verbose:
                     click.secho(
                         f"{hostname} ===> {neighbor}: {neighbor_status}",

--- a/canu/validate/network/bgp/bgp.py
+++ b/canu/validate/network/bgp/bgp.py
@@ -151,6 +151,7 @@ def bgp(ctx, username, password, verbose, network):
 
             if neighbor_status != "Established":
                 data[switch]["status"] = "FAIL"
+                errors.append(f"{hostname} ===> {neighbor}: {neighbor_status}")
                 if verbose:
                     click.secho(
                         f"{hostname} ===> {neighbor}: {neighbor_status}",
@@ -165,7 +166,6 @@ def bgp(ctx, username, password, verbose, network):
     click.echo(dash)
 
     for switch in data:
-
         bgp_neighbors = data[switch]["neighbors"]
         ip = switch
         hostname = data[switch]["hostname"]
@@ -190,6 +190,7 @@ def bgp(ctx, username, password, verbose, network):
         click.echo(dash)
         for error in errors:
             click.echo("{:<15s} - {}".format(error[0], error[1]))
+        sys.exit(1)
 
 
 def get_bgp_neighbors(ip, credentials, asn, network):
@@ -285,9 +286,7 @@ def get_bgp_neighbors_aruba(ip, credentials, asn, network):
                 f"Error connecting to switch {ip}, check the username or password"
             )
         elif exception_type == "ConnectionError":
-            error_message = (
-                f"Error connecting to switch {ip}, check the entered username, IP address and password."
-            )
+            error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password."
         else:
             error_message = f"Error connecting to switch {ip}."
 

--- a/tests/test_validate_network_bgp.py
+++ b/tests/test_validate_network_bgp.py
@@ -514,7 +514,6 @@ def test_validate_bgp_mellanox(pull_sls_networks, switch_vendor):
                 password,
             ],
         )
-        print(result.output)
         assert result.exit_code == 0
         assert "PASS - IP: 192.168.1.1 Hostname: sw-spine-001" in str(result.output)
         assert "PASS - IP: 192.168.1.2 Hostname: sw-spine-002" in str(result.output)


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->

- Fix CANU exit code on BGP validation

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

CASMNET-2017

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

surtur
fanta
```
ncn-m001:~/lbates # canu validate network bgp
Password:
|  Connecting

BGP Neighbors Established
--------------------------------------------------
FAIL - IP: 10.254.0.2 Hostname: sw-spine-001
PASS - IP: 10.254.0.3 Hostname: sw-spine-002


Errors
--------------------------------------------------
10.252.1.100    - Idle
ncn-m001:~/lbates # echo $?
1
```
<!-- How was this change tested? --->
