### PR TITLE
CASMTRIAGE-6179 fix exception on invalid password with shcd cabling

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fixed exception when bad credentials provided when running `canu validate shcd-cabling`
+
 ## [1.7.6]
 
 - Add ACL for DHCP

--- a/canu/validate/shcd_cabling/shcd_cabling.py
+++ b/canu/validate/shcd_cabling/shcd_cabling.py
@@ -250,7 +250,7 @@ def shcd_cabling(
                     elif exception_type == "ConnectionError":
                         error_message = f"Error connecting to switch {ip}, check the entered username, IP address and password."
                     elif exception_type == "NetmikoTimeoutException":
-                        error_message = f"Timeout error connecting to {ip}. Check the IP address and try again."
+                        error_message = f"Timeout error connecting to {ip}. Check the IP address or credentials and try again."
                     elif exception_type == "NetmikoAuthenticationException":
                         error_message = f"Auth error connecting to {ip}. Check the credentials or IP address and try again"
                     else:
@@ -261,6 +261,24 @@ def shcd_cabling(
     # Open the updated cache to model nodes
     with open(canu_cache_file, "r+") as file:
         canu_cache = yaml.load(file)
+
+    double_dash = "=" * 100
+    # if there are errors and no switches exist or we able to be connected to, error and exit
+    if len(errors) > 0 and canu_cache["switches"] is None:
+        click.echo("\n", file=out)
+        click.echo(double_dash, file=out)
+        click.secho(
+            "Errors",
+            fg="red",
+            file=out,
+        )
+        click.echo(double_dash, file=out)
+        for error in errors:
+            click.echo(
+                "{:<15s} - {}".format(error[0], error[1]),
+                file=out,
+            )
+        sys.exit(1)
 
     # Create Cabling Node factory and model
     log.debug("Creating model from switch LLDP data")
@@ -319,7 +337,6 @@ def shcd_cabling(
             click.secho(f"{host_mac_string}")
         sys.exit(0)
 
-    double_dash = "=" * 100
     click.echo("\n", file=out)
     click.echo(double_dash, file=out)
     click.secho(


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: CASMTRIAGE-6179

Checks for errors earlier (immediately after trying to connect to switches) and exiting if any are detected.

### Testing

<!-- How was this change tested? --->

Ran the same command from the ticket and validated the output on bad credentials

```
~ # canu validate shcd-cabling --ips 10.252.0.2,10.252.0.3 --tabs 25G_10G --corners I14,Q51 --csm 1.5 -a TDS --shcd SHCD.xlsx
Password: 
  Connecting to 127.0.0.6 - Switch 2 of 2         

====================================================================================================
Errors
====================================================================================================
10.252.0.2       - Timeout error connecting to 10.252.0.2. Check the IP address or credentials and try again.
10.252.0.3       - Timeout error connecting to 10.252.0.3. Check the IP address or credentials and try again.
```