### PR TITLE
CASMTRIAGE-6517 - Add snmp-server to the CSM VRF on leaf-bmc devices

### DIFF
--- a/network_modeling/configs/templates/1.5/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.5/aruba/full/sw-leaf-bmc.j2
@@ -80,6 +80,7 @@ interface vlan {{ variables.CMN_VLAN }}
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
 snmp-server vrf default
+snmp-server vrf {{ variables.VRF }}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 router ospf 2 vrf {{ variables.VRF }}
     router-id {{ variables.LOOPBACK_IP }}

--- a/network_modeling/configs/templates/1.5/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.5/aruba/tds/sw-leaf-bmc.j2
@@ -80,6 +80,7 @@ interface vlan {{ variables.CMN_VLAN }}
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
 snmp-server vrf default
+snmp-server vrf {{ variables.VRF }}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 router ospf 2 vrf {{ variables.VRF }}
     router-id {{ variables.LOOPBACK_IP }}


### PR DESCRIPTION
### Summary and Scope

Update CSM 1.5 Aruba templates to add the SNMP server to the CSM VRF in order to allow hms-discovery and REDS to function correctly.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: [CASMTRIAGE-6517](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6517)
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

Generated configuration using input files from tyr.
```
$ canu generate network config --csm 1.5 -a TDS --ccj ccj.json --sls-file tyr_sls.json --folder output
sw-spine-001 Config Generated
sw-spine-002 Config Generated
sw-leaf-bmc-001 Config Generated
```
Verified output was as expected.
```
$ grep snmp-server output/sw-leaf-bmc-001.cfg
snmp-server vrf default
snmp-server vrf CSM
```
<!-- How was this change tested? --->
