### PR TITLE
Fix selection of primary switch in little used code path

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Ensure that the variable designating a switch as primary is always initialized.
+
 ## [1.8.0]
 
 - Move NMN/HMN/MTL to new vrf, move CMN/CHN/CAN to default vrf.

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -1466,9 +1466,10 @@ def get_switch_nodes(
             }
             nodes.append(new_node)
         elif shasta_name == "sw-spine":
+            is_primary, primary, secondary = switch_is_primary(switch_name)
+
             # sw-leaf ==> sw-spine
             if switch_name.startswith("sw-leaf"):
-                is_primary, primary, secondary = switch_is_primary(switch_name)
                 digits = re.findall(r"(\d+)", primary)[0]
                 lag_number = 100 + int(digits)
 
@@ -1486,10 +1487,8 @@ def get_switch_nodes(
 
             # sw-spine ==> sw-spine
             elif switch_name.startswith("sw-spine"):
-                is_primary, primary, secondary = switch_is_primary(switch_name)
                 lag_number = 256
             elif switch_name.startswith("sw-edge"):
-                is_primary, primary, secondary = switch_is_primary(switch_name)
                 lag_number = 250
             new_node = {
                 "subtype": "spine",


### PR DESCRIPTION
### Summary and Scope

When CDU switches are listed (created) prior to Spine switches in either an SHCD, the resulting Paddle (CCJ) also contains this ordering.  When an SHCD or CCJ of this type is used to generate CDU switch configurations the code enters into a little used path (typically spines are created prior to cdus).  This path did not completely initialize a variable checking whether the switch is primary in a pair, resulting in an exception.

This change cleans up the code path to fully initialize the variable and avoid exceptions.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: [CASMTRIAGE-6641](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6641)
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

The customer file which illustrated the problem and exception was re-run with the code change without error.
