### PR TITLE
Fix 1.6 pyinstaller

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -165,6 +165,34 @@ added_files += [
         "network_modeling/configs/templates/1.5/dellmellanox/full/*.j2",
         "network_modeling/configs/templates/1.5/dellmellanox/full",
     ),
+    (
+        "network_modeling/configs/templates/1.6/arista/*.j2",
+        "network_modeling/configs/templates/1.6/arista",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/aruba/common/*.j2",
+        "network_modeling/configs/templates/1.6/aruba/common",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/aruba/*.j2",
+        "network_modeling/configs/templates/1.6/aruba/",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/aruba/full/*.j2",
+        "network_modeling/configs/templates/1.6/aruba/full",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/aruba/tds/*.j2",
+        "network_modeling/configs/templates/1.6/aruba/tds",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/dellmellanox/common/*.j2",
+        "network_modeling/configs/templates/1.6/dellmellanox/common",
+    ),
+    (
+        "network_modeling/configs/templates/1.6/dellmellanox/full/*.j2",
+        "network_modeling/configs/templates/1.6/dellmellanox/full",
+    ),
 ]
 a = Analysis(
     ["canu/cli.py"],


### PR DESCRIPTION
### Summary and Scope

Add 1.6 template files to pyinstaller.
This is needed to make the RPM functional. 
<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
