### PR TITLE
CAST-36209/CASMINST-6904 remove canu user and change ownership of canu-owned files

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [UNRELEASED]
 
+## [1.9.1]
+
+- remove canu user going forward. permissions are now default (root) 
 - Ensure that the variable designating a switch as primary is always initialized.
 
 ## [1.9.0]

--- a/canu.spec
+++ b/canu.spec
@@ -79,13 +79,18 @@ mkdir -p %{buildroot}%{_bindir}
 install -m 755 ./canuctl %{buildroot}%{_bindir}/canuctl
 
 %pre
-getent passwd canu >/dev/null || \
-    useradd -U -m -s /bin/bash -c "CANU user" canu
+# remove the canu user as it is no longer needed post v1.9.1
+if getent passwd canu; then 
+  userdel -r canu
+fi
+if getent group canu; then 
+  groupdel canu
+fi
 
 %files
-%attr(755, canu, canu) %{_bindir}/canuctl
-%attr(755, canu, canu) %{_bindir}/canu
-%attr(755, canu, canu) %{_bindir}/canu-inventory
+%attr(0755, -, -) %{_bindir}/canuctl
+%attr(0755, -, -) %{_bindir}/canu
+%attr(0755, -, -) %{_bindir}/canu-inventory
 %license LICENSE
 
 %changelog


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->

Sets the canu user's login shell to `/sbin/nologin`

- [x] I have added new tests to cover the new code
- [x] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Relates to: CAST-36209
* Resolves CASMINST-6904
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->

tested with an older canu version installed

```
ncn-m001:~ # canu --version
canu, version 1.7.6
ncn-m001:~ # getent passwd canu
canu:x:1000:1000:CANU user:/home/canu:/bin/bash
ncn-m001:~ # ls -l /usr/bin/canu*
-rwxr-xr-x 1 canu canu 44546496 Jun 25 10:23 /usr/bin/canu
-rwxr-xr-x 1 canu canu     6702 Jun 25 10:23 /usr/bin/canuctl
-rwxr-xr-x 1 canu canu 44543352 Jun 25 10:23 /usr/bin/canu-inventory
ncn-m001:~ # zypper in --allow-unsigned-rpm ./canu-1.8.2.dev3+gf28a0c4-1.x86_64.rpm
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following package is going to be upgraded:
  canu

The following package has no support information from its vendor:
  canu

1 package to upgrade.
Overall download size: 85.8 MiB. Already cached: 0 B. After the operation, additional 2.8 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: canu-1.8.2.dev3+gf28a0c4-1.x86_64 (Plain RPM files cache)                                                                           (1/1),  85.8 MiB

Checking for file conflicts: .................................................................................................................................[done]
canu:!:1000:
groupdel: cannot remove the primary group of user 'canu'
canu:x:1000:1000:CANU user:/home/canu:/bin/bash
no crontab for canu
(1/1) Installing: canu-1.8.2.dev3+gf28a0c4-1.x86_64 ..........................................................................................................[done]
There are running programs which still use files and libraries deleted or updated by recent upgrades. They should be restarted to benefit from the latest updates. Run 'zypper ps -s' to list these programs.

ncn-m001:~ # ls -l /usr/bin/canu*
-rwxr-xr-x 1 root root 45995568 Jun 28 19:03 /usr/bin/canu
-rwxr-xr-x 1 root root     6702 Jun 28 19:03 /usr/bin/canuctl
-rwxr-xr-x 1 root root 45995360 Jun 28 19:03 /usr/bin/canu-inventory
ncn-m001:~ # getent passwd canu
```
