### PR TITLE
CASMTRIAGE-6650 fix and test for 'IndexError: list index out of range' with 'canu

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [UNRELEASED]
 
+
+## [1.9.2]
+
+- fixed a bug, which fails to parse an SHCD because of a poorly-named cell
+- this release halts the changelog file in favor of the github release notes associated with each tag.  manually keeping this log up-to-date is a chore and with csm entering EOL, we should focus on the fixes, not painful manual release notes
+
 ## [1.9.1]
 
 - remove canu user going forward. permissions are now default (root) 

--- a/tests/test_validate_shcd_cabling_format_dst_name.py
+++ b/tests/test_validate_shcd_cabling_format_dst_name.py
@@ -1,0 +1,91 @@
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU validate shcd-cabling commands."""
+import unittest
+
+import canu.validate.network.cabling.cabling as cabling
+
+# Click commands do not expose their functions as attributes, so we need to
+# import directly and bypass the click command structure.  This is akin to a
+# regular unit test one might like to write.
+
+
+class TestValidateShcdCablingFormatDstName(unittest.TestCase):
+    """Unit tests for CANU validate shcd-cabling format_dst_name command."""
+
+    def test_format_switch_dst_name(self):
+        """Test the format_switch_dst_name function."""
+        # Test case 1: Name starts with "sw-" and has a string with multiple digits
+        dst_name = "sw-spine01"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-spine-001"
+        self.assertEqual(result, expected_result)
+
+        # Test case 2: Name starts with "sw-" has a string in the middle, followed by a dash and multiple digits
+        dst_name = "sw-spine-002"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-spine-002"
+        self.assertEqual(result, expected_result)
+
+        # Test case 3: Name starts with "sw-" has a string in the middle, followed by a two dashes and multiple digits
+        dst_name = "sw-leaf--bmc99"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-leaf-bmc-099"
+        self.assertEqual(result, expected_result)
+
+        # Test case 4: Name starts with "sw-" and has a string with multiple digits
+        dst_name = "sw-smn04"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-smn-004"
+        self.assertEqual(result, expected_result)
+
+        # Test case 5: Name starts with "sw-" and has a string with multiple digits but has a trailing dash
+        dst_name = "sw-25g06-"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-25g-006"
+        self.assertEqual(result, expected_result)
+
+        # Test case 6: Name starts with "sw-" and has a string that starts with digits but ends with all digits
+        dst_name = "sw-100g01"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-100g-001"
+        self.assertEqual(result, expected_result)
+
+        # Test case 7: Name does not start with "sw-" and has only non-digit characters
+        dst_name = "sw---=%$)"
+        with self.assertRaises(cabling.FormatSwitchDestinationNameError):
+            cabling.format_switch_dst_name(dst_name)
+
+        # Test case 11: Name starts with "sw-" but has no digits
+        dst_name = "sw-leaf"
+        with self.assertRaises(cabling.FormatSwitchDestinationNameError):
+            cabling.format_switch_dst_name(dst_name)
+
+        # Test case 12: Name starts with "sw-" and has leaf-bmc and multiple digits
+        dst_name = "sw-leaf-bmc99"
+        result = cabling.format_switch_dst_name(dst_name)
+        expected_result = "sw-leaf-bmc-099"
+        self.assertEqual(result, expected_result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
validate shcd-cabling'

When running 'canu validate shcd-cabling' with an SHCD that does not follow currently-supported naming conventions can cause this stacktrace:

```
  File "cli.py", line 314, in <module>
  File "click/core.py", line 1130, in __call__
  File "click/core.py", line 1055, in main
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1404, in invoke
  File "click/core.py", line 760, in invoke
  File "click/decorators.py", line 26, in new_func
  File "validate/shcd_cabling/shcd_cabling.py", line 286, in shcd_cabling
  File "validate/network/cabling/cabling.py", line 412, in node_model_from_canu
IndexError: list index out of range
[48583] Failed to execute script 'cli' due to unhandled exception!
```

canu is currently not setup to accurately test this situation since it requires an SHCD and a functioning system with switches that can be logged into.

To that end, I broke the problematic code into its own function so it could be unit-tested.  I then created some unit tests with various inputs to test against.  Both the line in question, and the one adjacent suffer from a similiar problem: a lack of checking if an index exists before trying to access it.  Thus, I changed the code to check these two lines:

```
                    dst_middle = re.findall(r"(?:sw-)([a-z-]+)", dst_name)[0]
                    dst_digits = re.findall(r"(\d+)", dst_name)[0]
```

This is quite a small bug, but we often have issues with inconsistencies in the content of cells in the SHCD.  Really, we should define the input we expect for every cell, attempt to sanitize any input, and fail if it does not meet specifications.

With all of the monolithic functions and complexity of this app, this is just one step in that directions.  Many of our functions are cognitively complex and do not unit test easily. We should also start adding testdata fixtures to test the same data against the entire app.

### Summary and Scope

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
