### PR TITLE
update container deps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        version: ['3.10', '3.9']
+        version: ['3.12']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: nox
       env:
         GIT_REPO_NAME: "${GITHUB_REPOSITORY#*/}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     name: Tests and Coverage
     strategy:
       matrix:
-        version: ['3.10', '3.9']
+        version: ['3.12']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
   integration_tests:
     strategy:
       matrix:
-        version: ['3.10', '3.9']
+        version: ['3.12']
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -128,7 +128,7 @@ pipeline {
                     }
                     axis {
                         name 'PYTHON_VERSION'
-                        values '3.10', '3.9'
+                        values '3.12'
                     }
                 }
                 environment {

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export ARCH := x86_64
 endif
 
 ifeq ($(PYTHON_VERSION),)
-export PYTHON_VERSION := 3.10
+export PYTHON_VERSION := 3.12
 endif
 
 ifeq ($(ALPINE_IMAGE),)
@@ -43,7 +43,7 @@ export ALPINE_IMAGE := artifactory.algol60.net/docker.io/library/alpine
 endif
 
 ifeq ($(ALPINE_VERSION),)
-export ALPINE_VERSION := 3.17
+export ALPINE_VERSION := 3.20
 endif
 
 export PYTHON_BIN := python$(PYTHON_VERSION)

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -1685,11 +1685,11 @@ def switch_is_primary(switch):
 
     if int(digits) % 2 == 0:  # Switch is Secondary
         is_primary = False
-        primary = f"sw-{middle.rstrip('-')}-{int(digits)-1 :03d}"
+        primary = f"sw-{middle.rstrip('-')}-{int(digits) - 1 :03d}"
         secondary = switch
     else:  # Switch is Primary
         is_primary = True
-        secondary = f"sw-{middle.rstrip('-')}-{int(digits)+1 :03d}"
+        secondary = f"sw-{middle.rstrip('-')}-{int(digits) + 1 :03d}"
         primary = switch
 
     return is_primary, primary, secondary

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -1206,7 +1206,7 @@ def print_node_list(node_list, title, out="-"):
                 if len(unused_block) == 1:
                     port_string = f"{unused_block[0]:02}==>UNUSED"
                 else:
-                    port_string = f"{unused_block[0]:02}-{unused_block[len(unused_block)-1]:02}==>UNUSED"
+                    port_string = f"{unused_block[0]:02}-{unused_block[len(unused_block) - 1]:02}==>UNUSED"
                 unused_block = []  # reset
                 click.secho(f"        {port_string}", fg="green", file=out)
 

--- a/canuctl
+++ b/canuctl
@@ -34,8 +34,8 @@ CANU_IMAGE="artifactory.algol60.net/csm-docker/stable/canu"
 CANU_TAG="latest"
 # Use the publicly available alpine image so users do not need to log in
 ALPINE_IMAGE="alpine"
-ALPINE_VERSION="3.17"
-PYTHON_VERSION="3.10"
+ALPINE_VERSION="3.20"
+PYTHON_VERSION="3.12"
 
 # die prints the line number and command that failed
 die() {

--- a/network_modeling/NetworkNode.py
+++ b/network_modeling/NetworkNode.py
@@ -427,7 +427,7 @@ class NetworkNode:
             if index > len(self.__ports) - 1 or index < 0:
                 raise Exception(
                     f"{__name__} Port {src_port.port()} was requested from {self.__id}:{self.__common_name} "
-                    f"but only {len(self.__ports)-1} Ports are available on the Node.",
+                    f"but only {len(self.__ports) - 1} Ports are available on the Node.",
                 )
 
             if self.__ports[index] is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,51 +33,51 @@ classifiers = [
     'Natural Language :: English',
     'Operating System :: POSIX',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.12',
 ]
 description = 'CSM Automatic Network Utility'
 dependencies = [
-    'aiohttp==3.8.4',
-    'click-help-colors==0.9.1',
-    'click-option-group==0.5.6',
-    'click-params==0.4.1',
-    'click-spinner==0.1.10',
-    'click==8.1.3',
-    'colorama==0.4.6',
-    'emoji==2.5.0',
-    'hier-config==2.2.2',
-    'ipython==8.14.0',
-    'jinja2==3.1.2',
-    'jsonschema==4.17.3',
-    'kubernetes==26.1.0',
-    'mac-vendor-lookup==0.1.12',
-    'natsort==8.3.1',
-    'netaddr==0.8.0',
-    'netmiko==4.1.2',
-    'netutils==1.4.1',
-    'nornir-netmiko==1.0.0',
-    'nornir-salt==0.19.2',
-    'nornir-scrapli==2023.1.30.post1',
-    'nornir-utils==0.2.0',
-    'nornir==3.3.0',
-    'openpyxl==3.1.2',
-    'pyyaml==6.0.1',
-    'requests==2.31.0',
-    'responses==0.23.1',
-    'ruamel.yaml<0.17.33',
-    'tabulate==0.9.0',
-    'tokenize-rt==5.1.0',
-    'tomli==2.0.1',
-    'ttp==0.9.4',
-    'urllib3==2.0.5',
-    'yamale<=4.0.4',
+    'aiohttp',
+    'click-help-colors',
+    'click-option-group',
+    'click-params',
+    'click-spinner',
+    'click',
+    'colorama',
+    'emoji',
+    'hier-config',
+    'ipython',
+    'jinja2',
+    'jsonschema',
+    'kubernetes',
+    'mac-vendor-lookup',
+    'natsort',
+    'netaddr',
+    'netmiko',
+    'netutils',
+    'nornir-netmiko',
+    'nornir-salt',
+    'nornir-scrapli',
+    'nornir-utils',
+    'nornir',
+    'openpyxl',
+    'pyyaml',
+    'requests',
+    'responses',
+    'ruamel.yaml',
+    'setuptools',
+    'tabulate',
+    'tokenize-rt',
+    'tomli',
+    'ttp',
+    'urllib3',
+    'yamale',
 ]
 dynamic = ['entry-points', 'scripts', 'version']
 maintainers = [
     { name = 'Russell Bunch', email = 'doomslayer@hpe.com'}
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.12'
 
 [metadata]
 url = 'https://github.com/Cray-HPE/canu'
@@ -86,47 +86,47 @@ license = { file = 'LICENSE' }
 
 [project.optional-dependencies]
 ci = [
-    'nox~=2023.4.22',
+    'nox',
 ]
 docs = [
-    'myst-parser~=1.0.0',
-    'sphinx~=6.1.3',
-    'sphinx-click~=4.4.0',
-    'sphinx-markdown-builder~=0.5.5',
-    'mike~=1.1.2',
-    'mkdocs~=1.4.2',
-    'mkdocs-material~=9.1.4',
-    'mkdocs-material-extensions~=1.1.1',
+    'myst-parser',
+    'sphinx',
+    'sphinx-click',
+    'sphinx-markdown-builder',
+    'mike',
+    'mkdocs',
+    'mkdocs-material',
+    'mkdocs-material-extensions',
 ]
 lint = [
-    'darglint~=1.8.1',
-    'flake8~=5.0.4',
-    'flake8-black~=0.3.6',
-    'flake8-bugbear~=23.3.12',
-    'flake8-commas~=2.1.0',
-    'flake8-comprehensions~=3.12.0',
-    'flake8-debugger~=4.1.2',
-    'flake8-docstrings~=1.7.0',
-    'flake8-eradicate~=1.5.0',
-    'flake8-import-order~=0.18.2',
-    'flake8-quotes~=3.3.2',
-    'flake8-string-format==0.3.0',
-    'pep8~=1.7.1',
-    'pep8-naming~=0.13.2',
-    'toml~=0.10.2',
+    'darglint',
+    'flake8',
+    'flake8-black',
+    'flake8-bugbear',
+    'flake8-commas',
+    'flake8-comprehensions',
+    'flake8-debugger',
+    'flake8-docstrings',
+    'flake8-eradicate',
+    'flake8-import-order',
+    'flake8-quotes',
+    'flake8-string-format',
+    'pep8',
+    'pep8-naming',
+    'toml',
 ]
 network_modeling = [
-    'jsonschema==4.17.3',
-    'yamale<=4.0.4',
+    'jsonschema',
+    'yamale',
 ]
 test = [
-    'coverage~=7.2.2',
-    'mock~=5.0.1',
-    'py~=1.11.0',
-    'pytest~=7.3.1',
-    'pytest-cov~=4.1.0',
-    'pytest-sugar~=0.9.6',
-    'testfixtures~=7.1.0',
+    'coverage',
+    'mock',
+    'py',
+    'pytest',
+    'pytest-cov',
+    'pytest-sugar',
+    'testfixtures',
 ]
 
 # Defines which folders belong to our package.
@@ -144,9 +144,9 @@ readme = { file = ['README.md'], content-type = 'text/markdown' }
 [build-system]
 build-backend = 'setuptools.build_meta'
 requires = [
-    'setuptools ~= 66.0',
-    'setuptools_scm[toml] ~= 7.1.0',
-    'wheel ~= 0.38.4',
+    'setuptools',
+    'setuptools_scm[toml]',
+    'wheel',
 ]
 
 [tool.distutils.bdist_wheel]


### PR DESCRIPTION
this updates quite a bit.  it brings python up to 3.12, alpine to edge
in order to aid in the remediation of https://github.com/advisories/GHSA-2x8c-95vh-gfv4.  at the time of
this commit, the patch is only available in edge.  as a result of this,
our pipeline marks this as unstable because it isn't a published
release.

beyond the CVE, I opted to bump everything since it has been nearly a
year and the tests all still pass, minus a few that needed a slight
adjustment for the new python version.

pinning the versions so strictly can be helpful, but difficult at the
same time.  in this case--as well as times in the past--it has been hard
to bump a single version of a dependency when a CVE or update is needed.
it usually triggers a cascade of other depdency warnings.

we also have a weird mix of dependencies from both the normal python
install and the container version of canu.  we had planned to drop the
binary version and bundle the image with the rpm, but that was more than
a year ago, and no progress has been made towards that.

to that end, I removed all the pinned versions and just went with the
latest.  since we do not release that often, we will be able to catch
problems when building locally and we can choose to pin at the time if
need be, but the CVE in this commit is not the only one out there, so
bringing everything up to latest (at least for now) seems to be the best
option IMO.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>