### PR TITLE
One dep pr to rule them all part3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     'tomli==2.0.1',
     'ttp==0.9.4',
     'urllib3==2.2.3',
-    'yamale<=4.0.4',
+    'yamale<=5.2.1',
 ]
 dynamic = ['entry-points', 'scripts', 'version']
 maintainers = [
@@ -117,7 +117,7 @@ lint = [
 ]
 network_modeling = [
     'jsonschema==4.17.3',
-    'yamale<=4.0.4',
+    'yamale<=5.2.1',
 ]
 test = [
     'coverage~=7.2.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     'responses==0.23.1',
     'ruamel.yaml<0.17.33',
     'tabulate==0.9.0',
-    'tokenize-rt==5.1.0',
+    'tokenize-rt==6.1.0',
     'tomli==2.0.1',
     'ttp==0.9.4',
     'urllib3==2.2.3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     'ipython==8.14.0',
     'jinja2==3.1.4',
     'jsonschema==4.17.3',
-    'kubernetes==26.1.0',
+    'kubernetes==31.0.0',
     'mac-vendor-lookup==0.1.12',
     'natsort==8.3.1',
     'netaddr==0.8.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ docs = [
     'sphinx-click~=4.4.0',
     'sphinx-markdown-builder~=0.5.5',
     'mike~=1.1.2',
-    'mkdocs~=1.4.2',
+    'mkdocs~=1.6.1',
     'mkdocs-material~=9.5.36',
     'mkdocs-material-extensions~=1.1.1',
 ]


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->
Includes:

- https://github.com/Cray-HPE/canu/pull/481
- https://github.com/Cray-HPE/canu/pull/499
- https://github.com/Cray-HPE/canu/pull/514
- https://github.com/Cray-HPE/canu/pull/520

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
Tested on redbull by running the following commands and verifying their output and generated files:
```bash
canu validate shcd -a tds --shcd ./Shasta\ River\ Redbull\ CCD_RevA16.xlsx --tabs 25G_10G,NMN,HMN --corners I15,Q50,I9,S10,I20,S30 --log DEBUG --json --out ccj.json
ll
canu generate network config --ccj ccj.json --csm 1.6 --sls-file redbull/sls_input_file.json --folder generated
canu validate switch config --ip 10.254.0.2 --generated ./generated/sw-spine-001.cfg --remediation
```
