### PR TITLE
Speed up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily" # FIXME: Revert back to weekly after we catch-up on updates.
     labels:
       - "pip"
       - "dependencies"
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     # Check for updates once a week
     schedule:
-      interval: "weekly"
+      interval: "daily" # FIXME: Revert back to weekly after we catch-up on updates.
     labels:
       - "github_actions"
       - "dependencies"


### PR DESCRIPTION
Let's blaze through the backlog of updates by changing dependabot to "daily" for a short period of time, at least until we catch-up.
