### PR TITLE
CASMNET-2260 Mountain HMN and HMN should use ospf area 2

### DIFF
--- a/network_modeling/configs/templates/1.5/aruba/common/mtn_hmn_vlan.j2
+++ b/network_modeling/configs/templates/1.5/aruba/common/mtn_hmn_vlan.j2
@@ -14,7 +14,7 @@ interface vlan {{ cabinet.VlanID }}
     active-gateway ip {{ cabinet.Gateway }}
     ipv6 address autoconfig
     ip helper-address 10.94.100.222
-    ip ospf 1 area 0.0.0.0
+    ip ospf 2 area 0.0.0.0
     ip ospf passive
 
 {%- endfor %}

--- a/network_modeling/configs/templates/1.5/aruba/common/mtn_nmn_vlan.j2
+++ b/network_modeling/configs/templates/1.5/aruba/common/mtn_nmn_vlan.j2
@@ -13,7 +13,7 @@ interface vlan {{ cabinet.VlanID }}
     active-gateway ip mac 12:00:00:00:73:00
     active-gateway ip {{ cabinet.Gateway }}
     ip helper-address 10.92.100.222
-    ip ospf 1 area 0.0.0.0
+    ip ospf 2 area 0.0.0.0
     ip ospf passive
 
 {%- endfor %}

--- a/network_modeling/configs/templates/1.6/aruba/common/mtn_hmn_vlan.j2
+++ b/network_modeling/configs/templates/1.6/aruba/common/mtn_hmn_vlan.j2
@@ -14,7 +14,7 @@ interface vlan {{ cabinet.VlanID }}
     active-gateway ip {{ cabinet.Gateway }}
     ipv6 address autoconfig
     ip helper-address 10.94.100.222
-    ip ospf 1 area 0.0.0.0
+    ip ospf 2 area 0.0.0.0
     ip ospf passive
 
 {%- endfor %}

--- a/network_modeling/configs/templates/1.6/aruba/common/mtn_nmn_vlan.j2
+++ b/network_modeling/configs/templates/1.6/aruba/common/mtn_nmn_vlan.j2
@@ -13,7 +13,7 @@ interface vlan {{ cabinet.VlanID }}
     active-gateway ip mac 12:00:00:00:73:00
     active-gateway ip {{ cabinet.Gateway }}
     ip helper-address 10.92.100.222
-    ip ospf 1 area 0.0.0.0
+    ip ospf 2 area 0.0.0.0
     ip ospf passive
 
 {%- endfor %}


### PR DESCRIPTION
Mountain HMN and NMN are now in custom VRF, this change implies using ospf area 2

### Summary and Scope

Canu version 1.8 change Management Networks VRF from default to CSM, ospf area are also changed, this change hasn't been
applied to all NMN/HMN Vlans resulting in Mountain HMN/HMN still being in ospf area 1
the result is one ospf in area 1 for default vrf and two ospf areas (1 and 2) in CSM vrf, this patch fixes the discrepancy


### Issues and Related PRs

addresses CAST-37220

### Testing

Tested by applying the config to Hill CDU switches
