### PR TITLE
Resolve `pkg_resources` deprecation warning

### DIFF
--- a/canu/cli.py
+++ b/canu/cli.py
@@ -21,13 +21,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU (CSM Automatic Network Utility) floats through a Shasta network and makes setup and config breeze."""
 from collections import defaultdict
+from importlib import metadata
 import json
 from os import environ, getenv, path
 import sys
 
 import certifi
 import click
-import pkg_resources
 import requests
 from ruamel.yaml import YAML
 import urllib3
@@ -53,7 +53,7 @@ if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):  # pragma: no cov
 else:
     parent_directory = path.abspath(path.dirname(path.dirname(__file__)))
 
-version = pkg_resources.get_distribution("canu").version
+version = metadata.version("canu")
 
 canu_config_file = path.join(parent_directory, "canu", "canu.yaml")
 with open(canu_config_file, "r") as canu_f:

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -21,6 +21,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 """CANU generate switch config commands."""
 from collections import defaultdict
+from importlib import metadata
 from itertools import groupby
 import json
 import logging
@@ -43,7 +44,6 @@ import natsort
 import netaddr
 from netutils.mac import is_valid_mac
 from network_modeling.NetworkNodeFactory import NetworkNodeFactory
-import pkg_resources
 import requests
 from ruamel.yaml import YAML
 from ttp import ttp
@@ -119,7 +119,7 @@ with open(canu_config_file, "r") as file:
 
 csm_options = canu_config["csm_versions"]
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = metadata.version("canu")
 
 log = logging.getLogger("generate_switch_config")
 

--- a/canu/utils/cache.py
+++ b/canu/utils/cache.py
@@ -22,6 +22,7 @@
 """Utilities to help CANU cache switch information to YAML."""
 
 import datetime
+from importlib import metadata
 from operator import itemgetter
 from os import path
 from pathlib import Path
@@ -29,7 +30,6 @@ import sys
 import tempfile
 
 import click
-import pkg_resources
 from ruamel.yaml import YAML
 
 yaml = YAML()
@@ -67,7 +67,7 @@ else:
     project_root = Path(__file__).resolve().parent.parent.parent
 
 canu_cache_file = path.join(cache_directory(), "canu_cache.yaml")
-version = pkg_resources.get_distribution("canu").version
+version = metadata.version("canu")
 file_exists = path.isfile(canu_cache_file)
 
 # Open the Cache file, and generate it if it does not exist

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -24,6 +24,7 @@
 """CANU commands that validate the shcd."""
 from collections import defaultdict
 import datetime
+from importlib import metadata
 import json
 import logging
 from os import path
@@ -37,7 +38,6 @@ from network_modeling.NetworkNodeFactory import NetworkNodeFactory
 from network_modeling.NetworkPort import NetworkPort
 from network_modeling.NodeLocation import NodeLocation
 from openpyxl import load_workbook
-import pkg_resources
 
 from canu.style import Style
 
@@ -48,7 +48,7 @@ else:
     prog = __file__
     project_root = Path(__file__).resolve().parent.parent.parent.parent
 
-version = pkg_resources.get_distribution("canu").version
+version = metadata.version("canu")
 
 log = logging.getLogger("validate_shcd")
 


### PR DESCRIPTION
Resolves deprecation warning for `pkg_resources` ([example](https://github.com/Cray-HPE/canu/actions/runs/11898762338/job/33155942357?pr=471#step:4:594)).

Does not resolve other deprecation warnings.
