### PR TITLE
One dep pr to rule them all part8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 description = 'CSM Automatic Network Utility'
 dependencies = [
-    'aiohttp==3.11.7',
+    'aiohttp==3.11.10',
     'click-help-colors==0.9.4',
     'click-option-group==0.5.6',
     'click-params==0.5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     'colorama==0.4.6',
     'emoji==2.5.0',
     'hier-config==2.2.3',
-    'ipython==8.29.0; python_version>"3.9"',
+    'ipython==8.30.0; python_version>"3.9"',
     'ipython~=8.18.1; python_version<"3.10"',
     'jinja2==3.1.4',
     'jsonschema==4.23.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     'responses==0.25.3',
     'ruamel.yaml<0.18.7',
     'tabulate==0.9.0',
-    'tomli==2.1.0',
+    'tomli==2.2.1',
     'ttp==0.9.5',
     'urllib3==2.2.3',
     'yamale<=5.2.1',


### PR DESCRIPTION
### Summary and Scope

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

Includes:
- https://github.com/Cray-HPE/canu/pull/578
- https://github.com/Cray-HPE/canu/pull/577
- https://github.com/Cray-HPE/canu/pull/575

### Issues and Related PRs

<!-- * Resolves: `Issue` --->
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
```bash
redbull-pit:/var/www/ephemeral/prep # canu --version
canu, version 1.9.6.dev58+g2fa613f
```

```bash
canu validate shcd -a tds --shcd ./Shasta\ River\ Redbull\ CCD_RevA16.xlsx --tabs 25G_10G,NMN,HMN --corners I15,Q50,I9,S10,I20,S30 --log DEBUG --json --out ccj.json
canu generate network config --ccj ccj.json --csm 1.6 --sls-file redbull/sls_input_file.json --folder generated
canu validate switch config --ip 10.254.0.2 --generated ./generated/sw-spine-001.cfg --remediation
```

Collected input and output files:
[canu-pr-579.tar.gz](https://github.com/user-attachments/files/18043492/canu-pr-579.tar.gz)
