### PR TITLE
CASMNET-2273 - CMN missing from mgmt access control list

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+## [1.9.5]
+
+- CASMNET-2273 Add the CMN to the mgmt access list to permit SSH, HTTPS, and SNMP over the CMN
+
 ## [1.9.4]
 
 - Add the ability to attach EX2500 to spines in validate.

--- a/network_modeling/configs/templates/1.5/aruba/common/acl.j2
+++ b/network_modeling/configs/templates/1.5/aruba/common/acl.j2
@@ -5,6 +5,10 @@ access-list ip mgmt
 {% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq https
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq snmp
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq snmp-trap
+{% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq ssh
+{% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq https
+{% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq snmp
+{% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq snmp-trap
 {% set sequence = sequence+10 %}    {{ sequence }} comment ALLOW SNMP FROM HMN METALLB SUBNET
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMNLB_NETWORK_IP }}/{{ variables.HMNLB_NETMASK }} any eq snmp
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMNLB_NETWORK_IP }}/{{ variables.HMNLB_NETMASK }} any eq snmp-trap

--- a/network_modeling/configs/templates/1.6/aruba/common/acl.j2
+++ b/network_modeling/configs/templates/1.6/aruba/common/acl.j2
@@ -5,6 +5,10 @@ access-list ip mgmt
 {% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq https
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq snmp
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMN_NETWORK_IP }}/{{ variables.HMN_NETMASK }} any eq snmp-trap
+{% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq ssh
+{% set sequence = sequence+10 %}    {{ sequence }} permit tcp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq https
+{% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq snmp
+{% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }} any eq snmp-trap
 {% set sequence = sequence+10 %}    {{ sequence }} comment ALLOW SNMP FROM HMN METALLB SUBNET
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMNLB_NETWORK_IP }}/{{ variables.HMNLB_NETMASK }} any eq snmp
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.HMNLB_NETWORK_IP }}/{{ variables.HMNLB_NETMASK }} any eq snmp-trap


### PR DESCRIPTION
### Summary and Scope

Add the CMN to the `mgmt` access list to permit SSH, HTTPS, and SNMP over the CMN.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `[CASMNET-2273](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2273)`
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

Generated new configuration using data from hela, verified the CMN is now present in the access list.
```
$ diff orig/sw-spine-001.cfg new/sw-spine-001.cfg
7c7
< # CANU version: 1.9.6.dev59+gd3b6bc3
---
> # CANU version: 1.9.6.dev59+gd3b6bc3.d20250106
30,39c30,43
<     60 comment ALLOW SNMP FROM HMN METALLB SUBNET
<     70 permit udp 10.94.100.0/255.255.255.0 any eq snmp
<     80 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
<     90 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
<     100 deny tcp any any eq ssh
<     110 deny tcp any any eq https
<     120 deny udp any any eq snmp
<     130 deny udp any any eq snmp-trap
<     140 comment ALLOW ANYTHING ELSE
<     150 permit any any any
---
>     60 permit tcp 10.102.66.0/255.255.255.128 any eq ssh
>     70 permit tcp 10.102.66.0/255.255.255.128 any eq https
>     80 permit udp 10.102.66.0/255.255.255.128 any eq snmp
>     90 permit udp 10.102.66.0/255.255.255.128 any eq snmp-trap
>     100 comment ALLOW SNMP FROM HMN METALLB SUBNET
>     110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
>     120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
>     130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
>     140 deny tcp any any eq ssh
>     150 deny tcp any any eq https
>     160 deny udp any any eq snmp
>     170 deny udp any any eq snmp-trap
>     180 comment ALLOW ANYTHING ELSE
>     190 permit any any any
```
