### PR TITLE
CASMNET-2317 - Add validate shcd corners and tabs to CCJ metadata

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,16 +1,28 @@
 ## Changelog
 
-## [UNRELEASED]
+### [UNRELEASED]
 
-- Add SHCD corner and tab metadata to CCJ files.
-- Fix canu test to allow configurable customer VRF.
-- Fix a logic bug in canu test for BGP which reported success despite having an underlying error.
+### [1.9.11]
 
-## [1.9.7]
+- CASMNET-2317 Add SHCD corner and tab metadata to CCJ files in https://github.com/Cray-HPE/canu/pull/649 
+
+### [1.9.10]
+
+- CASMNET-2301 Fix VRF test in https://github.com/Cray-HPE/canu/pull/633
+
+### [1.9.9]
+
+- CASMNET-2300 Update firmware versions for CSM 1.7 in https://github.com/Cray-HPE/canu/pull/637
+
+### [1.9.8]
+
+- One dep pr to rule them all11 in https://github.com/Cray-HPE/canu/pull/629
+
+### [1.9.7]
 
 - One dep pr to rule them all10 by @rustydb in https://github.com/Cray-HPE/canu/pull/606
 
-## [1.9.6]
+### [1.9.6]
 
 - One dep pr to rule them all part4 by @rustydb in https://github.com/Cray-HPE/canu/pull/532
 - Support Python 3.11 and 3.12 by @rustydb in https://github.com/Cray-HPE/canu/pull/533
@@ -30,11 +42,11 @@
 - CASMNET-2240 update ACLs to apply to default vrf by @lukebates123 in https://github.com/Cray-HPE/canu/pull/471
 - CASMNET-2273 - CMN missing from mgmt access control list by @spillerc-hpe in https://github.com/Cray-HPE/canu/pull/594
 
-## [1.9.5]
+### [1.9.5]
 
 - CASMNET-2273 Add the CMN to the mgmt access list to permit SSH, HTTPS, and SNMP over the CMN
 
-## [1.9.4]
+### [1.9.4]
 
 - Add the ability to attach EX2500 to spines in validate.
 - EX2500 configuration remain as custom configurations.
@@ -42,38 +54,38 @@
 - CASMNET-2254 Removed canu container
 - CASMNET-2253 Fixed RPM build
 
-## [1.9.3]
+### [1.9.3]
 
 - CASMNET-2233 Update Aruba device firmware
 
-## [1.9.2]
+### [1.9.2]
 
 - fixed a bug, which fails to parse an SHCD because of a poorly-named cell
 - this release halts the changelog file in favor of the github release notes associated with each tag.  manually keeping this log up-to-date is a chore and with csm entering EOL, we should focus on the fixes, not painful manual release notes
 
-## [1.9.1]
+### [1.9.1]
 
 - remove canu user going forward. permissions are now default (root) 
 - Ensure that the variable designating a switch as primary is always initialized.
 
-## [1.9.0]
+### [1.9.0]
 - Add CSM 1.6 templates
 - Fix case sensitivity when reading nodes from SHCD
 - Add Storage node support
 - Update ACLs to apply to default vrf
 
-## [1.8.0]
+### [1.8.0]
 
 - Move NMN/HMN/MTL to new vrf, move CMN/CHN/CAN to default vrf.
 - Added support for bonded application nodes.
 - Fixed exception when bad credentials provided when running `canu validate shcd-cabling`
 
-## [1.7.6]
+### [1.7.6]
 
 - Add ACL for DHCP
 - Fix CANU exit code on BGP validation
 
-## [1.7.5]
+### [1.7.5]
 
 - Disable Aruba Central in templates
 - Fix CSM 1.5 templates
@@ -81,7 +93,7 @@
 - Fix cmn ACL template
 - Bump Pyyaml
 
-## [1.7.4]
+### [1.7.4]
 
 - Updated `canu test`
 - Add CSM 1.5 dell/mellanox configs
@@ -91,21 +103,21 @@
 - added very basic integration tests via shellspec for local and github actions
 - Fix storage node lag configuration in Aruba templates to prevent loop
 
-## [1.7.3]
+### [1.7.3]
 
 - Add `force` option to generated Mellanox web and ntp configuration.
 
-## [1.7.2]
+### [1.7.2]
 
 - Bump Yamale and add pyinstaller hook file
 - Add significant testing to network_modeling and sls_utils modules and fix a couple bugs.
 - Adjust docs workflow to run during promote-release
 
-## [1.7.1]
+### [1.7.1]
 
 - rollback yamale version
 
-## [1.7.0]
+### [1.7.0]
 
 - Create baseline CSM 1.4 configuration
 - Fix error handling of the parent column for cmm/cec
@@ -649,6 +661,28 @@
 - Standardized the canu.yaml file to show currently supported switch firmware versions.
 
 [unreleased]: https://github.com/Cray-HPE/canu/tree/main 
+[1.9.10]: https://github.com/Cray-HPE/canu/tree/1.9.10
+[1.9.9]: https://github.com/Cray-HPE/canu/tree/1.9.9
+[1.9.8]: https://github.com/Cray-HPE/canu/tree/1.9.8
+[1.9.7]: https://github.com/Cray-HPE/canu/tree/1.9.7
+[1.9.6]: https://github.com/Cray-HPE/canu/tree/1.9.6
+[1.9.5]: https://github.com/Cray-HPE/canu/tree/1.9.5
+[1.9.4]: https://github.com/Cray-HPE/canu/tree/1.9.4
+[1.9.3]: https://github.com/Cray-HPE/canu/tree/1.9.3
+[1.9.2]: https://github.com/Cray-HPE/canu/tree/1.9.2
+[1.9.1]: https://github.com/Cray-HPE/canu/tree/1.9.1
+[1.9.0]: https://github.com/Cray-HPE/canu/tree/1.9.0
+[1.8.0]: https://github.com/Cray-HPE/canu/tree/1.8.0
+[1.7.6]: https://github.com/Cray-HPE/canu/tree/1.7.6
+[1.7.5]: https://github.com/Cray-HPE/canu/tree/1.7.5
+[1.7.4]: https://github.com/Cray-HPE/canu/tree/1.7.4
+[1.7.3]: https://github.com/Cray-HPE/canu/tree/1.7.3
+[1.7.2]: https://github.com/Cray-HPE/canu/tree/1.7.2
+[1.7.1]: https://github.com/Cray-HPE/canu/tree/1.7.1
+[1.7.0]: https://github.com/Cray-HPE/canu/tree/1.7.0
+[1.6.35]: https://github.com/Cray-HPE/canu/tree/1.6.35
+[1.6.34]: https://github.com/Cray-HPE/canu/tree/1.6.34
+[1.6.33]: https://github.com/Cray-HPE/canu/tree/1.6.33
 [1.6.32]: https://github.com/Cray-HPE/canu/tree/1.6.32
 [1.6.31]: https://github.com/Cray-HPE/canu/tree/1.6.31
 [1.6.30]: https://github.com/Cray-HPE/canu/tree/1.6.30
@@ -726,12 +760,6 @@
 [1.1.3]: https://github.com/Cray-HPE/canu/tree/1.1.3
 [1.1.2]: https://github.com/Cray-HPE/canu/tree/1.1.2
 [1.1.1]: https://github.com/Cray-HPE/canu/tree/1.1.1
-[0.0.6]: https://github.com/Cray-HPE/canu/tree/0.0.6
-[0.0.5]: https://github.com/Cray-HPE/canu/tree/0.0.5
-[0.0.4]: https://github.com/Cray-HPE/canu/tree/0.0.4
-[0.0.3]: https://github.com/Cray-HPE/canu/tree/0.0.3
-[0.0.2]: https://github.com/Cray-HPE/canu/tree/0.0.2
-[0.0.1]: https://github.com/Cray-HPE/canu/tree/0.0.1
 [0.0.6]: https://github.com/Cray-HPE/canu/tree/0.0.6
 [0.0.5]: https://github.com/Cray-HPE/canu/tree/0.0.5
 [0.0.4]: https://github.com/Cray-HPE/canu/tree/0.0.4

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### [1.9.11]
 
+- CASMNET-2309 Fixed BGP tests in https://github.com/Cray-HPE/canu/pull/654
 - CASMNET-2317 Add SHCD corner and tab metadata to CCJ files in https://github.com/Cray-HPE/canu/pull/649 
 
 ### [1.9.10]

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+- Add SHCD corner and tab metadata to CCJ files.
+- Fix canu test to allow configurable customer VRF.
+- Fix a logic bug in canu test for BGP which reported success despite having an underlying error.
+
 ## [1.9.7]
 
 - One dep pr to rule them all10 by @rustydb in https://github.com/Cray-HPE/canu/pull/606

--- a/canu/validate/shcd/shcd.py
+++ b/canu/validate/shcd/shcd.py
@@ -128,6 +128,7 @@ def shcd(ctx, architecture, shcd, tabs, corners, edge, out, json_, log_):
     """
     logging.basicConfig(format="%(name)s - %(levelname)s: %(message)s", level=log_)
 
+    # This should really be a lookup table in cray-network-architecture.yaml
     if architecture.lower() == "full":
         architecture = "network_v2"
     elif architecture.lower() == "tds":
@@ -153,7 +154,7 @@ def shcd(ctx, architecture, shcd, tabs, corners, edge, out, json_, log_):
     )
 
     if json_:
-        json_output(node_list, factory, architecture, shcd, out)
+        json_output(node_list, factory, architecture, ctx, out)
     else:
         print_node_list(node_list, "SHCD", out)
 
@@ -1231,7 +1232,7 @@ def print_node_list(node_list, title, out="-"):
             logical_index += 1
 
 
-def json_output(node_list, factory, architecture, shcd, out):
+def json_output(node_list, factory, architecture, ctx, out):
     """Create a schema-validated JSON Topology file from the model."""
     topology = []
     for node in node_list:
@@ -1240,7 +1241,10 @@ def json_output(node_list, factory, architecture, shcd, out):
     paddle = {
         "canu_version": version,
         "architecture": architecture,
-        "shcd_file": path.basename(shcd.name),
+        "shcd_file": path.basename(ctx.params["shcd"].name),
+        "tabs": ctx.params["tabs"],
+        "corners": ctx.params["corners"],
+        "edge": ctx.params["edge"],
         "updated_at": datetime.datetime.now().strftime(
             "%Y-%m-%d %H:%M:%S",
         ),

--- a/network_modeling/schema/paddle-schema.json
+++ b/network_modeling/schema/paddle-schema.json
@@ -11,6 +11,15 @@
         "shcd_file": {
             "type": "string"
         },
+        "tabs": {
+            "type": "string"
+        },
+        "corners": {
+            "type": "string"
+        },
+        "edge": {
+            "type": "string"
+        },
         "updated_at": {
             "type": "string"
         },

--- a/tests/data/Full_Architecture_Golden_Config_1.1.5.with_shcd_metadata.json
+++ b/tests/data/Full_Architecture_Golden_Config_1.1.5.with_shcd_metadata.json
@@ -1,0 +1,2051 @@
+{
+  "canu_version": "1.1.5~develop",
+  "architecture": "network_v2",
+  "shcd_file": "Full_Architecture_Golden_Config_1.1.5.xlsx",
+  "tabs": "25G_10G",
+  "corners": "I14,S48",
+  "edge": "Arista",
+  "updated_at": "2022-01-27 18:26:37",
+  "topology": [
+    {
+      "common_name": "sw-spine-001",
+      "id": 0,
+      "architecture": "spine",
+      "model": "8325_JL627A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 50,
+          "destination_slot": null
+        },
+        {
+          "port": 6,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 50,
+          "destination_slot": null
+        },
+        {
+          "port": 7,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 8,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 30,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 30,
+          "destination_slot": null
+        },
+        {
+          "port": 31,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 31,
+          "destination_slot": null
+        },
+        {
+          "port": 32,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 32,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-spine-002",
+      "id": 1,
+      "architecture": "spine",
+      "model": "8325_JL627A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 49,
+          "destination_slot": null
+        },
+        {
+          "port": 6,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 49,
+          "destination_slot": null
+        },
+        {
+          "port": 7,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 8,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 30,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 30,
+          "destination_slot": null
+        },
+        {
+          "port": 31,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 31,
+          "destination_slot": null
+        },
+        {
+          "port": 32,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 32,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-leaf-001",
+      "id": 2,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 7,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 8,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 9,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 10,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 51,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 48,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-leaf-002",
+      "id": 3,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 6,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 7,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 8,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 9,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 10,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 51,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-leaf-003",
+      "id": 4,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 4,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 6,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 7,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 8,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 9,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 10,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 52,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-leaf-004",
+      "id": 5,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 4,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 6,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 7,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 8,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 9,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 10,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 52,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-cdu-001",
+      "id": 6,
+      "architecture": "mountain_compute_leaf",
+      "model": "8360_JL706A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 31,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 32,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 33,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 34,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 35,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 48,
+          "destination_slot": null
+        },
+        {
+          "port": 49,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 50,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 51,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 52,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-cdu-002",
+      "id": 7,
+      "architecture": "mountain_compute_leaf",
+      "model": "8360_JL706A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 32,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 33,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 34,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 35,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 48,
+          "destination_slot": null
+        },
+        {
+          "port": 49,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 50,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 51,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 52,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u39"
+      }
+    },
+    {
+      "common_name": "sw-edge-001",
+      "id": 8,
+      "architecture": "customer_edge_router",
+      "model": "customer_edge_router",
+      "type": "switch",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 7,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3003",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-edge-002",
+      "id": 9,
+      "architecture": "customer_edge_router",
+      "model": "customer_edge_router",
+      "type": "switch",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 8,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3003",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-leaf-bmc-001",
+      "id": 10,
+      "architecture": "river_bmc_leaf",
+      "model": "6300M_JL762A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 3,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 4,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 5,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 6,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 7,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 8,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 9,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 10,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 11,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 12,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 24,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 13,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 25,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 14,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 15,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 16,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 28,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 17,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 29,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 18,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 30,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 19,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 20,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 24,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 1,
+          "destination_slot": "onboard"
+        },
+        {
+          "port": 25,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 24,
+          "destination_port": 1,
+          "destination_slot": "onboard"
+        },
+        {
+          "port": 26,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 25,
+          "destination_port": 1,
+          "destination_slot": "onboard"
+        },
+        {
+          "port": 27,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 1,
+          "destination_slot": "onboard"
+        },
+        {
+          "port": 28,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 47,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 51,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u37"
+      }
+    },
+    {
+      "common_name": "ncn-m001",
+      "id": 11,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u36"
+      }
+    },
+    {
+      "common_name": "ncn-m002",
+      "id": 12,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u35"
+      }
+    },
+    {
+      "common_name": "ncn-m003",
+      "id": 13,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u36"
+      }
+    },
+    {
+      "common_name": "ncn-w001",
+      "id": 14,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 3,
+          "destination_port": 6,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u34"
+      }
+    },
+    {
+      "common_name": "ncn-w002",
+      "id": 15,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 5,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u35"
+      }
+    },
+    {
+      "common_name": "ncn-w003",
+      "id": 16,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 5,
+          "destination_port": 4,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u34"
+      }
+    },
+    {
+      "common_name": "ncn-s001",
+      "id": 17,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 8,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u33"
+      }
+    },
+    {
+      "common_name": "ncn-s002",
+      "id": 18,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 2,
+          "destination_port": 10,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 3,
+          "destination_port": 10,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u32"
+      }
+    },
+    {
+      "common_name": "ncn-s003",
+      "id": 19,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 6,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u33"
+      }
+    },
+    {
+      "common_name": "uan001",
+      "id": 20,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 10,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 8,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u32"
+      }
+    },
+    {
+      "common_name": "lm001",
+      "id": 21,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 20,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 4,
+          "destination_port": 10,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "pcie-slot1",
+          "destination_node_id": 5,
+          "destination_port": 10,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u30"
+      }
+    },
+    {
+      "common_name": "gateway001",
+      "id": 22,
+      "architecture": "river_ncn_node_4_port_1g_ocp",
+      "model": "river_ncn_node_4_port_1g_ocp",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 10,
+          "destination_port": 28,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 19,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u30"
+      }
+    },
+    {
+      "common_name": "cn001",
+      "id": 23,
+      "architecture": "river_compute_node",
+      "model": "river_compute_node",
+      "type": "node",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "onboard",
+          "destination_node_id": 10,
+          "destination_port": 24,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 11,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u15"
+      }
+    },
+    {
+      "common_name": "cn002",
+      "id": 24,
+      "architecture": "river_compute_node",
+      "model": "river_compute_node",
+      "type": "node",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "onboard",
+          "destination_node_id": 10,
+          "destination_port": 25,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 12,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u16"
+      }
+    },
+    {
+      "common_name": "cn003",
+      "id": 25,
+      "architecture": "river_compute_node",
+      "model": "river_compute_node",
+      "type": "node",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "onboard",
+          "destination_node_id": 10,
+          "destination_port": 26,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 13,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u17"
+      }
+    },
+    {
+      "common_name": "cn004",
+      "id": 26,
+      "architecture": "river_compute_node",
+      "model": "river_compute_node",
+      "type": "node",
+      "vendor": "none",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "onboard",
+          "destination_node_id": 10,
+          "destination_port": 27,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 14,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u18"
+      }
+    },
+    {
+      "common_name": "pdu-x3000-000",
+      "id": 27,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 15,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u1"
+      }
+    },
+    {
+      "common_name": "pdu-x3000-001",
+      "id": 28,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 16,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u1"
+      }
+    },
+    {
+      "common_name": "pdu-x3001-000",
+      "id": 29,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 17,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u1"
+      }
+    },
+    {
+      "common_name": "pdu-x3001-001",
+      "id": 30,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 10,
+          "destination_port": 18,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3001",
+        "elevation": "u1"
+      }
+    },
+    {
+      "common_name": "cec-x3002-000",
+      "id": 31,
+      "architecture": "cec",
+      "model": "cec",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u38"
+      }
+    },
+    {
+      "common_name": "cmm-x3002-000",
+      "id": 32,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 2,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u37"
+      }
+    },
+    {
+      "common_name": "cmm-x3002-001",
+      "id": 33,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u36"
+      }
+    },
+    {
+      "common_name": "cmm-x3002-002",
+      "id": 34,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 4,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u35"
+      }
+    },
+    {
+      "common_name": "cmm-x3002-003",
+      "id": 35,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 5,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3002",
+        "elevation": "u34"
+      }
+    }
+  ]
+}

--- a/tests/test_validate_paddle.py
+++ b/tests/test_validate_paddle.py
@@ -31,6 +31,8 @@ from canu.cli import cli
 test_file_directory = Path(__file__).resolve().parent
 test_file_name = "Full_Architecture_Golden_Config_1.1.5.json"
 test_file = path.join(test_file_directory, "data", test_file_name)
+test_file_with_metadata_name = "Full_Architecture_Golden_Config_1.1.5.with_shcd_metadata.json"
+test_file_with_metadata = path.join(test_file_directory, "data", test_file_with_metadata_name)
 cache_minutes = 0
 runner = testing.CliRunner()
 
@@ -48,6 +50,64 @@ def test_validate_paddle():
                 "paddle",
                 "--ccj",
                 test_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert (
+            "CCJ Node Connections\n"
+            "------------------------------------------------------------\n"
+            "0: sw-spine-001 connects to 11 nodes: [2, 3, 4, 5, 6, 7, 8, 9, 1, 1, 1]\n"
+            "1: sw-spine-002 connects to 11 nodes: [2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0]\n"
+            "2: sw-leaf-001 connects to 13 nodes: [11, 12, 14, 17, 17, 18, 18, 10, 1, 0, 3, 3, 3]\n"
+            "3: sw-leaf-002 connects to 13 nodes: [11, 12, 14, 17, 17, 18, 18, 10, 1, 0, 2, 2, 2]\n"
+            "4: sw-leaf-003 connects to 14 nodes: [13, 15, 16, 19, 19, 20, 20, 21, 21, 1, 0, 5, 5, 5]\n"
+            "5: sw-leaf-004 connects to 14 nodes: [13, 15, 16, 19, 19, 20, 20, 21, 21, 1, 0, 4, 4, 4]\n"
+            "6: sw-cdu-001 connects to 10 nodes: [31, 32, 33, 34, 35, 7, 1, 0, 7, 7]\n"
+            "7: sw-cdu-002 connects to 9 nodes: [32, 33, 34, 35, 6, 1, 0, 6, 6]\n"
+            "8: sw-edge-001 connects to 2 nodes: [0, 1]\n"
+            "9: sw-edge-002 connects to 2 nodes: [0, 1]\n"
+            "10: sw-leaf-bmc-001 connects to 27 nodes: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 23, 24, 25, 26, 27, 28, 29, 30, 22, 21, 23, 24, 25, 26, 22, 3, 2]\n"  # noqa: B950
+            "11: ncn-m001 connects to 3 nodes: [10, 2, 3]\n"
+            "12: ncn-m002 connects to 3 nodes: [10, 2, 3]\n"
+            "13: ncn-m003 connects to 3 nodes: [10, 4, 5]\n"
+            "14: ncn-w001 connects to 3 nodes: [10, 2, 3]\n"
+            "15: ncn-w002 connects to 3 nodes: [10, 4, 5]\n"
+            "16: ncn-w003 connects to 3 nodes: [10, 4, 5]\n"
+            "17: ncn-s001 connects to 5 nodes: [10, 2, 2, 3, 3]\n"
+            "18: ncn-s002 connects to 5 nodes: [10, 2, 2, 3, 3]\n"
+            "19: ncn-s003 connects to 5 nodes: [10, 4, 4, 5, 5]\n"
+            "20: uan001 connects to 5 nodes: [10, 4, 4, 5, 5]\n"
+            "21: lm001 connects to 5 nodes: [10, 4, 4, 5, 5]\n"
+            "22: gateway001 connects to 2 nodes: [10, 10]\n"
+            "23: cn001 connects to 2 nodes: [10, 10]\n"
+            "24: cn002 connects to 2 nodes: [10, 10]\n"
+            "25: cn003 connects to 2 nodes: [10, 10]\n"
+            "26: cn004 connects to 2 nodes: [10, 10]\n"
+            "27: pdu-x3000-000 connects to 1 nodes: [10]\n"
+            "28: pdu-x3000-001 connects to 1 nodes: [10]\n"
+            "29: pdu-x3001-000 connects to 1 nodes: [10]\n"
+            "30: pdu-x3001-001 connects to 1 nodes: [10]\n"
+            "31: cec-x3002-000 connects to 1 nodes: [6]\n"
+            "32: cmm-x3002-000 connects to 2 nodes: [6, 7]\n"
+            "33: cmm-x3002-001 connects to 2 nodes: [6, 7]\n"
+            "34: cmm-x3002-002 connects to 2 nodes: [6, 7]\n"
+            "35: cmm-x3002-003 connects to 2 nodes: [6, 7]\n"
+        ) in str(result.output)
+
+
+def test_validate_paddle_with_shcd_metadata():
+    """Test that the `canu validate paddle` command runs and returns valid cabling."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "validate",
+                "paddle",
+                "--ccj",
+                test_file_with_metadata,
             ],
         )
         assert result.exit_code == 0


### PR DESCRIPTION
### Summary and Scope

A CCJ/paddle file includes information to reconstitute the topology of a management network.  Previously the originating SHCD and the CANU version were added to the CCJ metadata as convenience information to human users.  This change adds the tabs and corners and edge router information used in generating the CCJ. This information is optional, but helpful when one looks at a CCJ after much time has passed.

- [x] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CASMNET-2317`

### Testing

- Tested with Creek internal system data.