### PR TITLE
CASMNET-2319 - Allow retrieval and setting of system default route.

### DIFF
--- a/canu/utils/sls_utils/Networks.py
+++ b/canu/utils/sls_utils/Networks.py
@@ -252,7 +252,7 @@ class BicanNetwork(Network):
         self.mtu(network_mtu=9000)
 
     def system_default_route(self, default_route=None):
-        """Default Route for the System.
+        """Retrieve and set the default route for the system.
 
         Args:
             default_route (str): CHN, CAN, or CMN

--- a/canu/utils/sls_utils/Networks.py
+++ b/canu/utils/sls_utils/Networks.py
@@ -251,6 +251,19 @@ class BicanNetwork(Network):
         self.__system_default_route = default_route_network_name
         self.mtu(network_mtu=9000)
 
+    def system_default_route(self, default_route=None):
+        """Default Route for the System.
+
+        Args:
+            default_route (str): CHN, CAN, or CMN
+
+        Returns:
+            name (str): Short name of the network for the getter
+        """
+        if default_route is not None:
+            self.__system_default_route = default_route
+        return self.__system_default_route
+
     def to_sls(self):
         """Serialize the Network to SLS Networks format.
 

--- a/tests/test_sls_utils_networks.py
+++ b/tests/test_sls_utils_networks.py
@@ -189,6 +189,7 @@ def test_bican_network_init():
     assert bican.mtu() == 9000
     bican_sls = bican.to_sls()
     assert bican_sls["ExtraProperties"]["SystemDefaultRoute"] == "CMN"
+    assert bican.system_default_route() == "CMN"
 
 
 def test_subnet_init(subnet_data):


### PR DESCRIPTION
### Summary and Scope

Previously SLS Utils read in the system default route, but didn't allow official get and set off the value.  This changes adds access to the `system_default_route`.

- [x] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CASMNET-2319`

### Testing

* Nox test added here.