### PR TITLE
CASMNET-2309-fixed BGP tests

### DIFF
--- a/canu/test/aruba/bgp_test.py
+++ b/canu/test/aruba/bgp_test.py
@@ -23,12 +23,13 @@
 from ttp import ttp
 
 
-def bgp_config(result, vlan_ips):
+def bgp_config(result, vlan_ips, vrf):
     """Verify NCN-W IPs in SLS are BGP neighbors on the switch.
 
     Args:
         result: show run bgp
         vlan_ips: list of NCN and Switch IPs
+        vrf: Named VRF used for CSM networks
 
     Returns:
         Pass or fail
@@ -83,7 +84,7 @@ router bgp {{ asn }}
 
     # Get BGP peers from switch config
     bgp_peers = {}
-    bgp_peers.update(output[0][0]["bgp_cfg"]["vrfs"]["Customer"]["peers"])
+    bgp_peers.update(output[0][0]["bgp_cfg"]["vrfs"][vrf]["peers"])
     bgp_peers.update(output[0][0]["bgp_cfg"]["vrfs"]["default"]["peers"])
 
     # Get the worker nodes CMN and NMN IPs

--- a/canu/test/aruba/test_suite.yaml
+++ b/canu/test/aruba/test_suite.yaml
@@ -201,11 +201,11 @@
   device:
     - spine
 
-- name: BGP vrf Customer Routing Table
-  task: show ip route bgp vrf Customer
-  test: ncontains
-  pattern: No ipv4 routes configured
-  err_msg: There are no BGP routes in the Customer VRF routing table.
+- name: BGP vrf '{{variables.CSM_VRF}}' Routing Table
+  task: show ip route bgp vrf {{variables.CSM_VRF}}
+  test: contains
+  pattern: Displaying ipv4 routes selected for forwarding
+  err_msg: There are no BGP routes in the '{{variables.CSM_VRF}}' VRF routing table or there is a configuration error
   device:
     - spine
 

--- a/canu/test/aruba/vlan_interface_test.py
+++ b/canu/test/aruba/vlan_interface_test.py
@@ -23,12 +23,13 @@
 from ttp import ttp
 
 
-def vlan_interface_config(result, vlan_ips):
+def vlan_interface_config(result, vlan_ips, vrf=None):
     """Verify the switch VLAN IPs match SLS.
 
     Args:
         result: show run
         vlan_ips: list of NCN and Switch IPs
+        vrf: Named VRF used for CSM networks
 
     Returns:
         Pass or fail

--- a/canu/test/test.py
+++ b/canu/test/test.py
@@ -348,7 +348,7 @@ def test(
                         )
                         # Update the dictionary entry
                         test_command["function_file"] = test_path
-                        test_command["function_kwargs"] = {"vlan_ips": vlan_ips}
+                        test_command["function_kwargs"] = {"vlan_ips": vlan_ips, "vrf": vrf}
 
                 elif switch in devices and isinstance(test_command["task"], list):
                     switch_commands.extend(test_command["task"])


### PR DESCRIPTION
### Summary and Scope
This PR fixes the key error observed while running BGP tests by adding customized VRF name

### Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMNET-2309
### Testing

<!-- How was this change tested? --->

Tested on surtur spine switch