### PR TITLE
CASMNET-2332-adding csm 1.7 templates

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -193,6 +193,34 @@ added_files += [
         "network_modeling/configs/templates/1.6/dellmellanox/full/*.j2",
         "network_modeling/configs/templates/1.6/dellmellanox/full",
     ),
+    (
+        "network_modeling/configs/templates/1.7/arista/*.j2",
+        "network_modeling/configs/templates/1.7/arista",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/aruba/common/*.j2",
+        "network_modeling/configs/templates/1.7/aruba/common",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/aruba/*.j2",
+        "network_modeling/configs/templates/1.7/aruba/",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/aruba/full/*.j2",
+        "network_modeling/configs/templates/1.7/aruba/full",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/aruba/tds/*.j2",
+        "network_modeling/configs/templates/1.7/aruba/tds",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/dellmellanox/common/*.j2",
+        "network_modeling/configs/templates/1.7/dellmellanox/common",
+    ),
+    (
+        "network_modeling/configs/templates/1.7/dellmellanox/full/*.j2",
+        "network_modeling/configs/templates/1.7/dellmellanox/full",
+    ),
 ]
 a = Analysis(
     ["canu/cli.py"],


### PR DESCRIPTION
### Summary and Scope

The CSM 1.7 templates has been to the pyinstaller.py file similar to how they have been for CSM 1.6 in this fix. 

<!-- What does this change do? --->

- [ ] I have added new tests to cover the new code
- [x] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMNET-2332

### Testing

