### PR TITLE
CASMNET-2334 - Refactor generated config testing starting with CSM 1.5 configs

### DIFF
--- a/tests/data/golden_configs/full_configs_1.5/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.5/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.5/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-leaf-bmc-001.cfg
@@ -1,0 +1,464 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-spine-001.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:53<==sw-spine-001
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.5/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.5/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.6/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.6/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-leaf-bmc-001.cfg
@@ -1,0 +1,464 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-spine-001.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:53<==sw-spine-001
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.6/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.6/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.7/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001.cfg
@@ -1,0 +1,464 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-001.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:53<==sw-spine-001
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-leaf-bmc-001.cfg
@@ -1,0 +1,449 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+
+hostname sw-leaf-bmc-001
+vrf CSM
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-spine-001.cfg
@@ -1,0 +1,391 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.185
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.186/30
+#   exit
+# interface 1/1/1
+#   ip address 10.103.15.10/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-001
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-001
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.186/30
+    exit
+interface 1/1/1
+    no shutdown
+    ip address 10.103.15.10/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-001
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.185
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.3 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.2
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.3 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.3 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.5/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.5/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.189
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.190/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-002
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-002
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.190/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-002
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.189
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.2 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.3
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.2 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.2 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-003.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-003.cfg
@@ -1,0 +1,332 @@
+
+hostname sw-leaf-003
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-leaf-003
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-leaf-003
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-leaf-003
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-leaf-003
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-leaf-003
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-leaf-003
+    lag 6
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-leaf-003
+    lag 8
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-leaf-003
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:3<==sw-leaf-003
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:3<==sw-leaf-003
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.6/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.6/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.6/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.6/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.6/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.6
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.6
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-004.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-004.cfg
@@ -1,0 +1,330 @@
+
+hostname sw-leaf-004
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-leaf-004
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-leaf-004
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    lag 6
+
+interface 1/1/7
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    lag 8
+interface 1/1/9
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:4<==sw-leaf-004
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:4<==sw-leaf-004
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.7/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.7/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.7/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.7/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.7/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.7
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.7
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-leaf-bmc-001.cfg
@@ -1,0 +1,449 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+
+hostname sw-leaf-bmc-001
+vrf CSM
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-spine-001.cfg
@@ -1,0 +1,391 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.185
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.186/30
+#   exit
+# interface 1/1/1
+#   ip address 10.103.15.10/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-001
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-001
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.186/30
+    exit
+interface 1/1/1
+    no shutdown
+    ip address 10.103.15.10/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-001
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.185
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.3 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.2
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.3 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.3 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.6/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.6/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.189
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.190/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-002
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-002
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.190/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-002
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.189
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.2 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.3
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.2 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.2 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
@@ -1,0 +1,329 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001.cfg
@@ -1,0 +1,449 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+
+hostname sw-leaf-bmc-001
+vrf CSM
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001.cfg
@@ -1,0 +1,391 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.185
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.186/30
+#   exit
+# interface 1/1/1
+#   ip address 10.103.15.10/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-001
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-001
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.186/30
+    exit
+interface 1/1/1
+    no shutdown
+    ip address 10.103.15.10/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-001
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.185
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.3 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.2
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.3 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.3 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002.cfg
@@ -1,0 +1,389 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.189
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.190/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-002
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-002
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.190/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-002
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.189
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.2 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.3
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.2 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.2 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/tds_configs_1.5/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:50<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:50<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.5/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:49<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:49<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.5/sw-edge-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.5/sw-edge-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.5/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-leaf-bmc-001.cfg
@@ -1,0 +1,454 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 101
+    no shutdown
+    description leaf_bmc_to_spine_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-spine-002:51<==sw-leaf-bmc-001
+    lag 101
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-spine-001:51<==sw-leaf-bmc-001
+    lag 101
+
+interface 1/1/19
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.5/sw-spine-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-spine-001.cfg
@@ -1,0 +1,605 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-spine-001
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-spine-001
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-spine-001
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-spine-001
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-spine-001
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-spine-001
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-spine-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-spine-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-spine-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-spine-001
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-spine-001
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-spine-001
+    lag 12
+
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-spine-001
+    lag 14
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-spine-001
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.5/sw-spine-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.5/sw-spine-002.cfg
@@ -1,0 +1,603 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.5
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-spine-002
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-spine-002
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-spine-002
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    lag 12
+
+interface 1/1/13
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-spine-002
+    lag 14
+interface 1/1/15
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.6/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:50<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:50<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.6/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:49<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:49<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.6/sw-edge-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.6/sw-edge-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.6/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-leaf-bmc-001.cfg
@@ -1,0 +1,454 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 101
+    no shutdown
+    description leaf_bmc_to_spine_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-spine-002:51<==sw-leaf-bmc-001
+    lag 101
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-spine-001:51<==sw-leaf-bmc-001
+    lag 101
+
+interface 1/1/19
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.6/sw-spine-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-spine-001.cfg
@@ -1,0 +1,605 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-spine-001
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-spine-001
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-spine-001
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-spine-001
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-spine-001
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-spine-001
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-spine-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-spine-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-spine-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-spine-001
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-spine-001
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-spine-001
+    lag 12
+
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-spine-001
+    lag 14
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-spine-001
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.6/sw-spine-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.6/sw-spine-002.cfg
@@ -1,0 +1,603 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.6
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-spine-002
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-spine-002
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-spine-002
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    lag 12
+
+interface 1/1/13
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-spine-002
+    lag 14
+interface 1/1/15
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001.cfg
@@ -1,0 +1,282 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:50<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:50<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002.cfg
@@ -1,0 +1,274 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:49<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:49<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-edge-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-edge-001.cfg
@@ -1,0 +1,88 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.7/sw-edge-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-edge-002.cfg
@@ -1,0 +1,86 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+ip routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
@@ -1,0 +1,454 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 101
+    no shutdown
+    description leaf_bmc_to_spine_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-spine-002:51<==sw-leaf-bmc-001
+    lag 101
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-spine-001:51<==sw-leaf-bmc-001
+    lag 101
+
+interface 1/1/19
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-001.cfg
@@ -1,0 +1,605 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-spine-001
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-spine-001
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-spine-001
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-spine-001
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-spine-001
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-spine-001
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-spine-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-spine-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-spine-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-spine-001
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-spine-001
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-spine-001
+    lag 12
+
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-spine-001
+    lag 14
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-spine-001
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-002.cfg
@@ -1,0 +1,603 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.9
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh
+    70 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    100 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    140 deny tcp any any eq ssh
+    150 deny tcp any any eq https
+    160 deny udp any any eq snmp
+    170 deny udp any any eq snmp-trap
+    180 comment ALLOW ANYTHING ELSE
+    190 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-spine-002
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-spine-002
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-spine-002
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    lag 12
+
+interface 1/1/13
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-spine-002
+    lag 14
+interface 1/1/15
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_5.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_5.py
@@ -1,0 +1,2143 @@
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU generate switch config commands."""
+import json
+from os import path
+from pathlib import Path
+
+from click import testing
+import pkg_resources
+import requests
+import responses
+
+from canu.cli import cli
+
+test_file_directory = Path(__file__).resolve().parent
+
+test_file_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
+test_file = path.join(test_file_directory, "data", test_file_name)
+custom_file_name = "aruba_custom.yaml"
+custom_file = path.join(test_file_directory, "data", custom_file_name)
+architecture = "full"
+tabs = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners = "J14,T44,J14,T53,J14,T34,J14,T27"
+sls_file_name = "sls_input_file_csm_1.2.json"
+sls_file = path.join(test_file_directory, "data", sls_file_name)
+
+csm = "1.2"
+switch_name = "sw-spine-001"
+cache_minutes = 0
+sls_address = "api-gw-service-nmn.local"
+
+test_file_name_tds = "TDS_Architecture_Golden_Config_1.1.5.xlsx"
+test_file_tds = path.join(test_file_directory, "data", test_file_name_tds)
+architecture_tds = "TDS"
+tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
+
+canu_version = pkg_resources.get_distribution("canu").version
+banner_motd = (
+    "banner exec !\n"
+    "###############################################################################\n"
+    f"# CSM version:  {csm}\n"
+    f"# CANU version: {canu_version}\n"
+    "###############################################################################\n"
+    "!\n"
+)
+
+runner = testing.CliRunner()
+
+
+def test_switch_config_csi_file_missing():
+    """Test that the `canu generate switch config` command errors on sls_file.json file missing."""
+    bad_sls_file = "/bad_file.json"
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                bad_sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 2
+        assert "No such file or directory" in str(result.output)
+
+
+def test_switch_config_missing_file():
+    """Test that the `canu generate switch config` command fails on missing file."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 2
+
+        assert (
+            "Error: Missing one of the required mutually exclusive options from 'Network input source' option group:\n"
+            "  '--ccj'\n"
+            "  '--shcd'\n"
+        ) in str(result.output)
+
+
+def test_switch_config_bad_file():
+    """Test that the `canu generate switch config` command fails on bad file."""
+    bad_file = "does_not_exist.xlsx"
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                bad_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 2
+        assert "Error: Invalid value for '--shcd':" in str(result.output)
+
+
+def test_switch_config_missing_tabs():
+    """Test that the `canu generate switch config` command prompts for missing tabs."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+            ],
+            input="SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES\n",
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-001" in str(result.output)
+
+
+def test_switch_config_bad_tab():
+    """Test that the `canu generate switch config` command fails on bad tab name."""
+    bad_tab = "BAD_TAB_NAME"
+    bad_tab_corners = "I14,S48"
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                bad_tab,
+                "--corners",
+                bad_tab_corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 1
+        assert f"Tab BAD_TAB_NAME not found in {test_file}" in str(result.output)
+
+
+def test_switch_config_switch_name_prompt():
+    """Test that the `canu generate switch config` command prompts for missing switch name."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+            ],
+            input="sw-spine-001\n",
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-001" in str(result.output)
+        assert "ntp server 192.168.4.4" in str(result.output)
+        assert "ntp server 192.168.4.5" in str(result.output)
+        assert "ntp server 192.168.4.6" in str(result.output)
+        assert "deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0" in str(
+            result.output,
+        )
+        assert "interface 1/1/30" in str(result.output)
+        assert "interface 1/1/31" in str(result.output)
+        assert "interface 1/1/32" in str(result.output)
+
+
+def test_switch_config_corner_prompt():
+    """Test that the `canu generate switch config` command prompts for corner input and runs."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+            input="J14\nT42\nJ14\nT48\nJ14\nT24\nJ14\nT23",
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-001" in str(result.output)
+        assert "ntp server 192.168.4.4" in str(result.output)
+        assert "ntp server 192.168.4.5" in str(result.output)
+        assert "ntp server 192.168.4.6" in str(result.output)
+        assert "deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0" in str(
+            result.output,
+        )
+        assert "interface 1/1/30" in str(result.output)
+        assert "interface 1/1/31" in str(result.output)
+        assert "interface 1/1/32" in str(result.output)
+
+
+def test_switch_config_not_enough_corners():
+    """Test that the `canu generate switch config` command fails on not enough corners."""
+    not_enough_corners = "H16"
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                not_enough_corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "There were 1 corners entered, but there should be 8." in str(
+            result.output,
+        )
+
+
+def test_switch_config_bad_switch_name_1():
+    """Test that the `canu generate switch config` command fails on bad switch name."""
+    bad_name_1 = "sw-bad"
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                bad_name_1,
+            ],
+        )
+        assert result.exit_code == 1
+
+        assert (
+            f"For switch {bad_name_1}, the type cannot be determined. Please check the switch name and try again."
+            in str(result.output)
+        )
+
+
+def test_switch_config_bad_switch_name_2():
+    """Test that the `canu generate switch config` command fails on bad switch name."""
+    bad_name_2 = "sw-spine-999"
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                bad_name_2,
+            ],
+        )
+        assert result.exit_code == 1
+
+        assert (
+            f"For switch {bad_name_2}, the type cannot be determined. Please check the switch name and try again."
+            in str(result.output)
+        )
+
+
+def test_switch_config_non_switch():
+    """Test that the `canu generate switch config` command fails on non switch."""
+    non_switch = "ncn-w001"
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                non_switch,
+            ],
+        )
+        assert result.exit_code == 1
+
+        assert (
+            f"{non_switch} is not a switch. Only switch config can be generated."
+            in str(result.output)
+        )
+
+
+@responses.activate
+def test_switch_config_sls():
+    """Test that the `canu generate switch config` command runs with SLS."""
+    with runner.isolated_filesystem():
+
+        with open(sls_file, "r") as read_file:
+            sls_data = json.load(read_file)
+
+        sls_networks = [
+            network[x] for network in [sls_data.get("Networks", {})] for x in network
+        ]
+
+        responses.add(
+            responses.GET,
+            f"https://{sls_address}/apis/sls/v1/networks",
+            json=sls_networks,
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-001" in str(result.output)
+        assert "ntp server 192.168.4.4" in str(result.output)
+        assert "ntp server 192.168.4.5" in str(result.output)
+        assert "ntp server 192.168.4.6" in str(result.output)
+        assert "deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0" in str(
+            result.output,
+        )
+        assert "interface 1/1/30" in str(result.output)
+        assert "interface 1/1/31" in str(result.output)
+        assert "interface 1/1/32" in str(result.output)
+
+
+@responses.activate
+def test_switch_config_sls_token_bad():
+    """Test that the `canu generate switch config` command errors on bad token file."""
+    bad_token = "bad_token.token"
+    with runner.isolated_filesystem():
+        with open(bad_token, "w") as f:
+            f.write('{"access_token": "123"}')
+
+        responses.add(
+            responses.GET,
+            f"https://{sls_address}/apis/sls/v1/networks",
+            body=requests.exceptions.HTTPError(
+                "503 Server Error: Service Unavailable for url",
+            ),
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--name",
+                switch_name,
+                "--auth-token",
+                bad_token,
+            ],
+        )
+        assert result.exit_code == 0
+
+        assert (
+            "Error connecting SLS api-gw-service-nmn.local, check that the token is valid, or generate a new one"
+            in str(result.output)
+        )
+
+
+@responses.activate
+def test_switch_config_sls_token_missing():
+    """Test that the `canu generate switch config` command errors on no token file."""
+    bad_token = "no_token.token"
+
+    result = runner.invoke(
+        cli,
+        [
+            "--cache",
+            cache_minutes,
+            "generate",
+            "switch",
+            "config",
+            "--csm",
+            csm,
+            "--architecture",
+            architecture,
+            "--shcd",
+            test_file,
+            "--tabs",
+            tabs,
+            "--corners",
+            corners,
+            "--name",
+            switch_name,
+            "--auth-token",
+            bad_token,
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Invalid token file, generate another token or try again." in str(
+        result.output,
+    )
+
+
+@responses.activate
+def test_switch_config_sls_address_bad():
+    """Test that the `canu generate switch config` command errors with bad SLS address."""
+    bad_sls_address = "192.168.254.254"
+
+    responses.add(
+        responses.GET,
+        f"https://{bad_sls_address}/apis/sls/v1/networks",
+        body=requests.exceptions.ConnectionError(
+            "Failed to establish a new connection: [Errno 51] Network is unreachable",
+        ),
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "--cache",
+            cache_minutes,
+            "generate",
+            "switch",
+            "config",
+            "--csm",
+            csm,
+            "--architecture",
+            architecture,
+            "--shcd",
+            test_file,
+            "--tabs",
+            tabs,
+            "--corners",
+            corners,
+            "--name",
+            switch_name,
+            "--sls-address",
+            bad_sls_address,
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        "Error connecting to SLS 192.168.254.254, check the address or pass in a new address using --sls-address."
+        in str(result.output)
+    )
+
+
+# TDS Tests
+
+
+def test_switch_config_tds_spine_primary():
+    """Test that the `canu generate switch config` command runs and returns valid TDS primary spine config."""
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-001\n" in str(result.output)
+        assert banner_motd in str(result.output)
+
+        assert (
+            "no ip icmp redirect\n"
+            + "vrf Customer\n"
+            + "vrf keepalive\n"
+            + "ntp server 192.168.4.4\n"
+            + "ntp server 192.168.4.5\n"
+            + "ntp server 192.168.4.6\n"
+            + "ntp enable\n"
+        ) in str(result.output)
+
+        assert (
+            "ssh server vrf Customer\n"
+            + "ssh server vrf default\n"
+            + "ssh server vrf keepalive\n"
+            + "ssh server vrf mgmt\n"
+            + "access-list ip mgmt\n"
+            + "    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN\n"
+            + "    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh\n"
+            + "    30 permit tcp 192.168.0.0/255.255.128.0 any eq https\n"
+            + "    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp\n"
+            + "    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap\n"
+            + "    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh\n"
+            + "    70 permit tcp 192.168.12.0/255.255.255.0 any eq https\n"
+            + "    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp\n"
+            + "    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap\n"
+            + "    100 comment ALLOW SNMP FROM HMN METALLB SUBNET\n"
+            + "    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp\n"
+            + "    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap\n"
+            + "    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE\n"
+            + "    140 deny tcp any any eq ssh\n"
+            + "    150 deny tcp any any eq https\n"
+            + "    160 deny udp any any eq snmp\n"
+            + "    170 deny udp any any eq snmp-trap\n"
+            + "    180 comment ALLOW ANYTHING ELSE\n"
+            + "    190 permit any any any\n"
+            + "access-list ip nmn-hmn\n"
+            + "    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    90 permit any any any\n"
+            + "access-list ip cmn-can\n"
+            + "    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0\n"
+            + "    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0\n"
+            + "    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    50 permit any any any\n"
+            + "apply access-list ip mgmt control-plane vrf default\n"
+            + "\n"
+            + "vlan 1\n"
+            + "vlan 2\n"
+            + "    name NMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 4\n"
+            + "    name HMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 6\n"
+            + "    name CMN\n"
+            + "vlan 7\n"
+            + "    name CAN\n"
+            + "vlan 10\n"
+            + "    name SUN\n"
+            + "spanning-tree\n"
+            + "spanning-tree forward-delay 4\n"
+            + "spanning-tree priority 0\n"
+            + "spanning-tree config-name MST0\n"
+            + "spanning-tree config-revision 1\n"
+            + "interface mgmt\n"
+            + "    shutdown\n"
+            + "    ip dhcp\n"
+        ) in str(result.output)
+
+        ncn_m = (
+            "interface lag 1 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m001:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/1\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m001:ocp:1<==sw-spine-001\n"
+            + "    lag 1\n"
+            + "\n"
+            + "interface lag 2 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m002:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/2\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m002:ocp:1<==sw-spine-001\n"
+            + "    lag 2\n"
+            + "\n"
+            + "interface lag 3 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m003:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/3\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m003:ocp:1<==sw-spine-001\n"
+            + "    lag 3\n"
+        )
+
+        assert ncn_m in str(result.output)
+
+        ncn_w = (
+            "interface lag 4 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w001:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/4\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w001:ocp:1<==sw-spine-001\n"
+            + "    lag 4\n"
+            + "\n"
+            + "interface lag 5 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w002:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/5\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w002:ocp:1<==sw-spine-001\n"
+            + "    lag 5\n"
+            + "\n"
+            + "interface lag 6 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w003:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/6\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w003:ocp:1<==sw-spine-001\n"
+            + "    lag 6\n"
+        )
+
+        assert ncn_w in str(result.output)
+
+        ncn_s = (
+            "interface lag 7 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s001:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/7\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s001:ocp:1<==sw-spine-001\n"
+            + "    lag 7\n"
+            + "\n"
+            + "interface lag 8 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s001:ocp:2<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/8\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s001:ocp:2<==sw-spine-001\n"
+            + "    lag 8\n"
+            + "\n"
+            + "interface lag 9 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s002:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/9\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s002:ocp:1<==sw-spine-001\n"
+            + "    lag 9\n"
+            + "\n"
+            + "interface lag 10 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s002:ocp:2<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/10\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s002:ocp:2<==sw-spine-001\n"
+            + "    lag 10\n"
+            + "\n"
+            + "interface lag 11 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s003:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/11\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s003:ocp:1<==sw-spine-001\n"
+            + "    lag 11\n"
+            + "\n"
+            + "interface lag 12 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s003:ocp:2<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/12\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s003:ocp:2<==sw-spine-001\n"
+            + "    lag 12\n"
+        )
+
+        assert ncn_s in str(result.output)
+
+        uan = (
+            "interface 1/1/13\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description uan001:ocp:1<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan access 2\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface lag 14 multi-chassis\n"
+            + "    description uan001:ocp:2<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "    no shutdown\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 6\n"
+            + "\n"
+            + "interface 1/1/14\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description uan001:ocp:2<==sw-spine-001\n"
+            + "    lag 14\n"
+        )
+        assert uan in str(result.output)
+
+        sw_spine_to_leaf_bmc = (
+            "interface lag 151 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description sw-leaf-bmc-001:48<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6\n"
+            + "    lacp mode active\n"
+            + "\n"
+            + "interface 1/1/51\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-leaf-bmc-001:48<==sw-spine-001\n"
+            + "    lag 151\n"
+        )
+        assert sw_spine_to_leaf_bmc in str(result.output)
+
+        spine_to_cdu = (
+            "interface 1/1/49\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-cdu-002:50<==sw-spine-001\n"
+            + "    lag 201\n"
+            + "\n"
+            + "interface lag 201 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description sw-cdu-001:50<==sw-spine-001\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6\n"
+            + "    lacp mode active\n"
+            + "    spanning-tree root-guard\n"
+            + "\n"
+            + "interface 1/1/50\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-cdu-001:50<==sw-spine-001\n"
+            + "    lag 201\n"
+        )
+        assert spine_to_cdu in str(result.output)
+
+        assert (
+            "interface lag 256\n"
+            + "    no shutdown\n"
+            + "    description ISL link\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1 tag\n"
+            + "    vlan trunk allowed all\n"
+            + "    lacp mode active\n"
+            + "interface 1/1/54\n"
+            + "    no shutdown\n"
+            + "    vrf attach keepalive\n"
+            + "    description VSX keepalive\n"
+            + "    ip address 192.168.255.0/31\n"
+            + "interface 1/1/55\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description vsx isl\n"
+            + "    lag 256\n"
+            + "interface 1/1/56\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description vsx isl\n"
+            + "    lag 256\n"
+            + "vsx\n"
+            + "    system-mac 02:00:00:00:01:00\n"
+            + "    inter-switch-link lag 256\n"
+            + "    role primary\n"
+            + "    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive\n"
+            + "    linkup-delay-timer 600\n"
+            + "    vsx-sync vsx-global\n"
+            + "\n"
+            + "interface loopback 0\n"
+            + "    ip address 10.2.0.2/32\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 1\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.1.2/16\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.1.1\n"
+            + "    ip helper-address 10.92.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 2\n"
+            + "    description NMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.3.2/17\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.3.1\n"
+            + "    ip helper-address 10.92.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 4\n"
+            + "    description HMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.0.2/17\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.0.1\n"
+            + "    ip helper-address 10.94.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 6\n"
+            + "    vrf attach Customer\n"
+            + "    description CMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.12.2/24\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.12.1\n"
+            + "    ip ospf 2 area 0.0.0.0\n"
+            + "interface vlan 7\n"
+            + "    vrf attach Customer\n"
+            + "    description CAN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.11.2/24\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.11.1\n"
+            + "    ip ospf 2 area 0.0.0.0\n"
+            + "ip dns server-address 10.92.100.225\n"
+        ) in str(result.output)
+
+        assert (
+            "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
+            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
+            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
+            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
+            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
+            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
+        ) in str(result.output)
+
+        assert (
+            "route-map ncn-w001 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w001 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w001 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w001 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.4\n"
+            + "route-map ncn-w001 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.4\n"
+            + "\n"
+            + "route-map ncn-w001-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.4\n"
+            + "route-map ncn-w001-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+            + "\n"
+            + "\n"
+            + "route-map ncn-w002 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w002 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w002 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w002 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.5\n"
+            + "route-map ncn-w002 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.5\n"
+            + "\n"
+            + "route-map ncn-w002-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.5\n"
+            + "route-map ncn-w002-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+            + "\n"
+            + "\n"
+            + "route-map ncn-w003 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w003 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w003 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w003 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.6\n"
+            + "route-map ncn-w003 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.6\n"
+            + "\n"
+            + "route-map ncn-w003-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.6\n"
+            + "route-map ncn-w003-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+        ) in str(result.output)
+
+        assert (
+            "router ospf 2 vrf Customer\n"
+            + "    router-id 10.2.0.2\n"
+            + "    default-information originate\n"
+            + "    area 0.0.0.0\n"
+            + "router ospf 1\n"
+            + "    router-id 10.2.0.2\n"
+            + "    redistribute bgp\n"
+            + "    area 0.0.0.0\n"
+            + "\n"
+            + "router bgp 65533\n"
+            + "    bgp router-id 10.2.0.2\n"
+            + "    maximum-paths 8\n"
+            + "    timers bgp 1 3\n"
+            + "    distance bgp 20 70\n"
+            + "    neighbor 192.168.3.3 remote-as 65533\n"
+            + "    neighbor 192.168.4.4 remote-as 65531\n"
+            + "    neighbor 192.168.4.4 passive\n"
+            + "    neighbor 192.168.4.5 remote-as 65531\n"
+            + "    neighbor 192.168.4.5 passive\n"
+            + "    neighbor 192.168.4.6 remote-as 65531\n"
+            + "    neighbor 192.168.4.6 passive\n"
+            + "    address-family ipv4 unicast\n"
+            + "        neighbor 192.168.3.3 activate\n"
+            + "        neighbor 192.168.4.4 activate\n"
+            + "        neighbor 192.168.4.4 route-map ncn-w001 in\n"
+            + "        neighbor 192.168.4.5 activate\n"
+            + "        neighbor 192.168.4.5 route-map ncn-w002 in\n"
+            + "        neighbor 192.168.4.6 activate\n"
+            + "        neighbor 192.168.4.6 route-map ncn-w003 in\n"
+            + "    exit-address-family\n"
+            + "    vrf Customer\n"
+            + "        bgp router-id 10.2.0.2\n"
+            + "        maximum-paths 8\n"
+            + "        timers bgp 1 3\n"
+            + "        distance bgp 20 70\n"
+            + "        neighbor 192.168.12.3 remote-as 65533\n"
+            + "        neighbor 192.168.12.4 remote-as 65532\n"
+            + "        neighbor 192.168.12.4 passive\n"
+            + "        neighbor 192.168.12.5 remote-as 65532\n"
+            + "        neighbor 192.168.12.5 passive\n"
+            + "        neighbor 192.168.12.6 remote-as 65532\n"
+            + "        neighbor 192.168.12.6 passive\n"
+            + "        address-family ipv4 unicast\n"
+            + "            neighbor 192.168.12.3 activate\n"
+            + "            neighbor 192.168.12.4 activate\n"
+            + "            neighbor 192.168.12.4 route-map ncn-w001-Customer in\n"
+            + "            neighbor 192.168.12.5 activate\n"
+            + "            neighbor 192.168.12.5 route-map ncn-w002-Customer in\n"
+            + "            neighbor 192.168.12.6 activate\n"
+            + "            neighbor 192.168.12.6 route-map ncn-w003-Customer in\n"
+            + "        exit-address-family\n"
+            + "https-server vrf Customer\n"
+            + "https-server vrf default\n"
+            + "https-server vrf mgmt\n"
+        ) in str(result.output)
+
+
+def test_switch_config_tds_spine_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid TDS secondary spine config."""
+    spine_secondary = "sw-spine-002"
+
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                spine_secondary,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-spine-002\n" in str(result.output)
+        assert banner_motd in str(result.output)
+
+        assert (
+            "no ip icmp redirect\n"
+            + "vrf Customer\n"
+            + "vrf keepalive\n"
+            + "ntp server 192.168.4.4\n"
+            + "ntp server 192.168.4.5\n"
+            + "ntp server 192.168.4.6\n"
+            + "ntp enable\n"
+        ) in str(result.output)
+
+        assert (
+            "ssh server vrf Customer\n"
+            + "ssh server vrf default\n"
+            + "ssh server vrf keepalive\n"
+            + "ssh server vrf mgmt\n"
+            + "access-list ip mgmt\n"
+            + "    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN\n"
+            + "    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh\n"
+            + "    30 permit tcp 192.168.0.0/255.255.128.0 any eq https\n"
+            + "    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp\n"
+            + "    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap\n"
+            + "    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh\n"
+            + "    70 permit tcp 192.168.12.0/255.255.255.0 any eq https\n"
+            + "    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp\n"
+            + "    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap\n"
+            + "    100 comment ALLOW SNMP FROM HMN METALLB SUBNET\n"
+            + "    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp\n"
+            + "    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap\n"
+            + "    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE\n"
+            + "    140 deny tcp any any eq ssh\n"
+            + "    150 deny tcp any any eq https\n"
+            + "    160 deny udp any any eq snmp\n"
+            + "    170 deny udp any any eq snmp-trap\n"
+            + "    180 comment ALLOW ANYTHING ELSE\n"
+            + "    190 permit any any any\n"
+            + "access-list ip nmn-hmn\n"
+            + "    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    90 permit any any any\n"
+            + "access-list ip cmn-can\n"
+            + "    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0\n"
+            + "    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0\n"
+            + "    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    50 permit any any any\n"
+            + "apply access-list ip mgmt control-plane vrf default\n"
+            + "\n"
+            + "vlan 1\n"
+            + "vlan 2\n"
+            + "    name NMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 4\n"
+            + "    name HMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 6\n"
+            + "    name CMN\n"
+            + "vlan 7\n"
+            + "    name CAN\n"
+            + "vlan 10\n"
+            + "    name SUN\n"
+            + "spanning-tree\n"
+            + "spanning-tree forward-delay 4\n"
+            + "spanning-tree priority 0\n"
+            + "spanning-tree config-name MST0\n"
+            + "spanning-tree config-revision 1\n"
+            + "interface mgmt\n"
+            + "    shutdown\n"
+            + "    ip dhcp\n"
+        ) in str(result.output)
+
+        ncn_m = (
+            "interface lag 1 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m001:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/1\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m001:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 1\n"
+            + "\n"
+            + "interface lag 2 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m002:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/2\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m002:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 2\n"
+            + "\n"
+            + "interface lag 3 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-m003:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/3\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m003:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 3\n"
+        )
+
+        assert ncn_m in str(result.output)
+
+        ncn_w = (
+            "interface lag 4 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w001:ocp:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/4\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w001:ocp:2<==sw-spine-002\n"
+            + "    lag 4\n"
+            + "\n"
+            + "interface lag 5 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w002:ocp:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/5\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w002:ocp:2<==sw-spine-002\n"
+            + "    lag 5\n"
+            + "\n"
+            + "interface lag 6 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-w003:ocp:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/6\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w003:ocp:2<==sw-spine-002\n"
+            + "    lag 6\n"
+        )
+
+        assert ncn_w in str(result.output)
+
+        ncn_s = (
+            "interface lag 7 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s001:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/7\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s001:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 7\n"
+            + "\n"
+            + "interface lag 8 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s001:pcie-slot1:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/8\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s001:pcie-slot1:2<==sw-spine-002\n"
+            + "    lag 8\n"
+            + "\n"
+            + "interface lag 9 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s002:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/9\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s002:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 9\n"
+            + "\n"
+            + "interface lag 10 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s002:pcie-slot1:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/10\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s002:pcie-slot1:2<==sw-spine-002\n"
+            + "    lag 10\n"
+            + "\n"
+            + "interface lag 11 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s003:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6-7\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/11\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s003:pcie-slot1:1<==sw-spine-002\n"
+            + "    lag 11\n"
+            + "\n"
+            + "interface lag 12 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description ncn-s003:pcie-slot1:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 10\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface 1/1/12\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s003:pcie-slot1:2<==sw-spine-002\n"
+            + "    lag 12\n"
+        )
+
+        assert ncn_s in str(result.output)
+
+        uan = (
+            "interface 1/1/13\n"
+            + "    mtu 9198\n"
+            + "    description uan001:pcie-slot1:1<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan access 2\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "\n"
+            + "interface lag 14 multi-chassis\n"
+            + "    description uan001:pcie-slot1:2<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    lacp mode active\n"
+            + "    lacp fallback\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "    no shutdown\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 6\n"
+            + "\n"
+            + "interface 1/1/14\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description uan001:pcie-slot1:2<==sw-spine-002\n"
+            + "    lag 14\n"
+        )
+        assert uan in str(result.output)
+
+        sw_spine_to_leaf_bmc = (
+            "interface lag 151 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description sw-leaf-bmc-001:47<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6\n"
+            + "    lacp mode active\n"
+            + "\n"
+            + "interface 1/1/51\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-leaf-bmc-001:47<==sw-spine-002\n"
+            + "    lag 151\n"
+        )
+        assert sw_spine_to_leaf_bmc in str(result.output)
+
+        spine_to_cdu = (
+            "interface 1/1/49\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-cdu-002:49<==sw-spine-002\n"
+            + "    lag 201\n"
+            + "\n"
+            + "interface lag 201 multi-chassis\n"
+            + "    no shutdown\n"
+            + "    description sw-cdu-001:49<==sw-spine-002\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6\n"
+            + "    lacp mode active\n"
+            + "    spanning-tree root-guard\n"
+            + "\n"
+            + "interface 1/1/50\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-cdu-001:49<==sw-spine-002\n"
+            + "    lag 201\n"
+        )
+        assert spine_to_cdu in str(result.output)
+
+        assert (
+            "interface lag 256\n"
+            + "    no shutdown\n"
+            + "    description ISL link\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1 tag\n"
+            + "    vlan trunk allowed all\n"
+            + "    lacp mode active\n"
+            + "interface 1/1/54\n"
+            + "    no shutdown\n"
+            + "    vrf attach keepalive\n"
+            + "    description VSX keepalive\n"
+            + "    ip address 192.168.255.1/31\n"
+            + "interface 1/1/55\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description vsx isl\n"
+            + "    lag 256\n"
+            + "interface 1/1/56\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description vsx isl\n"
+            + "    lag 256\n"
+            + "vsx\n"
+            + "    system-mac 02:00:00:00:01:00\n"
+            + "    inter-switch-link lag 256\n"
+            + "    role secondary\n"
+            + "    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive\n"
+            + "    linkup-delay-timer 600\n"
+            + "    vsx-sync vsx-global\n"
+            + "\n"
+            + "interface loopback 0\n"
+            + "    ip address 10.2.0.3/32\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 1\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.1.3/16\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.1.1\n"
+            + "    ip helper-address 10.92.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 2\n"
+            + "    description NMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.3.3/17\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.3.1\n"
+            + "    ip helper-address 10.92.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 4\n"
+            + "    description HMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.0.3/17\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.0.1\n"
+            + "    ip helper-address 10.94.100.222\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 6\n"
+            + "    vrf attach Customer\n"
+            + "    description CMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.12.3/24\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.12.1\n"
+            + "    ip ospf 2 area 0.0.0.0\n"
+            + "interface vlan 7\n"
+            + "    vrf attach Customer\n"
+            + "    description CAN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.11.3/24\n"
+            + "    active-gateway ip mac 12:00:00:00:6b:00\n"
+            + "    active-gateway ip 192.168.11.1\n"
+            + "    ip ospf 2 area 0.0.0.0\n"
+            + "ip dns server-address 10.92.100.225\n"
+        ) in str(result.output)
+
+        assert (
+            "ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24\n"
+            + "ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24\n"
+            + "ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24\n"
+            + "ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24\n"
+            + "ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32\n"
+            + "ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32\n"
+        ) in str(result.output)
+
+        assert (
+            "route-map ncn-w001 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w001 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w001 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w001 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.4\n"
+            + "route-map ncn-w001 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.4\n"
+            + "\n"
+            + "route-map ncn-w001-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.4\n"
+            + "route-map ncn-w001-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+            + "\n"
+            + "\n"
+            + "route-map ncn-w002 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w002 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w002 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w002 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.5\n"
+            + "route-map ncn-w002 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.5\n"
+            + "\n"
+            + "route-map ncn-w002-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.5\n"
+            + "route-map ncn-w002-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+            + "\n"
+            + "\n"
+            + "route-map ncn-w003 permit seq 10\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.4\n"
+            + "     set local-preference 1000\n"
+            + "route-map ncn-w003 permit seq 20\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.5\n"
+            + "     set local-preference 1100\n"
+            + "route-map ncn-w003 permit seq 30\n"
+            + "     match ip address prefix-list tftp\n"
+            + "     match ip next-hop 192.168.4.6\n"
+            + "     set local-preference 1200\n"
+            + "route-map ncn-w003 permit seq 40\n"
+            + "     match ip address prefix-list pl-hmn\n"
+            + "     set ip next-hop 192.168.0.6\n"
+            + "route-map ncn-w003 permit seq 50\n"
+            + "     match ip address prefix-list pl-nmn\n"
+            + "     set ip next-hop 192.168.4.6\n"
+            + "\n"
+            + "route-map ncn-w003-Customer permit seq 10\n"
+            + "     match ip address prefix-list pl-can\n"
+            + "     set ip next-hop 192.168.11.6\n"
+            + "route-map ncn-w003-Customer permit seq 20\n"
+            + "     match ip address prefix-list pl-cmn\n"
+        ) in str(result.output)
+
+        assert (
+            "router ospf 2 vrf Customer\n"
+            + "    router-id 10.2.0.3\n"
+            + "    default-information originate\n"
+            + "    area 0.0.0.0\n"
+            + "router ospf 1\n"
+            + "    router-id 10.2.0.3\n"
+            + "    redistribute bgp\n"
+            + "    area 0.0.0.0\n"
+            + "\n"
+            + "router bgp 65533\n"
+            + "    bgp router-id 10.2.0.3\n"
+            + "    maximum-paths 8\n"
+            + "    timers bgp 1 3\n"
+            + "    distance bgp 20 70\n"
+            + "    neighbor 192.168.3.2 remote-as 65533\n"
+            + "    neighbor 192.168.4.4 remote-as 65531\n"
+            + "    neighbor 192.168.4.4 passive\n"
+            + "    neighbor 192.168.4.5 remote-as 65531\n"
+            + "    neighbor 192.168.4.5 passive\n"
+            + "    neighbor 192.168.4.6 remote-as 65531\n"
+            + "    neighbor 192.168.4.6 passive\n"
+            + "    address-family ipv4 unicast\n"
+            + "        neighbor 192.168.3.2 activate\n"
+            + "        neighbor 192.168.4.4 activate\n"
+            + "        neighbor 192.168.4.4 route-map ncn-w001 in\n"
+            + "        neighbor 192.168.4.5 activate\n"
+            + "        neighbor 192.168.4.5 route-map ncn-w002 in\n"
+            + "        neighbor 192.168.4.6 activate\n"
+            + "        neighbor 192.168.4.6 route-map ncn-w003 in\n"
+            + "    exit-address-family\n"
+            + "    vrf Customer\n"
+            + "        bgp router-id 10.2.0.3\n"
+            + "        maximum-paths 8\n"
+            + "        timers bgp 1 3\n"
+            + "        distance bgp 20 70\n"
+            + "        neighbor 192.168.12.2 remote-as 65533\n"
+            + "        neighbor 192.168.12.4 remote-as 65532\n"
+            + "        neighbor 192.168.12.4 passive\n"
+            + "        neighbor 192.168.12.5 remote-as 65532\n"
+            + "        neighbor 192.168.12.5 passive\n"
+            + "        neighbor 192.168.12.6 remote-as 65532\n"
+            + "        neighbor 192.168.12.6 passive\n"
+            + "        address-family ipv4 unicast\n"
+            + "            neighbor 192.168.12.2 activate\n"
+            + "            neighbor 192.168.12.4 activate\n"
+            + "            neighbor 192.168.12.4 route-map ncn-w001-Customer in\n"
+            + "            neighbor 192.168.12.5 activate\n"
+            + "            neighbor 192.168.12.5 route-map ncn-w002-Customer in\n"
+            + "            neighbor 192.168.12.6 activate\n"
+            + "            neighbor 192.168.12.6 route-map ncn-w003-Customer in\n"
+            + "        exit-address-family\n"
+            + "https-server vrf Customer\n"
+            + "https-server vrf default\n"
+            + "https-server vrf mgmt\n"
+        ) in str(result.output)
+
+
+def test_switch_config_tds_leaf_bmc():
+    """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
+    leaf_bmc_tds = "sw-leaf-bmc-001"
+
+    with runner.isolated_filesystem():
+
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                leaf_bmc_tds,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "hostname sw-leaf-bmc-001\n" in str(result.output)
+        assert banner_motd in str(result.output)
+
+        assert (
+            "no ip icmp redirect\n"
+            + "vrf Customer\n"
+            + "ntp server 192.168.4.4\n"
+            + "ntp server 192.168.4.5\n"
+            + "ntp server 192.168.4.6\n"
+            + "ntp enable\n"
+        ) in str(result.output)
+
+        assert "ssh server vrf default\n" in str(result.output)
+        assert banner_motd in str(result.output)
+
+        assert (
+            "ssh server vrf mgmt\n"
+            + "ssh server vrf Customer\n"
+            + "access-list ip mgmt\n"
+            + "    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN\n"
+            + "    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh\n"
+            + "    30 permit tcp 192.168.0.0/255.255.128.0 any eq https\n"
+            + "    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp\n"
+            + "    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap\n"
+            + "    60 permit tcp 192.168.12.0/255.255.255.0 any eq ssh\n"
+            + "    70 permit tcp 192.168.12.0/255.255.255.0 any eq https\n"
+            + "    80 permit udp 192.168.12.0/255.255.255.0 any eq snmp\n"
+            + "    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap\n"
+            + "    100 comment ALLOW SNMP FROM HMN METALLB SUBNET\n"
+            + "    110 permit udp 10.94.100.0/255.255.255.0 any eq snmp\n"
+            + "    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap\n"
+            + "    130 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE\n"
+            + "    140 deny tcp any any eq ssh\n"
+            + "    150 deny tcp any any eq https\n"
+            + "    160 deny udp any any eq snmp\n"
+            + "    170 deny udp any any eq snmp-trap\n"
+            + "    180 comment ALLOW ANYTHING ELSE\n"
+            + "    190 permit any any any\n"
+            + "access-list ip nmn-hmn\n"
+            + "    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0\n"
+            + "    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0\n"
+            + "    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0\n"
+            + "    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0\n"
+            + "    90 permit any any any\n"
+            + "access-list ip cmn-can\n"
+            + "    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0\n"
+            + "    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0\n"
+            + "    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0\n"
+            + "    50 permit any any any\n"
+            + "apply access-list ip mgmt control-plane vrf default\n"
+            + "\n"
+            + "vlan 1\n"
+            + "vlan 2\n"
+            + "    name NMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 4\n"
+            + "    name HMN\n"
+            + "    apply access-list ip nmn-hmn in\n"
+            + "    apply access-list ip nmn-hmn out\n"
+            + "vlan 6\n"
+            + "    name CMN\n"
+            + "\n"
+            + "spanning-tree\n"
+            + "spanning-tree forward-delay 4\n"
+            + "spanning-tree config-name MST0\n"
+            + "spanning-tree config-revision 1\n"
+            + "interface mgmt\n"
+            + "    shutdown\n"
+            + "    ip dhcp\n"
+        ) in str(result.output)
+        leaf_bmc_to_leaf = (
+            "interface lag 101\n"
+            + "    no shutdown\n"
+            + "    description leaf_bmc_to_spine_lag\n"
+            + "    no routing\n"
+            + "    vlan trunk native 1\n"
+            + "    vlan trunk allowed 1-2,4,6\n"
+            + "    lacp mode active\n"
+            + "interface 1/1/47\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-spine-002:51<==sw-leaf-bmc-001\n"
+            + "    lag 101\n"
+            + "interface 1/1/48\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description sw-spine-001:51<==sw-leaf-bmc-001\n"
+            + "    lag 101\n"
+        )
+        assert leaf_bmc_to_leaf in str(result.output)
+
+        bmc = (
+            "interface 1/1/1\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m001:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/2\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m002:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/3\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-m003:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/4\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w001:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/5\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w002:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/6\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-w003:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/7\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s001:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/8\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s002:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/9\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description ncn-s003:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/10\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description uan001:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/11\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description cn001:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/12\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description cn002:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/13\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description cn003:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+            + "interface 1/1/14\n"
+            + "    no shutdown\n"
+            + "    mtu 9198\n"
+            + "    description cn004:bmc:1<==sw-leaf-bmc-001\n"
+            + "    no routing\n"
+            + "    vlan access 4\n"
+            + "    spanning-tree bpdu-guard\n"
+            + "    spanning-tree port-type admin-edge\n"
+        )
+        assert bmc in str(result.output)
+
+        assert (
+            "interface loopback 0\n"
+            + "    ip address 10.2.0.12/32\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 1\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.1.12/16\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 2\n"
+            + "    description NMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.3.12/17\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "interface vlan 4\n"
+            + "    description HMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.0.12/17\n"
+            + "    ip ospf 1 area 0.0.0.0\n"
+            + "    ip ospf passive\n"
+            + "interface vlan 6\n"
+            + "    vrf attach Customer\n"
+            + "    description CMN\n"
+            + "    ip mtu 9198\n"
+            + "    ip address 192.168.12.12/24\n"
+            + "    ip ospf 2 area 0.0.0.0\n"
+            + "snmp-server vrf default\n"
+            + "ip dns server-address 10.92.100.225\n"
+            + "router ospf 2 vrf Customer\n"
+            + "    router-id 10.2.0.12\n"
+            + "    area 0.0.0.0\n"
+            + "router ospf 1\n"
+            + "    router-id 10.2.0.12\n"
+            + "    area 0.0.0.0\n"
+            + "https-server vrf Customer\n"
+            + "https-server vrf default\n"
+            + "https-server vrf mgmt\n"
+        ) in str(result.output)

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_6.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_6.py
@@ -33,7 +33,7 @@ from canu.cli import cli
 
 test_file_directory = Path(__file__).resolve().parent
 
-csm = "1.5"
+csm = "1.6"
 
 test_file_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
 test_file = path.join(test_file_directory, "data", test_file_name)

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
@@ -33,7 +33,7 @@ from canu.cli import cli
 
 test_file_directory = Path(__file__).resolve().parent
 
-csm = "1.5"
+csm = "1.6"
 
 test_file_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
 test_file = path.join(test_file_directory, "data", test_file_name)

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
@@ -134,7 +134,7 @@ def test_switch_config_spine_primary_custom():
     config_file = f"{switch_name}.cfg"
     golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
 
-    with runner.isolated_filesystem("/Users/lynns/blah"):
+    with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
             [

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
@@ -1,0 +1,1037 @@
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU generate switch config commands."""
+import difflib
+from os import path
+from pathlib import Path
+
+from click import testing
+import pkg_resources
+
+from canu.cli import cli
+
+test_file_directory = Path(__file__).resolve().parent
+data_directory = path.join(test_file_directory, "data")
+
+csm = "1.5"
+cache_minutes = 0
+sls_address = "api-gw-service-nmn.local"
+
+sls_file_name = "sls_input_file_csm_1.2.json"
+sls_file = path.join(data_directory, sls_file_name)
+
+# Full systems
+test_shcd_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file = path.join(data_directory, test_shcd_name)
+custom_file_name = "aruba_custom.yaml"
+custom_file = path.join(data_directory, custom_file_name)
+architecture = "full"
+tabs = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners = "J14,T44,J14,T53,J14,T34,J14,T27"
+
+# TDS systems
+test_shcd_name_tds = "TDS_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file_tds = path.join(test_file_directory, "data", test_shcd_name_tds)
+architecture_tds = "tds"
+tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
+
+canu_version = pkg_resources.get_distribution("canu").version
+
+banner_version = f"# CANU version: {canu_version}\n"
+
+runner = testing.CliRunner()
+
+
+def diff_config_files(golden_file_name, test_file_name):
+    """Compare a test config file with a golden config file."""
+    with open(golden_file_name, "r") as file:
+        golden_config = file.readlines()
+    with open(test_file_name, "r") as file:
+        test_config = file.readlines()
+
+    d = difflib.Differ()
+    full_diff = list(d.compare(golden_config, test_config))
+    # Clean up - remove same lines " ", diff description lines "?", and CANU version
+    # lines (tested elsewhere) so that a real diff size can be obtained. The CANU version
+    # banner actual number will often be different between golden and testing so we don't
+    # test this.
+    real_diff = [
+        x for x in full_diff
+        if x[0] != " "
+        if x[0] != "?"
+        if banner_version[:14] not in x
+    ]
+
+    # If there's a real diff then print out the verbose diff (in stdout)
+    # for debugging.
+    if len(real_diff) != 0:
+        for myline in full_diff:
+            print(myline, end="")
+
+    return len(real_diff)
+
+
+def test_switch_config_spine_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_primary_custom():
+    """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem("/Users/lynns/blah"):
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary_custom():
+    """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
+    switch_name = "sw-leaf-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary leaf config."""
+    switch_name = "sw-leaf-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
+    switch_name = "sw-leaf-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary leaf custom config."""
+    switch_name = "sw-leaf-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc():
+    """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc_custom():
+    """Test that the `canu generate switch config` command runs and returns valid leaf bmc custom config."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary cdu custom config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary edge config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary edge custom config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary cdu config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary edge config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.5/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_6.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_6.py
@@ -32,7 +32,7 @@ from canu.cli import cli
 test_file_directory = Path(__file__).resolve().parent
 data_directory = path.join(test_file_directory, "data")
 
-csm = "1.5"
+csm = "1.6"
 cache_minutes = 0
 sls_address = "api-gw-service-nmn.local"
 
@@ -95,7 +95,7 @@ def test_switch_config_spine_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -132,7 +132,7 @@ def test_switch_config_spine_primary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -172,7 +172,7 @@ def test_switch_config_spine_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -210,7 +210,7 @@ def test_switch_config_spine_secondary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -250,7 +250,7 @@ def test_switch_config_leaf_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -287,7 +287,7 @@ def test_switch_config_leaf_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -326,7 +326,7 @@ def test_switch_config_leaf_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -363,7 +363,7 @@ def test_switch_config_leaf_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf custom config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -402,7 +402,7 @@ def test_switch_config_leaf_bmc():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -439,7 +439,7 @@ def test_switch_config_leaf_bmc_custom():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc custom config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -478,7 +478,7 @@ def test_switch_config_cdu_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -515,7 +515,7 @@ def test_switch_config_cdu_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -554,7 +554,7 @@ def test_switch_config_cdu_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -591,7 +591,7 @@ def test_switch_config_cdu_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu custom config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -630,7 +630,7 @@ def test_switch_config_edge_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -667,7 +667,7 @@ def test_switch_config_edge_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -706,7 +706,7 @@ def test_switch_config_edge_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -743,7 +743,7 @@ def test_switch_config_edge_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge custom config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -782,7 +782,7 @@ def test_switch_config_spine_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -819,7 +819,7 @@ def test_switch_config_spine_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -856,7 +856,7 @@ def test_switch_config_leaf_bmc_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -893,7 +893,7 @@ def test_switch_config_cdu_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -930,7 +930,7 @@ def test_switch_config_cdu_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -967,7 +967,7 @@ def test_switch_config_edge_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -1004,7 +1004,7 @@ def test_switch_config_edge_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
@@ -32,7 +32,7 @@ from canu.cli import cli
 test_file_directory = Path(__file__).resolve().parent
 data_directory = path.join(test_file_directory, "data")
 
-csm = "1.5"
+csm = "1.6"
 cache_minutes = 0
 sls_address = "api-gw-service-nmn.local"
 
@@ -95,7 +95,7 @@ def test_switch_config_spine_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -132,7 +132,7 @@ def test_switch_config_spine_primary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -172,7 +172,7 @@ def test_switch_config_spine_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -210,7 +210,7 @@ def test_switch_config_spine_secondary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -250,7 +250,7 @@ def test_switch_config_leaf_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -287,7 +287,7 @@ def test_switch_config_leaf_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -326,7 +326,7 @@ def test_switch_config_leaf_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -363,7 +363,7 @@ def test_switch_config_leaf_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf custom config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -402,7 +402,7 @@ def test_switch_config_leaf_bmc():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -439,7 +439,7 @@ def test_switch_config_leaf_bmc_custom():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc custom config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -478,7 +478,7 @@ def test_switch_config_cdu_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -515,7 +515,7 @@ def test_switch_config_cdu_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -554,7 +554,7 @@ def test_switch_config_cdu_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -591,7 +591,7 @@ def test_switch_config_cdu_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu custom config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -630,7 +630,7 @@ def test_switch_config_edge_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -667,7 +667,7 @@ def test_switch_config_edge_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -706,7 +706,7 @@ def test_switch_config_edge_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -743,7 +743,7 @@ def test_switch_config_edge_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge custom config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -782,7 +782,7 @@ def test_switch_config_spine_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -819,7 +819,7 @@ def test_switch_config_spine_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -856,7 +856,7 @@ def test_switch_config_leaf_bmc_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -893,7 +893,7 @@ def test_switch_config_cdu_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -930,7 +930,7 @@ def test_switch_config_cdu_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -967,7 +967,7 @@ def test_switch_config_edge_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -1004,7 +1004,7 @@ def test_switch_config_edge_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_{csm}/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(


### PR DESCRIPTION
### Summary and Scope

Recent additions to CANU uncovered a lack of testing for canu-generated switch configurations from the CSM 1.5 version onward. Investigation revealed that the exising configuration testing framework was incredibly lengthy, hard to maintain, and nearly impossible to debug if problems occurred.  Developers had avoided creating tests because the framework was awful.

This change entirely refactors testing of `canu generate switch config` from CSM 1.5 and moving foward.

- Generated switch configuration testing and canu command line (CLI) testing have been split into separate tests files.
- A generalized function which "diffs" text files and modifies the output for config files has been created.
- If differences are found between a golden config and a generated config, test now prints the entire diff to stdout where it's able to be displayed to the user and allows easy debugging.
- The "golden" test configs have been externalized to the `tests/data/golden_configs` directory for much easier readability and  test management.

After this change a (nox) test failure will appear as:

```
...snip...
            assert result.exit_code == 0
>           assert diff_config_files(golden_config_file, config_file) == 0
E           AssertionError: assert 2 == 0
E            +  where 2 = diff_config_files('/Users/lynns/sources/git/canu/tests/data/golden_configs/tds_configs_1.5/sw-leaf-bmc-001.cfg', 'sw-leaf-bmc-001.cfg')

tests/test_generate_switch_config_aruba_configs_csm_1_5.py:889: AssertionError
...snip...
```
where the integer returned from `diff_config_files` is the number of lines differing between the golden and generated config, and the initial error shows the problem exists in the tds configs for leaf-bmc-001.

The existing nox framework around pytest has always printed stdout (output from the test) when a test assertion fails. The new config test framework takes advantage of stdout to print the entire calculated diff between the golden and generated config.  This will enable developers to quickly troubleshoot test failures.  An example follows:

```
------------------------------------- Captured stdout call -------------------------------------
  
  hostname sw-leaf-bmc-001
  ...snip...
  interface vlan 4
      vrf attach CSM
-     description HMN FOR REAL
?                    ---------
+     description HMN GENERATED
      ip mtu 9198
      ip address 192.168.0.12/17
      ip ospf 2 area 0.0.0.0
      ip ospf passive
...snip...
```

- [x] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CASMNET-2334`
* Relates to: `CASMNET-2304`
* Relates to: `CASMNET-2305`

### Testing

These are new tests.
