### PR TITLE
CASMNET-2339 - Bump VLAN max in schema checks to 4095

### DIFF
--- a/canu/utils/sls_utils/schemas/sls_networks_schema.json
+++ b/canu/utils/sls_utils/schemas/sls_networks_schema.json
@@ -135,7 +135,7 @@
                             "items": {
                                 "type": "integer",
                                 "minimum": 0,
-                                "maximum": 4094
+                                "maximum": 4095
                             }
                         },
                         "SystemDefaultRoute": {


### PR DESCRIPTION
### Summary and Scope

Since the beginning CSI has created SLS data that has a maximum VLAN range value of 4095.  The actual max physically allowed in networking is 4094 and CANU checked to enforce this physical value.

This change increases the max allowed VLAN to 4095 to match CSI. Many, many running systems have the 4095 data, but CANU is the only tooling that actually takes SLS network data and produces running switch configurations.  This change is not a runtime risk as it only impacts the VLAN range value in SLS which is not used by any tooling (including CANU).

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

<!-- * Resolves: `Issue` --->

### Testing

No testing needed.  This only affects SLS VlanRange values which are not used by any tooling whatsoever.
