### PR TITLE
CASMNET-2285

### DIFF
--- a/network_modeling/configs/templates/1.7/aruba/common/acl.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/acl.j2
@@ -57,6 +57,26 @@ access-list ip nmn-hmn
 {%- if variables.NMN and variables.HMNLB %}
 {% set sequence = sequence+10 %}    {{ sequence }} deny any {{ variables.NMN_NETWORK_IP }}/{{ variables.NMN_NETMASK }} {{ variables.HMNLB_NETWORK_IP }}/{{ variables.HMNLB_NETMASK }}
 {%- endif %}
+{% set sequence = sequence+10 %}    {{ sequence }} comment ALLOW traffic between NMN and NMN_MTN
+{%- if variables.NMN and variables.NMN_MTN %}
+{% set sequence = sequence+10 %}    {{ sequence }} permit any {{ variables.NMN_NETWORK_IP }}/{{ variables.NMN_NETMASK }} {{ variables.NMN_MTN_NETWORK_IP }}/{{ variables.NMN_MTN_NETMASK }}
+{% set sequence = sequence+10 %}    {{ sequence }} permit any {{ variables.NMN_MTN_NETWORK_IP }}/{{ variables.NMN_MTN_NETMASK }} {{ variables.NMN_NETWORK_IP }}/{{ variables.NMN_NETMASK }}
+{%- endif %}
+{%- if variables.NMN_MTN_CABINETS | length > 1 %}
+{% set sequence = sequence+10 %}    {{ sequence }} comment BLOCK traffic between NMN_MTN_CABINETS
+{%- set seq = namespace(val=sequence) -%}
+{%- for src in variables.NMN_MTN_CABINETS %}
+  {%- set src_index = loop.index0 %}
+  {%- for dst in variables.NMN_MTN_CABINETS %}
+    {%- set dst_index = loop.index0 %}
+    {%- if src.Name != dst.Name %}
+    {%- set seq.val = seq.val + 10 %}
+    {{ seq.val }} deny any {{ src.CIDR.split('/')[0] }}/{{ variables.NMN_MTN_CABINETS_NETMASK[src_index]['Netmask'] }} {{ dst.CIDR.split('/')[0] }}/{{ variables.NMN_MTN_CABINETS_NETMASK[dst_index]['Netmask'] }}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+{% set sequence = seq.val %}
+{%- endif %}
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp {{ variables.NMNLB_DHCP }} range 67 68 any
 {% set sequence = sequence+10 %}    {{ sequence }} permit udp any range 67 68 {{ variables.NMNLB_DHCP }}
 {% set sequence = sequence+10 %}    {{ sequence }} deny any any {{ variables.NMNLB_DHCP }}

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-001.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-002.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
@@ -57,13 +57,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
@@ -57,13 +57,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001.cfg
@@ -54,13 +54,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-001.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-002.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
@@ -57,13 +57,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
@@ -57,13 +57,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001.cfg
@@ -46,13 +46,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001.cfg
@@ -65,13 +65,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002.cfg
@@ -62,13 +62,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
@@ -55,13 +55,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-001.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-002.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-002.cfg
@@ -56,13 +56,19 @@ access-list ip nmn-hmn
     100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
     110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
     120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
-    130 permit udp 10.92.100.222 range 67 68 any
-    140 permit udp any range 67 68 10.92.100.222
-    150 deny any any 10.92.100.222
-    160 permit udp 10.94.100.222 range 67 68 any
-    170 permit udp any range 67 68 10.94.100.222
-    180 deny any any 10.94.100.222
-    190 permit any any any
+    130 comment ALLOW traffic between NMN and NMN_MTN
+    140 permit any 192.168.3.0/255.255.128.0 192.168.100.0/255.255.128.0
+    150 permit any 192.168.100.0/255.255.128.0 192.168.3.0/255.255.128.0
+    160 comment BLOCK traffic between NMN_MTN_CABINETS
+    170 deny any 192.168.100.0/255.255.252.0 192.168.104.0/255.255.252.0
+    180 deny any 192.168.104.0/255.255.252.0 192.168.100.0/255.255.252.0
+    190 permit udp 10.92.100.222 range 67 68 any
+    200 permit udp any range 67 68 10.92.100.222
+    210 deny any any 10.92.100.222
+    220 permit udp 10.94.100.222 range 67 68 any
+    230 permit udp any range 67 68 10.94.100.222
+    240 deny any any 10.94.100.222
+    250 permit any any any
 access-list ip cmn-can
     10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
     20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0


### PR DESCRIPTION
### Summary and Scope
Implemented required ACL's to block cabinet to cabinet traffic as part of NMN Isolation feature. 
<!-- What does this change do? --->
It prevents the communication from cmm's from cabinet to other cabinet and vice versa. 
- [x] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMNET-2284
https://jira-pro.it.hpe.com:8443/browse/CASMNET-2285

<!-- * Resolves: `Issue` ---> https://jira-pro.it.hpe.com:8443/browse/CASMNET-22845
<!-- * Relates to: `Issue` --->https://jira-pro.it.hpe.com:8443/browse/CASMNET-2132
<!-- * Required: `Issue` --->https://jira-pro.it.hpe.com:8443/browse/CASMNET-2132

### Testing
Testing is done on Hela cluster hela-ncn-m001.hpc.amslabs.hpecorp.net
<!-- How was this change tested? --->
After implementing Switch ACL's, have a test script which does ping and SSH to IP address range from NMN_MTN Cabinet1 tocabinet2.