### PR TITLE
CASMNET-2331 - canu switch config updates for IPv6 addressing

### DIFF
--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -1851,10 +1851,19 @@ def parse_sls_for_config(input_json):
 
     # Figure out up front if IPv6 support should be enabled or not.
     cmn_network = list(filter(lambda network: network.get("Name") == "CMN", input_json))
-    if cmn_network:
-        sls_variables["IPV6_ENABLED"] = bool(cmn_network[0].get("ExtraProperties", {}).get("CIDR6"))
-    else:
-        sls_variables["IPV6_ENABLED"] = False
+    chn_network = list(filter(lambda network: network.get("Name") == "CHN", input_json))
+
+    if cmn_network and chn_network:
+        cmn_has_ipv6 = bool(cmn_network[0].get("ExtraProperties", {}).get("CIDR6"))
+        chn_has_ipv6 = bool(chn_network[0].get("ExtraProperties", {}).get("CIDR6"))
+
+        if cmn_has_ipv6 and chn_has_ipv6:
+            sls_variables["IPV6_ENABLED"] = True
+        else:
+            sls_variables["IPV6_ENABLED"] = False
+            log.debug(
+                f"Missing IPv6 data. cmn_has_ipv6: {cmn_has_ipv6}, chn_has_ipv6: {chn_has_ipv6}",
+            )
 
     for sls_network in input_json:
         name = sls_network.get("Name", "")

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -900,7 +900,8 @@ def generate_switch_config(
             sys.exit(1)
     else:
         variables["CMN_IP"] = sls_variables.get("CMN_IPs", {}).get(switch_name)
-        variables["CMN_IP6"] = sls_variables.get("CMN_IPs6", {}).get(switch_name)
+        if variables["IPV6_ENABLED"]:
+            variables["CMN_IP6"] = sls_variables.get("CMN_IPs6", {}).get(switch_name)
         variables["HMN_IP"] = sls_variables.get("HMN_IPs", {}).get(switch_name)
         variables["MTL_IP"] = sls_variables.get("MTL_IPs", {}).get(switch_name)
         variables["NMN_IP"] = sls_variables.get("NMN_IPs", {}).get(switch_name)

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -772,16 +772,20 @@ def generate_switch_config(
         "CAN_NETWORK_IP": sls_variables["CAN_NETWORK_IP"],
         "CAN_PREFIX_LEN": sls_variables["CAN_PREFIX_LEN"],
         "CHN": sls_variables["CHN"],
+        "CHN6": sls_variables["CHN6"],
         "CHN_VLAN": sls_variables["CHN_VLAN"],
         "CHN_NETMASK": sls_variables["CHN_NETMASK"],
         "CHN_NETWORK_IP": sls_variables["CHN_NETWORK_IP"],
         "CHN_PREFIX_LEN": sls_variables["CHN_PREFIX_LEN"],
+        "CHN_PREFIX_LEN6": sls_variables["CHN_PREFIX_LEN6"],
         "CHN_ASN": sls_variables["CHN_ASN"],
         "CMN": sls_variables["CMN"],
+        "CMN6": sls_variables["CMN6"],
         "CMN_VLAN": sls_variables["CMN_VLAN"],
         "CMN_NETMASK": sls_variables["CMN_NETMASK"],
         "CMN_NETWORK_IP": sls_variables["CMN_NETWORK_IP"],
         "CMN_PREFIX_LEN": sls_variables["CMN_PREFIX_LEN"],
+        "CMN_PREFIX_LEN6": sls_variables["CMN_PREFIX_LEN6"],
         "CMN_ASN": sls_variables["CMN_ASN"],
         "MTL_NETMASK": sls_variables["MTL_NETMASK"],
         "MTL_PREFIX_LEN": sls_variables["MTL_PREFIX_LEN"],
@@ -825,9 +829,13 @@ def generate_switch_config(
         "CAN_IP_PRIMARY": sls_variables["CAN_IP_PRIMARY"],
         "CAN_IP_SECONDARY": sls_variables["CAN_IP_SECONDARY"],
         "CHN_IP_GATEWAY": sls_variables["CHN_IP_GATEWAY"],
+        "CHN_IP_GATEWAY6": sls_variables["CHN_IP_GATEWAY6"],
         "CHN_IP_PRIMARY": sls_variables["CHN_IP_PRIMARY"],
         "CHN_IP_SECONDARY": sls_variables["CHN_IP_SECONDARY"],
+        "CHN_IP_PRIMARY6": sls_variables["CHN_IP_PRIMARY6"],
+        "CHN_IP_SECONDARY6": sls_variables["CHN_IP_SECONDARY6"],
         "CMN_IP_GATEWAY": sls_variables["CMN_IP_GATEWAY"],
+        "CMN_IP_GATEWAY6": sls_variables["CMN_IP_GATEWAY6"],
         "CMN_IP_PRIMARY": sls_variables["CMN_IP_PRIMARY"],
         "CMN_IP_SECONDARY": sls_variables["CMN_IP_SECONDARY"],
         "NMN_MTN_CABINETS": sls_variables["NMN_MTN_CABINETS"],
@@ -838,6 +846,7 @@ def generate_switch_config(
         "CAN_IPs": sls_variables["CAN_IPs"],
         "CHN_IPs": sls_variables["CHN_IPs"],
         "CMN_IPs": sls_variables["CMN_IPs"],
+        "CMN_IPs6": sls_variables["CMN_IPs6"],
         "NMN_IPs": sls_variables["NMN_IPs"],
         "HMN_IPs": sls_variables["HMN_IPs"],
         "SWITCH_ASN": sls_variables["SWITCH_ASN"],
@@ -846,6 +855,7 @@ def generate_switch_config(
         "BOND_APP_NODES": bond_app_nodes,
         "BLACK_HOLE_VLAN_1": black_hole_vlan_1,
         "BLACK_HOLE_VLAN_2": black_hole_vlan_2,
+        "IPV6_ENABLED": sls_variables["IPV6_ENABLED"],
     }
 
     cabling = {}
@@ -875,6 +885,8 @@ def generate_switch_config(
             switch_name = "chn-switch-2"
         if sls_variables.get("CHN_IPs", {}).get(switch_name):
             variables["CHN_IP"] = sls_variables["CHN_IPs"][switch_name]
+            if variables["IPV6_ENABLED"]:
+                variables["CHN_IP6"] = sls_variables["CHN_IPs6"][switch_name]
             last_octet = variables["CHN_IP"].split(".")[3]
             variables["LOOPBACK_IP"] = "10.2.1." + last_octet
             variables["EDGE_BGP_IP_PRIMARY"] = "10.2.3.2"
@@ -888,6 +900,7 @@ def generate_switch_config(
             sys.exit(1)
     else:
         variables["CMN_IP"] = sls_variables.get("CMN_IPs", {}).get(switch_name)
+        variables["CMN_IP6"] = sls_variables.get("CMN_IPs6", {}).get(switch_name)
         variables["HMN_IP"] = sls_variables.get("HMN_IPs", {}).get(switch_name)
         variables["MTL_IP"] = sls_variables.get("MTL_IPs", {}).get(switch_name)
         variables["NMN_IP"] = sls_variables.get("NMN_IPs", {}).get(switch_name)
@@ -1751,15 +1764,19 @@ def parse_sls_for_config(input_json):
         "CAN_PREFIX_LEN": None,
         "CAN_NETWORK_IP": None,
         "CHN": None,
+        "CHN6": None,
         "CHN_VLAN": None,
         "CHN_NETMASK": None,
         "CHN_PREFIX_LEN": None,
+        "CHN_PREFIX_LEN6": None,
         "CHN_NETWORK_IP": None,
         "CHN_ASN": None,
         "CMN": None,
+        "CMN6": None,
         "CMN_VLAN": None,
         "CMN_NETMASK": None,
         "CMN_PREFIX_LEN": None,
+        "CMN_PREFIX_LEN6": None,
         "CMN_NETWORK_IP": None,
         "CMN_ASN": None,
         "HMN": None,
@@ -1799,7 +1816,9 @@ def parse_sls_for_config(input_json):
         "NMNLB_DNS": None,
         "CAN_IP_GATEWAY": None,
         "CHN_IP_GATEWAY": None,
+        "CHN_IP_GATEWAY6": None,
         "CMN_IP_GATEWAY": None,
+        "CMN_IP_GATEWAY6": None,
         "HMN_IP_GATEWAY": None,
         "MTL_IP_GATEWAY": None,
         "NMN_IP_GATEWAY": None,
@@ -1812,17 +1831,29 @@ def parse_sls_for_config(input_json):
         "CAN_IP_SECONDARY": None,
         "CHN_IP_PRIMARY": None,
         "CHN_IP_SECONDARY": None,
+        "CHN_IP_PRIMARY6": None,
+        "CHN_IP_SECONDARY6": None,
         "CMN_IP_PRIMARY": None,
         "CMN_IP_SECONDARY": None,
         "CAN_IPs": defaultdict(),
         "CHN_IPs": defaultdict(),
+        "CHN_IPs6": defaultdict(),
         "CMN_IPs": defaultdict(),
+        "CMN_IPs6": defaultdict(),
         "HMN_IPs": defaultdict(),
         "MTL_IPs": defaultdict(),
         "NMN_IPs": defaultdict(),
         "NMN_MTN_CABINETS": [],
         "HMN_MTN_CABINETS": [],
+        "IPV6_ENABLED": None,
     }
+
+    # Figure out up front if IPv6 support should be enabled or not.
+    cmn_network = list(filter(lambda network: network.get("Name") == "CMN", input_json))
+    if cmn_network:
+        sls_variables["IPV6_ENABLED"] = bool(cmn_network[0].get("ExtraProperties", {}).get("CIDR6"))
+    else:
+        sls_variables["IPV6_ENABLED"] = False
 
     for sls_network in input_json:
         name = sls_network.get("Name", "")
@@ -1858,6 +1889,14 @@ def parse_sls_for_config(input_json):
                     "",
                 ),
             )
+            if sls_variables["IPV6_ENABLED"]:
+                sls_variables["CHN6"] = netaddr.IPNetwork(
+                    sls_network.get("ExtraProperties", {}).get(
+                        "CIDR6",
+                        "",
+                    ),
+                )
+                sls_variables["CHN_PREFIX_LEN6"] = sls_variables["CHN6"].prefixlen
             sls_variables["CHN_NETMASK"] = sls_variables["CHN"].netmask
             sls_variables["CHN_PREFIX_LEN"] = sls_variables["CHN"].prefixlen
             sls_variables["CHN_NETWORK_IP"] = sls_variables["CHN"].ip
@@ -1868,15 +1907,23 @@ def parse_sls_for_config(input_json):
             for subnets in sls_network.get("ExtraProperties", {}).get("Subnets", {}):
                 if subnets["Name"] == "bootstrap_dhcp":
                     sls_variables["CHN_IP_GATEWAY"] = subnets["Gateway"]
+                    if sls_variables["IPV6_ENABLED"]:
+                        sls_variables["CHN_IP_GATEWAY6"] = subnets["Gateway6"]
                     sls_variables["CHN_VLAN"] = subnets["VlanID"]
                     for ip in subnets["IPReservations"]:
                         if ip["Name"] == "chn-switch-1":
                             sls_variables["CHN_IP_PRIMARY"] = ip["IPAddress"]
+                            if sls_variables["IPV6_ENABLED"]:
+                                sls_variables["CHN_IP_PRIMARY6"] = ip["IPAddress6"]
                         elif ip["Name"] == "chn-switch-2":
                             sls_variables["CHN_IP_SECONDARY"] = ip["IPAddress"]
+                            if sls_variables["IPV6_ENABLED"]:
+                                sls_variables["CHN_IP_SECONDARY6"] = ip["IPAddress6"]
                 if subnets["Name"] == "bootstrap_dhcp":
                     for ip in subnets["IPReservations"]:
                         sls_variables["CHN_IPs"][ip["Name"]] = ip["IPAddress"]
+                        if sls_variables["IPV6_ENABLED"]:
+                            sls_variables["CHN_IPs6"][ip["Name"]] = ip["IPAddress6"]
 
         elif name == "CMN":
             sls_variables["CMN"] = netaddr.IPNetwork(
@@ -1885,6 +1932,14 @@ def parse_sls_for_config(input_json):
                     "",
                 ),
             )
+            if sls_variables["IPV6_ENABLED"]:
+                sls_variables["CMN6"] = netaddr.IPNetwork(
+                    sls_network.get("ExtraProperties", {}).get(
+                        "CIDR6",
+                        "",
+                    ),
+                )
+                sls_variables["CMN_PREFIX_LEN6"] = sls_variables["CMN6"].prefixlen
             sls_variables["CMN_NETMASK"] = sls_variables["CMN"].netmask
             sls_variables["CMN_PREFIX_LEN"] = sls_variables["CMN"].prefixlen
             sls_variables["CMN_NETWORK_IP"] = sls_variables["CMN"].ip
@@ -1895,11 +1950,15 @@ def parse_sls_for_config(input_json):
             for subnets in sls_network.get("ExtraProperties", {}).get("Subnets", {}):
                 if subnets["Name"] == "bootstrap_dhcp":
                     sls_variables["CMN_IP_GATEWAY"] = subnets["Gateway"]
+                    if sls_variables["IPV6_ENABLED"]:
+                        sls_variables["CMN_IP_GATEWAY6"] = subnets["Gateway6"]
                     sls_variables["CMN_VLAN"] = subnets["VlanID"]
                 if subnets["Name"] == "network_hardware":
                     for ip in subnets["IPReservations"]:
                         if "sw" in ip["Name"]:
                             sls_variables["CMN_IPs"][ip["Name"]] = ip["IPAddress"]
+                            if sls_variables["IPV6_ENABLED"]:
+                                sls_variables["CMN_IPs6"][ip["Name"]] = ip["IPAddress6"]
                 if subnets["Name"] == "bootstrap_dhcp":
                     for ip in subnets["IPReservations"]:
                         if "ncn-w" in ip["Name"]:

--- a/network_modeling/configs/templates/1.7/arista/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.7/arista/sw-edge.primary.j2
@@ -37,7 +37,16 @@ interface Vlan{{ variables.CHN_VLAN }}
    mtu 9214
    ip address {{ variables.CHN_IP }}/{{variables.CHN_PREFIX_LEN}}
    ip virtual-router address {{ variables.CHN_IP_GATEWAY }}
+{%- if variables.IPV6_ENABLED %}
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address {{ variables.CHN_IP_GATEWAY6 }}
+   ipv6 address {{ variables.CHN_IP6 }}/{{variables.CHN_PREFIX_LEN6}}
+{%- endif %}
+
 ip routing
+{%- if variables.IPV6_ENABLED %}
+ipv6 unicast-routing
+{%- endif %}
 
 ip virtual-router mac-address 06:00:00:20:20:20
 

--- a/network_modeling/configs/templates/1.7/arista/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.7/arista/sw-edge.primary.j2
@@ -42,7 +42,6 @@ interface Vlan{{ variables.CHN_VLAN }}
    ipv6 virtual-router address {{ variables.CHN_IP_GATEWAY6 }}
    ipv6 address {{ variables.CHN_IP6 }}/{{variables.CHN_PREFIX_LEN6}}
 {%- endif %}
-
 ip routing
 {%- if variables.IPV6_ENABLED %}
 ipv6 unicast-routing

--- a/network_modeling/configs/templates/1.7/arista/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.7/arista/sw-edge.secondary.j2
@@ -37,7 +37,15 @@ interface Vlan{{ variables.CHN_VLAN }}
    mtu 9214
    ip address {{ variables.CHN_IP }}/{{variables.CHN_PREFIX_LEN}}
    ip virtual-router address {{ variables.CHN_IP_GATEWAY }}
+{%- if variables.IPV6_ENABLED %}
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address {{ variables.CHN_IP_GATEWAY6 }}
+   ipv6 address {{ variables.CHN_IP_PRIMARY6 }}/{{variables.CHN_PREFIX_LEN6}}
+{%- endif %}
 ip routing
+{%- if variables.IPV6_ENABLED %}
+ipv6 unicast-routing
+{%- endif %}
 
 ip virtual-router mac-address 06:00:00:20:20:20
 

--- a/network_modeling/configs/templates/1.7/aruba/common/acl.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/acl.j2
@@ -79,6 +79,13 @@ access-list ip cmn-can
 {% set sequence = sequence+10 %}    {{ sequence }} deny any {{ variables.CHN_NETWORK_IP }}/{{ variables.CHN_NETMASK }} {{ variables.CMN_NETWORK_IP }}/{{ variables.CMN_NETMASK }}
 {%- endif %}
 {% set sequence = sequence+10 %}    {{ sequence }} permit any any any
+{%- if variables.IPV6_ENABLED %}
+access-list ipv6 cmn-chn-ipv6
+{%- set sequence = 0 %}
+{% set sequence = sequence+10 %}    {{ sequence }} deny any {{ variables.CMN6 }} {{ variables.CHN6 }}
+{% set sequence = sequence+10 %}    {{ sequence }} deny any {{ variables.CHN6 }} {{ variables.CMN6 }}
+{% set sequence = sequence+10 %}    {{ sequence }} permit any any any
+{%- endif  %}
 apply access-list ip mgmt control-plane vrf default
 apply access-list ip mgmt control-plane vrf {{ variables.VRF }}
 {#- end acl #}

--- a/network_modeling/configs/templates/1.7/aruba/common/sw-cdu.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/sw-cdu.primary.j2
@@ -32,6 +32,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -80,6 +84,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 router ospf 2 vrf {{ variables.VRF }}
@@ -88,6 +96,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/common/sw-cdu.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/sw-cdu.secondary.j2
@@ -32,6 +32,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -80,6 +84,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 router ospf 2 vrf {{ variables.VRF }}
@@ -88,6 +96,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-leaf-bmc.j2
@@ -26,6 +26,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -75,6 +79,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 snmp-server vrf default
 snmp-server vrf {{ variables.VRF }}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
@@ -84,6 +92,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.primary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -87,6 +91,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 
 router ospf 2 vrf {{ variables.VRF }}
@@ -95,6 +103,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.secondary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -87,6 +91,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 
 router ospf 2 vrf {{ variables.VRF }}
@@ -95,6 +103,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-spine.primary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -95,6 +99,12 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CMN_IP_GATEWAY6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
@@ -116,6 +126,11 @@ router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     redistribute bgp
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 {% include variables.CSM_VERSION+'/aruba/common/bgp.primary.j2' %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-spine.secondary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -95,6 +99,12 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CMN_IP_GATEWAY6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
@@ -116,6 +126,11 @@ router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     redistribute bgp
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 {% include variables.CSM_VERSION+'/aruba/common/bgp.secondary.j2' %}
 https-server vrf {{ variables.VRF }}
 https-server vrf default

--- a/network_modeling/configs/templates/1.7/aruba/sw-edge.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/sw-edge.primary.j2
@@ -57,6 +57,12 @@ interface vlan {{ variables.CHN_VLAN }}
     active-gateway ip {{ variables.CHN_IP_GATEWAY }}
     ip helper-address 10.92.100.222
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CHN_IP6 }}/{{ variables.CHN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CHN_IP_GATEWAY6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 
 vsx

--- a/network_modeling/configs/templates/1.7/aruba/sw-edge.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/sw-edge.secondary.j2
@@ -56,6 +56,11 @@ interface vlan {{ variables.CHN_VLAN }}
     active-gateway ip {{ variables.CHN_IP_GATEWAY }}
     ip helper-address 10.92.100.222
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CHN_IP6 }}/{{ variables.CHN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CHN_IP_GATEWAY6 }}
+{%- endif %}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
 
 vsx

--- a/network_modeling/configs/templates/1.7/aruba/tds/sw-leaf-bmc.j2
+++ b/network_modeling/configs/templates/1.7/aruba/tds/sw-leaf-bmc.j2
@@ -26,6 +26,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -75,6 +79,10 @@ interface vlan {{ variables.CMN_VLAN }}
     ip mtu 9198
     ip address {{ variables.CMN_IP }}/{{variables.CMN_PREFIX_LEN}}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 snmp-server vrf default
 snmp-server vrf {{ variables.VRF }}
 ip dns server-address {{ variables.NMNLB_DNS }} vrf {{ variables.VRF }}
@@ -84,6 +92,11 @@ router ospf 2 vrf {{ variables.VRF }}
 router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 https-server vrf default
 https-server vrf mgmt
 https-server vrf {{ variables.VRF }}

--- a/network_modeling/configs/templates/1.7/aruba/tds/sw-spine.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/tds/sw-spine.primary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -100,6 +104,12 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CMN_IP_GATEWAY6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
@@ -121,6 +131,11 @@ router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     redistribute bgp
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 {% include variables.CSM_VERSION+'/aruba/common/bgp.primary.j2' %}
 https-server vrf default
 https-server vrf mgmt

--- a/network_modeling/configs/templates/1.7/aruba/tds/sw-spine.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/tds/sw-spine.secondary.j2
@@ -28,6 +28,10 @@ vlan {{ variables.CMN_VLAN }}
     name CMN
     apply access-list ip cmn-can in
     apply access-list ip cmn-can out
+{%- if variables.IPV6_ENABLED %}
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+{%- endif %}
 vlan {{ variables.BLACK_HOLE_VLAN_1 }}
     name NULL{{ variables.BLACK_HOLE_VLAN_1 }}
     description Black hole VLAN {{ variables.BLACK_HOLE_VLAN_1 }}
@@ -100,6 +104,12 @@ interface vlan {{ variables.CMN_VLAN }}
     active-gateway ip mac 12:00:00:00:6b:00
     active-gateway ip {{ variables.CMN_IP_GATEWAY }}
     ip ospf 1 area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+    ipv6 address {{ variables.CMN_IP6 }}/{{ variables.CMN_PREFIX_LEN6 }}
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 {{ variables.CMN_IP_GATEWAY6 }}
+    ipv6 ospfv3 1 area 0.0.0.0
+{%- endif %}
 {%- endif %}
 {%- if variables.CAN != None %}
 interface vlan {{ variables.CAN_VLAN }}
@@ -121,6 +131,11 @@ router ospf 1
     router-id {{ variables.LOOPBACK_IP }}
     redistribute bgp
     area 0.0.0.0
+{%- if variables.IPV6_ENABLED %}
+router ospfv3 1
+   router-id {{ variables.LOOPBACK_IP }}
+   area 0.0.0.0
+{%- endif %}
 {% include variables.CSM_VERSION+'/aruba/common/bgp.secondary.j2' %}
 https-server vrf default
 https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-001-ipv6.cfg
@@ -1,0 +1,294 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::c/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.16
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-002-ipv6.cfg
@@ -1,0 +1,286 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::d/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.17
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-edge-001-ipv6.cfg
@@ -1,0 +1,93 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-edge-001-ipv6.cfg
@@ -40,7 +40,6 @@ interface Vlan5
    ipv6 nd ra disabled all
    ipv6 virtual-router address 2001:db8:200::1
    ipv6 address 2001:db8:200::2/64
-
 ip routing
 ipv6 unicast-routing
 

--- a/tests/data/golden_configs/full_configs_1.7/sw-edge-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-edge-002-ipv6.cfg
@@ -1,0 +1,90 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-001-ipv6.cfg
@@ -1,0 +1,341 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::4/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.4
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-001.cfg
@@ -16,7 +16,6 @@ ntp server 192.168.4.6
 ntp enable
 ntp vrf CSM
 
-
 aruba-central
     disable
 ssh server vrf default

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-002-ipv6.cfg
@@ -1,0 +1,341 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::5/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.5
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-002.cfg
@@ -16,7 +16,6 @@ ntp server 192.168.4.6
 ntp enable
 ntp vrf CSM
 
-
 aruba-central
     disable
 ssh server vrf default

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-003-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-003-ipv6.cfg
@@ -1,0 +1,344 @@
+
+hostname sw-leaf-003
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-leaf-003
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-leaf-003
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-leaf-003
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-leaf-003
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-leaf-003
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-leaf-003
+    lag 6
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-leaf-003
+    lag 8
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-leaf-003
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:3<==sw-leaf-003
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:3<==sw-leaf-003
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.6/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.6/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.6/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.6/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.6/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::6/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.6
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.6
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.6
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-004-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-004-ipv6.cfg
@@ -1,0 +1,341 @@
+
+hostname sw-leaf-004
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-leaf-004
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-leaf-004
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    lag 6
+
+interface 1/1/7
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    lag 8
+interface 1/1/9
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:4<==sw-leaf-004
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:4<==sw-leaf-004
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.7/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.7/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.7/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.7/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.7/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::7/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.7
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.7
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.7
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001-ipv6.cfg
@@ -1,0 +1,476 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::8/64
+    ipv6 ospfv3 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.12
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-001-ipv6.cfg
@@ -1,0 +1,404 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:53<==sw-spine-001
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::2/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.2
+   area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-002-ipv6.cfg
@@ -1,0 +1,404 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::3/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.3
+   area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-001-ipv6.cfg
@@ -1,0 +1,294 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::c/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.16
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-cdu-002-ipv6.cfg
@@ -1,0 +1,286 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::d/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.17
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001-ipv6.cfg
@@ -1,0 +1,93 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-001-ipv6.cfg
@@ -40,7 +40,6 @@ interface Vlan5
    ipv6 nd ra disabled all
    ipv6 virtual-router address 2001:db8:200::1
    ipv6 address 2001:db8:200::2/64
-
 ip routing
 ipv6 unicast-routing
 

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-edge-002-ipv6.cfg
@@ -1,0 +1,90 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001-ipv6.cfg
@@ -1,0 +1,341 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::4/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.4
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-001.cfg
@@ -16,7 +16,6 @@ ntp server 192.168.4.6
 ntp enable
 ntp vrf CSM
 
-
 aruba-central
     disable
 ssh server vrf default

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002-ipv6.cfg
@@ -1,0 +1,341 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::5/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.5
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-002.cfg
@@ -16,7 +16,6 @@ ntp server 192.168.4.6
 ntp enable
 ntp vrf CSM
 
-
 aruba-central
     disable
 ssh server vrf default

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-003-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-003-ipv6.cfg
@@ -1,0 +1,344 @@
+
+hostname sw-leaf-003
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-leaf-003
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-leaf-003
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-leaf-003
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-leaf-003
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-leaf-003
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-leaf-003
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-leaf-003
+    lag 6
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-leaf-003
+    lag 8
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-leaf-003
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:ocp:2<==sw-leaf-003
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-leaf-003
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:3<==sw-leaf-003
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:3<==sw-leaf-003
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.6/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.6/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.6/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.6/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.6/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::6/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.6
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.6
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.6
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-004-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-004-ipv6.cfg
@@ -1,0 +1,342 @@
+
+hostname sw-leaf-004
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-leaf-004
+    lag 1
+
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-leaf-004
+    lag 3
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-leaf-004
+    lag 4
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-leaf-004
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-leaf-004
+    lag 6
+
+interface 1/1/7
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 8 multi-chassis
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-leaf-004
+    lag 8
+interface 1/1/9
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-leaf-004
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 10 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-leaf-004
+    lag 10
+
+
+
+
+interface lag 103 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:4<==sw-leaf-004
+    lag 103
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:4<==sw-leaf-004
+    lag 103
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:03:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.7/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.7/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.7/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.7/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.7/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::7/64
+    ipv6 ospfv3 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.7
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.7
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.7
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-leaf-bmc-001-ipv6.cfg
@@ -1,0 +1,462 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+
+hostname sw-leaf-bmc-001
+vrf CSM
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::8/64
+    ipv6 ospfv3 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospfv3 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-001-ipv6.cfg
@@ -1,0 +1,406 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.185
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.186/30
+#   exit
+# interface 1/1/1
+#   ip address 10.103.15.10/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-001
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-001
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::2/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.186/30
+    exit
+interface 1/1/1
+    no shutdown
+    ip address 10.103.15.10/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-001
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.185
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+    router-id 10.2.0.2
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.3 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.2
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.3 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.3 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002-ipv6.cfg
+++ b/tests/data/golden_configs/full_configs_custom_1.7/sw-spine-002-ipv6.cfg
@@ -1,0 +1,404 @@
+# The following switch configurations were inserted into the plan-of-record configuration from aruba_custom.yaml
+# Custom configurations are merged into the generated configuration to maintainsite-specific behaviors and (less frequently) to override known issues.
+
+# ip route 0.0.0.0/0 10.103.15.189
+# interface 1/1/36
+#   no shutdown
+#   ip address 10.103.15.190/30
+#   exit
+# system interface-group 3 speed 10g
+# interface 1/1/20
+#   no shutdown
+#   mtu 9198
+#   description ion-node<==sw-spine-002
+#   no routing
+#   vlan access 7
+#   spanning-tree bpdu-guard
+#   spanning-tree port-type admin-edge
+
+hostname sw-spine-002
+vrf CSM
+vrf keepalive
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    spanning-tree root-guard
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+aruba-central
+    disable
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+system interface-group 3 speed 10g
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::3/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/36
+    no shutdown
+    ip address 10.103.15.190/30
+    exit
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description ion-node<==sw-spine-002
+    no routing
+    vlan access 7
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+ip dns server-address 10.92.100.225 vrf CSM
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+ip route 0.0.0.0/0 10.103.15.189
+route-map ncn-w001 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w001 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w001 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w001 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.4
+route-map ncn-w001-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w002 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w002 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w002 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w002 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.5
+route-map ncn-w002-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+route-map ncn-w003 permit seq 10
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.4
+    set local-preference 1000
+route-map ncn-w003 permit seq 20
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.5
+    set local-preference 1100
+route-map ncn-w003 permit seq 30
+    match ip address prefix-list tftp
+    match ip next-hop 192.168.4.6
+    set local-preference 1200
+route-map ncn-w003 permit seq 40
+    match ip address prefix-list pl-hmn
+    set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+    match ip address prefix-list pl-nmn
+    set ip next-hop 192.168.4.6
+route-map ncn-w003-Customer permit seq 10
+    match ip address prefix-list pl-can
+    set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+    match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+    router-id 10.2.0.3
+    area 0.0.0.0
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+      neighbor 192.168.12.2 activate
+      neighbor 192.168.12.4 activate
+      neighbor 192.168.12.4 route-map ncn-w001-Customer in
+      neighbor 192.168.12.5 activate
+      neighbor 192.168.12.5 route-map ncn-w002-Customer in
+      neighbor 192.168.12.6 activate
+      neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+      bgp router-id 10.2.0.3
+      maximum-paths 32
+      timers bgp 1 3
+      distance bgp 20 70
+      neighbor 192.168.3.2 remote-as 65533
+      neighbor 192.168.4.4 remote-as 65531
+      neighbor 192.168.4.4 passive
+      neighbor 192.168.4.5 remote-as 65531
+      neighbor 192.168.4.5 passive
+      neighbor 192.168.4.6 remote-as 65531
+      neighbor 192.168.4.6 passive
+      address-family ipv4 unicast
+        neighbor 192.168.3.2 activate
+        neighbor 192.168.4.4 activate
+        neighbor 192.168.4.4 route-map ncn-w001 in
+        neighbor 192.168.4.5 activate
+        neighbor 192.168.4.5 route-map ncn-w002 in
+        neighbor 192.168.4.6 activate
+        neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-001-ipv6.cfg
@@ -1,0 +1,294 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:50<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:50<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::c/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.16
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-cdu-002-ipv6.cfg
@@ -1,0 +1,286 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:49<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:49<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::d/64
+    ipv6 ospfv3 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.17
+   area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-edge-001-ipv6.cfg
@@ -1,0 +1,93 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-001
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.194/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.119/20
+   
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.0/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.2/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.1
+   peer-address heartbeat 172.30.52.120
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.194
+   max-lsa 12000
+   default-information originate
+
+
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.194
+   maximum-paths 32
+   neighbor 10.2.1.195 remote-as 65533
+   neighbor 10.2.1.195 next-hop-self
+   neighbor 10.2.1.195 update-source Loopback0
+   neighbor 10.2.1.195 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.195 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.7/sw-edge-001-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-edge-001-ipv6.cfg
@@ -40,7 +40,6 @@ interface Vlan5
    ipv6 nd ra disabled all
    ipv6 virtual-router address 2001:db8:200::1
    ipv6 address 2001:db8:200::2/64
-
 ip routing
 ipv6 unicast-routing
 

--- a/tests/data/golden_configs/tds_configs_1.7/sw-edge-002-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-edge-002-ipv6.cfg
@@ -1,0 +1,90 @@
+
+
+transceiver qsfp default-mode 4x10G
+!
+hostname sw-edge-002
+!
+spanning-tree mode none
+no spanning-tree vlan-id 4094
+
+interface Loopback0
+   ip address 10.2.1.195/32
+   ip ospf area 0.0.0.0
+
+interface Management1
+   ip address 172.30.52.120/20
+
+vlan 5
+   name CHN
+
+vlan 4094
+   trunk group MLAG-Peer
+!
+interface Port-Channel1000
+ description [MLAG Peer-Link]
+ switchport mode trunk
+ switchport trunk group MLAG-Peer
+!
+interface Vlan4094
+   description [MLAG Link]
+   no autostate
+   ip address 10.255.255.1/31
+   ip ospf area 0.0.0.0
+!
+
+interface Vlan5
+   description CHN
+   mtu 9214
+   ip address 192.168.200.3/24
+   ip virtual-router address 192.168.200.1
+   ipv6 nd ra disabled all
+   ipv6 virtual-router address 2001:db8:200::1
+   ipv6 address 2001:db8:200::2/64
+ip routing
+ipv6 unicast-routing
+
+ip virtual-router mac-address 06:00:00:20:20:20
+
+ip prefix-list HSN seq 10 permit 192.168.200.0/24 ge 24
+!
+
+mlag configuration
+   domain-id edge
+   local-interface Vlan4094
+   peer-address 10.255.255.0
+   peer-address heartbeat 172.30.52.119
+   peer-link Port-Channel1000
+
+router ospf 1
+   router-id 10.2.1.195
+   max-lsa 12000
+   default-information originate
+route-map HSN permit 5
+   match ip address prefix-list HSN
+
+router bgp 65533
+   timers bgp 1 3
+   distance bgp 20 200 200
+   router-id 10.2.1.195
+   maximum-paths 32
+   neighbor 10.2.1.194 remote-as 65533
+   neighbor 10.2.1.194 next-hop-self
+   neighbor 10.2.1.194 update-source Loopback0
+   neighbor 10.2.1.194 maximum-routes 12000
+   neighbor 192.168.200.4 remote-as 65530
+   neighbor 192.168.200.4 passive
+   neighbor 192.168.200.4 route-map HSN in
+   neighbor 192.168.200.4 maximum-routes 12000
+   neighbor 192.168.200.5 remote-as 65530
+   neighbor 192.168.200.5 passive
+   neighbor 192.168.200.5 route-map HSN in
+   neighbor 192.168.200.5 maximum-routes 12000
+   neighbor 192.168.200.6 remote-as 65530
+   neighbor 192.168.200.6 passive
+   neighbor 192.168.200.6 route-map HSN in
+   neighbor 192.168.200.6 maximum-routes 12000
+   address-family ipv4
+      neighbor 10.2.1.194 activate
+      neighbor 192.168.200.4 activate
+      neighbor 192.168.200.5 activate
+      neighbor 192.168.200.6 activate

--- a/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001-ipv6.cfg
@@ -1,0 +1,466 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 101
+    no shutdown
+    description leaf_bmc_to_spine_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-spine-002:51<==sw-leaf-bmc-001
+    lag 101
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-spine-001:51<==sw-leaf-bmc-001
+    lag 101
+
+interface 1/1/19
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/20
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/21
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/22
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::8/64
+    ipv6 ospfv3 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.12
+   area 0.0.0.0
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-leaf-bmc-001.cfg
@@ -15,7 +15,6 @@ ntp server 192.168.4.6
 ntp enable
 ntp vrf CSM
 
-
 aruba-central
     disable
 ssh server vrf default

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-001-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-001-ipv6.cfg
@@ -1,0 +1,620 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-spine-001
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-spine-001
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:ocp:1<==sw-spine-001
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-spine-001
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:1<==sw-spine-001
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:1<==sw-spine-001
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-spine-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-spine-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-spine-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-spine-001
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:1<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:1<==sw-spine-001
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:ocp:2<==sw-spine-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:ocp:2<==sw-spine-001
+    lag 12
+
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description uan001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:ocp:2<==sw-spine-001
+    lag 14
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:1<==sw-spine-001
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:ocp:2<==sw-spine-001
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:ocp:2<==sw-spine-001
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-spine-001
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::2/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.2
+   area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/golden_configs/tds_configs_1.7/sw-spine-002-ipv6.cfg
+++ b/tests/data/golden_configs/tds_configs_1.7/sw-spine-002-ipv6.cfg
@@ -1,0 +1,618 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 1.9.14.dev0+g9cd029d.d20250627
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+access-list ipv6 cmn-chn-ipv6
+    10 deny any 2001:db8:100::/64 2001:db8:200::/64
+    20 deny any 2001:db8:200::/64 2001:db8:100::/64
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+    apply access-list ipv6 cmn-chn-ipv6 in
+    apply access-list ipv6 cmn-chn-ipv6 out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-spine-002
+    lag 1
+
+interface lag 2 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-spine-002
+    lag 2
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:pcie-slot1:1<==sw-spine-002
+    lag 3
+
+
+interface lag 4 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-spine-002
+    lag 4
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w002:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:ocp:2<==sw-spine-002
+    lag 5
+
+interface lag 6 multi-chassis
+    no shutdown
+    description ncn-w003:ocp:2<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:ocp:2<==sw-spine-002
+    lag 6
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-spine-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-spine-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-spine-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-spine-002
+    lag 10
+
+interface lag 11 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:1<==sw-spine-002
+    lag 11
+
+interface lag 12 multi-chassis
+    no shutdown
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description ncn-s003:pcie-slot1:2<==sw-spine-002
+    lag 12
+
+interface 1/1/13
+    mtu 9198
+    description uan001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 14 multi-chassis
+    description uan001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description uan001:pcie-slot1:2<==sw-spine-002
+    lag 14
+interface 1/1/15
+    mtu 9198
+    description lmem001:pcie-slot1:1<==sw-spine-002
+    no routing
+    vlan access 2
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 16 multi-chassis
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    no routing
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    no shutdown
+    vlan trunk native 2701
+    vlan trunk allowed 2707
+
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description lmem001:pcie-slot1:2<==sw-spine-002
+    lag 16
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-spine-002
+    lag 151
+
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+    ipv6 address 2001:db8:100::3/64
+    active-gateway ipv6 mac 12:00:00:00:6b:00
+    active-gateway ipv6 2001:db8:100::1
+    ipv6 ospfv3 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospfv3 1
+   router-id 10.2.0.3
+   area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf default
+https-server vrf mgmt
+https-server vrf CSM
+

--- a/tests/data/sls_input_file_csm_1.2_ipv6.json
+++ b/tests/data/sls_input_file_csm_1.2_ipv6.json
@@ -1,0 +1,299 @@
+{
+    "Networks": {
+        "CAN": {
+            "Name": "CAN",
+            "ExtraProperties": {
+                "CIDR": "192.168.11.0/24",
+                "Subnets": [
+                    {
+                        "Name": "bootstrap_dhcp",
+                        "CIDR": "192.168.11.0/24",
+                        "IPReservations": [
+                            {"Name": "can-switch-1", "IPAddress": "192.168.11.2"},
+                            {"Name": "can-switch-2", "IPAddress": "192.168.11.3"}
+                        ],
+                        "VlanID": 7,
+                        "Gateway": "192.168.11.1"
+                    },
+                    {
+                        "FullName": "CAN Bootstrap DHCP Subnet",
+                        "CIDR": "192.168.11.0/24",
+                        "IPReservations": [
+                            {"Name": "ncn-w001", "IPAddress": "192.168.11.4"},
+                            {"Name": "ncn-w002", "IPAddress": "192.168.11.5"},
+                            {"Name": "ncn-w003", "IPAddress": "192.168.11.6"}
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 7,
+                        "Gateway": "192.168.11.1"
+                    }
+                ]
+            }
+        },
+        "CHN": {
+            "Name": "CHN",
+            "ExtraProperties": {
+                "CIDR": "192.168.200.0/24",
+		"CIDR6": "2001:db8:200::/64",
+                "MyASN": 65530,
+                "PeerASN": 65533,
+                "Subnets": [
+                    {
+                        "Name": "bootstrap_dhcp",
+                        "CIDR": "192.168.200.0/24",
+		        "CIDR6": "2001:db8:200::/64",
+                        "IPReservations": [
+                            {"Name": "chn-switch-1", "IPAddress": "192.168.200.2", "IPAddress6": "2001:db8:200::2"},
+                            {"Name": "chn-switch-2", "IPAddress": "192.168.200.3", "IPAddress6": "2001:db8:200::3"}
+                        ],
+                        "VlanID": 5,
+                        "Gateway": "192.168.200.1",
+		        "Gateway6": "2001:db8:200::1"
+                    },
+                    {
+                        "FullName": "CHN Bootstrap DHCP Subnet",
+                        "CIDR": "192.168.200.0/24",
+		        "CIDR6": "2001:db8:100::/64",
+                        "IPReservations": [
+                            {"Name": "ncn-w001", "IPAddress": "192.168.200.4", "IPAddress6": "2001:db8:200::4"},
+                            {"Name": "ncn-w002", "IPAddress": "192.168.200.5", "IPAddress6": "2001:db8:200::5"},
+                            {"Name": "ncn-w003", "IPAddress": "192.168.200.6", "IPAddress6": "2001:db8:200::6"}
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 5,
+                        "Gateway": "192.168.200.1",
+		        "Gateway6": "2001:db8:200::1"
+                    }
+                ]
+            }
+        },
+        "CMN": {
+            "Name": "CMN",
+            "ExtraProperties": {
+                "CIDR": "192.168.12.0/24",
+		"CIDR6": "2001:db8:100::/64",
+                "MyASN": 65532,
+                "PeerASN": 65533,
+                "Subnets": [
+                    {
+                        "Name": "network_hardware",
+                        "CIDR": "192.168.12.0/24",
+		        "CIDR6": "2001:db8:100::/64",
+                        "IPReservations": [
+                            {"Name": "sw-spine-001", "IPAddress": "192.168.12.2", "IPAddress6": "2001:db8:100::2"},
+                            {"Name": "sw-spine-002", "IPAddress": "192.168.12.3", "IPAddress6": "2001:db8:100::3"},
+                            {"Name": "sw-leaf-001", "IPAddress": "192.168.12.4", "IPAddress6": "2001:db8:100::4"},
+                            {"Name": "sw-leaf-002", "IPAddress": "192.168.12.5", "IPAddress6": "2001:db8:100::5"},
+                            {"Name": "sw-leaf-003", "IPAddress": "192.168.12.6", "IPAddress6": "2001:db8:100::6"},
+                            {"Name": "sw-leaf-004", "IPAddress": "192.168.12.7", "IPAddress6": "2001:db8:100::7"},
+                            {"Name": "sw-leaf-bmc-001", "IPAddress": "192.168.12.12", "IPAddress6": "2001:db8:100::8"},
+                            {"Name": "sw-leaf-bmc-002", "IPAddress": "192.168.12.13", "IPAddress6": "2001:db8:100::9"},
+                            {"Name": "sw-leaf-bmc-003", "IPAddress": "192.168.12.14", "IPAddress6": "2001:db8:100::a"},
+                            {"Name": "sw-leaf-bmc-004", "IPAddress": "192.168.12.15", "IPAddress6": "2001:db8:100::b"},
+                            {"Name": "sw-cdu-001", "IPAddress": "192.168.12.16", "IPAddress6": "2001:db8:100::c"},
+                            {"Name": "sw-cdu-002", "IPAddress": "192.168.12.17", "IPAddress6": "2001:db8:100::d"}
+                        ],
+                        "VlanID": 6,
+                        "Gateway": "192.168.12.1",
+			"Gateway6": "2001:db8:100::1"
+                    },
+                    {
+                        "FullName": "CMN Bootstrap DHCP Subnet",
+                        "CIDR": "192.168.12.0/24",
+                        "IPReservations": [
+                            {"Name": "ncn-w001", "IPAddress": "192.168.12.4", "IPAddress6": "2001:db8:100::4"},
+                            {"Name": "ncn-w002", "IPAddress": "192.168.12.5", "IPAddress6": "2001:db8:100::5"},
+                            {"Name": "ncn-w003", "IPAddress": "192.168.12.6", "IPAddress6": "2001:db8:100::6"}
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 6,
+                        "Gateway": "192.168.12.1",
+			"Gateway6": "2001:db8:100::1"
+                    }
+                ]
+            }
+        },
+        "HMN": {
+            "Name": "HMN",
+            "ExtraProperties": {
+                "CIDR": "192.168.0.0/17",
+                "Subnets": [
+                    {
+                        "Name": "network_hardware",
+                        "CIDR": "192.168.0.0/17",
+                        "IPReservations": [
+                            {"Name": "sw-spine-001", "IPAddress": "192.168.0.2"},
+                            {"Name": "sw-spine-002", "IPAddress": "192.168.0.3"},
+                            {"Name": "sw-leaf-001", "IPAddress": "192.168.0.4"},
+                            {"Name": "sw-leaf-002", "IPAddress": "192.168.0.5"},
+                            {"Name": "sw-leaf-003", "IPAddress": "192.168.0.6"},
+                            {"Name": "sw-leaf-004", "IPAddress": "192.168.0.7"},
+                            {"Name": "sw-leaf-bmc-001", "IPAddress": "192.168.0.12"},
+                            {"Name": "sw-leaf-bmc-002", "IPAddress": "192.168.0.13"},
+                            {"Name": "sw-leaf-bmc-003", "IPAddress": "192.168.0.14"},
+                            {"Name": "sw-leaf-bmc-004", "IPAddress": "192.168.0.15"},
+                            {"Name": "sw-cdu-001", "IPAddress": "192.168.0.16"},
+                            {"Name": "sw-cdu-002", "IPAddress": "192.168.0.17"}
+                        ],
+                        "VlanID": 4,
+                        "Gateway": "192.168.0.1"
+                    },
+                    {
+                        "FullName": "HMN Bootstrap DHCP Subnet",
+                        "CIDR": "192.168.0.0/17",
+                        "IPReservations": [
+                            {"Name": "ncn-w001", "IPAddress": "192.168.0.4"},
+                            {"Name": "ncn-w002", "IPAddress": "192.168.0.5"},
+                            {"Name": "ncn-w003", "IPAddress": "192.168.0.6"}
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 4,
+                        "Gateway": "192.168.0.1"
+                    }
+                ]
+            }
+        },
+        "MTL": {
+            "Name": "MTL",
+            "ExtraProperties": {
+                "CIDR": "192.168.1.0/16",
+                "Subnets": [
+                    {
+                        "Name": "network_hardware",
+                        "CIDR": "192.168.1.0/16",
+                        "IPReservations": [
+                            {"Name": "sw-spine-001", "IPAddress": "192.168.1.2"},
+                            {"Name": "sw-spine-002", "IPAddress": "192.168.1.3"},
+                            {"Name": "sw-leaf-001", "IPAddress": "192.168.1.4"},
+                            {"Name": "sw-leaf-002", "IPAddress": "192.168.1.5"},
+                            {"Name": "sw-leaf-003", "IPAddress": "192.168.1.6"},
+                            {"Name": "sw-leaf-004", "IPAddress": "192.168.1.7"},
+                            {"Name": "sw-leaf-bmc-001", "IPAddress": "192.168.1.12"},
+                            {"Name": "sw-leaf-bmc-002", "IPAddress": "192.168.1.13"},
+                            {"Name": "sw-leaf-bmc-003", "IPAddress": "192.168.1.14"},
+                            {"Name": "sw-leaf-bmc-004", "IPAddress": "192.168.1.15"},
+                            {"Name": "sw-cdu-001", "IPAddress": "192.168.1.16"},
+                            {"Name": "sw-cdu-002", "IPAddress": "192.168.1.17"}
+                        ],
+                        "VlanID": 0,
+                        "Gateway": "192.168.1.1"
+                    }
+                ]
+            }
+        },
+        "NMN": {
+            "Name": "NMN",
+            "FullName": "Node Management Network",
+            "ExtraProperties": {
+                "CIDR": "192.168.3.0/17",
+                "MyASN": 65531,
+                "PeerASN": 65533,
+                "Subnets": [
+                    {
+                        "FullName": "NMN Management Network Infrastructure",
+                        "CIDR": "192.168.3.0/17",
+                        "IPReservations": [
+                            {"Name": "sw-spine-001", "IPAddress": "192.168.3.2"},
+                            {"Name": "sw-spine-002", "IPAddress": "192.168.3.3"},
+                            {"Name": "sw-leaf-001", "IPAddress": "192.168.3.4"},
+                            {"Name": "sw-leaf-002", "IPAddress": "192.168.3.5"},
+                            {"Name": "sw-leaf-003", "IPAddress": "192.168.3.6"},
+                            {"Name": "sw-leaf-004", "IPAddress": "192.168.3.7"},
+                            {"Name": "sw-leaf-bmc-001", "IPAddress": "192.168.3.12"},
+                            {"Name": "sw-leaf-bmc-002", "IPAddress": "192.168.3.13"},
+                            {"Name": "sw-leaf-bmc-003", "IPAddress": "192.168.3.14"},
+                            {"Name": "sw-leaf-bmc-004", "IPAddress": "192.168.3.15"},
+                            {"Name": "sw-cdu-001", "IPAddress": "192.168.3.16"},
+                            {"Name": "sw-cdu-002", "IPAddress": "192.168.3.17"}
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 2,
+                        "Gateway": "192.168.3.1"
+                    },
+                    {
+                        "FullName": "NMN Bootstrap DHCP Subnet",
+                        "CIDR": "192.168.4.0/17",
+                        "IPReservations": [
+                            {"Name": "ncn-w001", "IPAddress": "192.168.4.4"},
+                            {"Name": "ncn-w002", "IPAddress": "192.168.4.5"},
+                            {"Name": "ncn-w003", "IPAddress": "192.168.4.6"}
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 2,
+                        "Gateway": "192.168.3.1"
+                    }
+                ]
+            }
+        },
+        "NMN_MTN": {
+            "Name": "NMN_MTN",
+            "ExtraProperties": {
+                "CIDR": "192.168.100.0/17",
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "192.168.100.0/22",
+                        "Name": "cabinet_3002",
+                        "VlanID": 2000,
+                        "Gateway": "192.168.100.1",
+                        "DHCPStart": "192.168.100.10",
+                        "DHCPEnd": "192.168.3.254"
+                    }
+                ]
+            }
+        },
+        "HMN_MTN": {
+            "Name": "HMN_MTN",
+            "ExtraProperties": {
+                "CIDR": "192.168.200.0/17",
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "192.168.104.0/22",
+                        "Name": "cabinet_3002",
+                        "VlanID": 3000,
+                        "Gateway": "192.168.104.1",
+                        "DHCPStart": "192.168.104.10",
+                        "DHCPEnd": "192.168.104.254"
+                    }
+                ]
+            }
+        },
+        "HMNLB": {
+            "Name": "HMNLB",
+            "ExtraProperties": {
+                "CIDR": "10.94.100.0/24",
+                "Subnets": [
+                    {
+                        "FullName": "NMN MetalLB",
+                        "CIDR": "10.94.100.0/24",
+                        "IPReservations": [
+                            {"Name": "cray-tftp", "IPAddress": "10.94.100.60"},
+                            {"Name": "unbound", "IPAddress": "10.94.100.225"}
+                        ],
+                        "Name": "hmn_metallb_address_pool",
+                        "Gateway": "10.94.100.1"
+                    }
+                ]
+            }
+        },
+        "NMNLB": {
+            "Name": "NMNLB",
+            "ExtraProperties": {
+                "CIDR": "10.92.100.0/24",
+                "Subnets": [
+                    {
+                        "FullName": "HMN MetalLB",
+                        "CIDR": "10.92.100.0/24",
+                        "IPReservations": [
+                            {"Name": "cray-tftp", "IPAddress": "10.92.100.60"},
+                            {"Name": "unbound", "IPAddress": "10.92.100.225"}
+                        ],
+                        "Name": "nmn_metallb_address_pool",
+                        "Gateway": "10.92.100.1"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
@@ -33,7 +33,7 @@ from canu.cli import cli
 
 test_file_directory = Path(__file__).resolve().parent
 
-csm = "1.6"
+csm = "1.7"
 
 test_file_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
 test_file = path.join(test_file_directory, "data", test_file_name)

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
@@ -32,7 +32,7 @@ from canu.cli import cli
 test_file_directory = Path(__file__).resolve().parent
 data_directory = path.join(test_file_directory, "data")
 
-csm = "1.6"
+csm = "1.7"
 cache_minutes = 0
 sls_address = "api-gw-service-nmn.local"
 
@@ -95,7 +95,7 @@ def test_switch_config_spine_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -132,7 +132,7 @@ def test_switch_config_spine_primary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -172,7 +172,7 @@ def test_switch_config_spine_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -210,7 +210,7 @@ def test_switch_config_spine_secondary_custom():
     """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -250,7 +250,7 @@ def test_switch_config_leaf_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -287,7 +287,7 @@ def test_switch_config_leaf_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary leaf config."""
     switch_name = "sw-leaf-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -326,7 +326,7 @@ def test_switch_config_leaf_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -363,7 +363,7 @@ def test_switch_config_leaf_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf custom config."""
     switch_name = "sw-leaf-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -402,7 +402,7 @@ def test_switch_config_leaf_bmc():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -439,7 +439,7 @@ def test_switch_config_leaf_bmc_custom():
     """Test that the `canu generate switch config` command runs and returns valid leaf bmc custom config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -478,7 +478,7 @@ def test_switch_config_cdu_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -515,7 +515,7 @@ def test_switch_config_cdu_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -554,7 +554,7 @@ def test_switch_config_cdu_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -591,7 +591,7 @@ def test_switch_config_cdu_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary cdu custom config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -630,7 +630,7 @@ def test_switch_config_edge_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -667,7 +667,7 @@ def test_switch_config_edge_primary_custom():
     """Test that the `canu generate switch config` command runs and returns valid custom primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -706,7 +706,7 @@ def test_switch_config_edge_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -743,7 +743,7 @@ def test_switch_config_edge_secondary_custom():
     """Test that the `canu generate switch config` command runs and returns valid secondary edge custom config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -782,7 +782,7 @@ def test_switch_config_spine_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary spine config."""
     switch_name = "sw-spine-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -819,7 +819,7 @@ def test_switch_config_spine_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary spine config."""
     switch_name = "sw-spine-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -856,7 +856,7 @@ def test_switch_config_leaf_bmc_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
     switch_name = "sw-leaf-bmc-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -893,7 +893,7 @@ def test_switch_config_cdu_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary cdu config."""
     switch_name = "sw-cdu-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -930,7 +930,7 @@ def test_switch_config_cdu_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary cdu config."""
     switch_name = "sw-cdu-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -967,7 +967,7 @@ def test_switch_config_edge_primary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds primary edge config."""
     switch_name = "sw-edge-001"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(
@@ -1004,7 +1004,7 @@ def test_switch_config_edge_secondary_tds():
     """Test that the `canu generate switch config` command runs and returns valid tds secondary edge config."""
     switch_name = "sw-edge-002"
     config_file = f"{switch_name}.cfg"
-    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.6/{config_file}")
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
 
     with runner.isolated_filesystem():
         result = runner.invoke(

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7_ipv6.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7_ipv6.py
@@ -1,0 +1,1037 @@
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU generate switch config commands."""
+import difflib
+from os import path
+from pathlib import Path
+
+from click import testing
+import pkg_resources
+
+from canu.cli import cli
+
+test_file_directory = Path(__file__).resolve().parent
+data_directory = path.join(test_file_directory, "data")
+
+csm = "1.7"
+cache_minutes = 0
+sls_address = "api-gw-service-nmn.local"
+
+sls_file_name = "sls_input_file_csm_1.2_ipv6.json"
+sls_file = path.join(data_directory, sls_file_name)
+
+# Full systems
+test_shcd_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file = path.join(data_directory, test_shcd_name)
+custom_file_name = "aruba_custom.yaml"
+custom_file = path.join(data_directory, custom_file_name)
+architecture = "full"
+tabs = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners = "J14,T44,J14,T53,J14,T34,J14,T27"
+
+# TDS systems
+test_shcd_name_tds = "TDS_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file_tds = path.join(test_file_directory, "data", test_shcd_name_tds)
+architecture_tds = "tds"
+tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
+
+canu_version = pkg_resources.get_distribution("canu").version
+
+banner_version = f"# CANU version: {canu_version}\n"
+
+runner = testing.CliRunner()
+
+
+def diff_config_files(golden_file_name, test_file_name):
+    """Compare a test config file with a golden config file."""
+    with open(golden_file_name, "r") as file:
+        golden_config = file.readlines()
+    with open(test_file_name, "r") as file:
+        test_config = file.readlines()
+
+    d = difflib.Differ()
+    full_diff = list(d.compare(golden_config, test_config))
+    # Clean up - remove same lines " ", diff description lines "?", and CANU version
+    # lines (tested elsewhere) so that a real diff size can be obtained. The CANU version
+    # banner actual number will often be different between golden and testing so we don't
+    # test this.
+    real_diff = [
+        x for x in full_diff
+        if x[0] != " "
+        if x[0] != "?"
+        if banner_version[:14] not in x
+    ]
+
+    # If there's a real diff then print out the verbose diff (in stdout)
+    # for debugging.
+    if len(real_diff) != 0:
+        for myline in full_diff:
+            print(myline, end="")
+
+    return len(real_diff)
+
+
+def test_switch_config_spine_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_primary_custom():
+    """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary_custom():
+    """Test that the `canu generate switch config custom` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
+    switch_name = "sw-leaf-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary leaf config."""
+    switch_name = "sw-leaf-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
+    switch_name = "sw-leaf-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary leaf custom config."""
+    switch_name = "sw-leaf-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc():
+    """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc_custom():
+    """Test that the `canu generate switch config` command runs and returns valid leaf bmc custom config."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary cdu custom config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid custom primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary edge config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary_custom():
+    """Test that the `canu generate switch config` command runs and returns valid secondary edge custom config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_custom_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--custom-config",
+                custom_file,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds leaf-bmc config."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary cdu config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_primary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds primary edge config."""
+    switch_name = "sw-edge-001"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_edge_secondary_tds():
+    """Test that the `canu generate switch config` command runs and returns valid tds secondary edge config."""
+    switch_name = "sw-edge-002"
+    config_file = f"{switch_name}-ipv6.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/tds_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "--cache",
+                cache_minutes,
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture_tds,
+                "--shcd",
+                test_shcd_file_tds,
+                "--tabs",
+                tabs_tds,
+                "--corners",
+                corners_tds,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0


### PR DESCRIPTION
### Summary and Scope

This change adds support for IPv6 on the CMN and CHN networks when used with an SLS file containing IPv6 information.

If the IPv6 fields are not present in SLS then the default behaviour is preserved and no IPv6 information is added to the generated output.

This PR also fixes the CSM 1.7 non-IPv6 tests to use the CSM 1.7 templates and golden configs, they were previously looking at the CSM 1.6 versions.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: [CASMNET-2331](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2331)

### Testing

This configuration has been applied to the following in-house systems

* surtur
* tyr

New unit tests were added to cover the output generated when an IPv6 enabled SLS file is used. New golden configs were added for this purpose.