### PR TITLE
CASMNET-2349 - canu test fails with IPv6 data in SLS

### DIFF
--- a/canu/utils/sls_utils/schemas/sls_networks_schema.json
+++ b/canu/utils/sls_utils/schemas/sls_networks_schema.json
@@ -39,6 +39,9 @@
                             "type": "string",
                             "pattern": "((^|\\.)((25[0-5])|(2[0-4]\\d)|(1\\d\\d)|([1-9]?\\d))){4}\\/(?:\\d|[12]\\d|3[01])$"
                         },
+                        "CIDR6": {
+                            "type": "string"
+                        },
                         "MTU": {
                             "type": "integer",
                             "minimum": 1400,
@@ -59,9 +62,16 @@
                                         "type": "string",
                                         "pattern": "((^|\\.)((25[0-5])|(2[0-4]\\d)|(1\\d\\d)|([1-9]?\\d))){4}\\/(?:\\d|[12]\\d|3[01])$"
                                     },
+                                    "CIDR6": {
+                                        "type": "string"
+                                    },
                                     "Gateway": {
                                         "type": "string",
                                         "format": "ipv4"
+                                    },
+                                    "Gateway6": {
+                                        "type": "string",
+                                        "format": "ipv6"
                                     },
                                     "VlanID": {
                                         "type": "integer",
@@ -98,6 +108,10 @@
                                                 "IPAddress": {
                                                     "type": "string",
                                                     "format": "ipv4"
+                                                },
+                                                "IPAddress6": {
+                                                    "type": "string",
+                                                    "format": "ipv6"
                                                 },
                                                 "Aliases": {
                                                     "type": "array",

--- a/canu/utils/sls_utils/schemas/sls_reservations_schema.json
+++ b/canu/utils/sls_utils/schemas/sls_reservations_schema.json
@@ -14,6 +14,10 @@
                     "type": "string",
                     "format": "ipv4"
                 },
+                "IPAddress6": {
+                    "type": "string",
+                    "format": "ipv6"
+                },
                 "Aliases": {
                     "type": "array",
                     "items": {

--- a/canu/utils/sls_utils/schemas/sls_subnets_schema.json
+++ b/canu/utils/sls_utils/schemas/sls_subnets_schema.json
@@ -17,9 +17,16 @@
                     "type": "string",
                     "pattern": "((^|\\.)((25[0-5])|(2[0-4]\\d)|(1\\d\\d)|([1-9]?\\d))){4}\\/(?:\\d|[12]\\d|3[01])$"
                 },
+                "CIDR6": {
+                    "type": "string"
+                },
                 "Gateway": {
                     "type": "string",
                     "format": "ipv4"
+                },
+                "Gateway6": {
+                    "type": "string",
+                    "format": "ipv6"
                 },
                 "VlanID": {
                     "type": "integer",
@@ -56,6 +63,10 @@
                             "IPAddress": {
                                 "type": "string",
                                 "format": "ipv4"
+                            },
+                            "IPAddress6": {
+                                "type": "string",
+                                "format": "ipv6"
                             },
                             "Aliases": {
                                 "type": "array",


### PR DESCRIPTION
### Summary and Scope

`canu test` fails on a system that has had IPv6 data loaded into SLS.

```
ncn-m001:~ # canu test
Enter the switch password:
SLS JSON failed schema checks:
    Additional properties are not allowed ('CIDR6' was unexpected) in deque(['CHN', 'ExtraProperties'])
    Additional properties are not allowed ('CIDR6' was unexpected) in deque(['CMN', 'ExtraProperties'])
    Additional properties are not allowed ('CIDR6', 'Gateway6' were unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1])
    Additional properties are not allowed ('CIDR6', 'Gateway6' were unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 2])
    Additional properties are not allowed ('CIDR6', 'Gateway6' were unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 0])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 10])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 11])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 1])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 2])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 3])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 4])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 5])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 6])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 7])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 8])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CHN', 'ExtraProperties', 'Subnets', 1, 'IPReservations', 9])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 2, 'IPReservations', 0])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 2, 'IPReservations', 1])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 2, 'IPReservations', 2])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 0])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 10])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 11])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 1])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 2])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 3])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 4])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 5])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 6])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 7])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 8])
    Additional properties are not allowed ('IPAddress6' was unexpected) in deque(['CMN', 'ExtraProperties', 'Subnets', 3, 'IPReservations', 9])
```

This PR updates the SLS schemas to tolerate the presence of that data while not requiring it.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: [CASMNET-2349](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2349)
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

<!-- How was this change tested? --->
