### PR TITLE
Added tests for services ACL

### DIFF
--- a/canu/test/aruba/bgp_test.py
+++ b/canu/test/aruba/bgp_test.py
@@ -23,7 +23,7 @@
 from ttp import ttp
 
 
-def bgp_config(result, vlan_ips, vrf, mtn_acls=None):
+def bgp_config(result, vlan_ips, vrf, mtn_acls=None, services_acl=None):
     """Verify NCN-W IPs in SLS are BGP neighbors on the switch.
 
     Args:
@@ -31,6 +31,7 @@ def bgp_config(result, vlan_ips, vrf, mtn_acls=None):
         vlan_ips: list of NCN and Switch IPs
         vrf: Named VRF used for CSM networks
         mtn_acls: Mountain Cabinet ACLs
+        services_acl: Services ACLs between managed and management nodes
 
     Returns:
         Pass or fail

--- a/canu/test/aruba/services_acl_test.py
+++ b/canu/test/aruba/services_acl_test.py
@@ -19,11 +19,11 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-"""parse aruba mgmt ACL config for MTN cabinet ACLs."""
+"""parse aruba mgmt ACL config for Services ACLs."""
 
 
-def mtn_acl(result, vlan_ips=None, vrf=None, mtn_acls=None, services_acl=None):
-    """Verify NCN-W IPs in SLS are BGP neighbors on the switch.
+def services_acl(result, vlan_ips=None, vrf=None, mtn_acls=None, services_acl=None):
+    """Verify services ACLs on the switch.
 
     Args:
         result: show access-list ip nmn-hmn command
@@ -41,26 +41,25 @@ def mtn_acl(result, vlan_ips=None, vrf=None, mtn_acls=None, services_acl=None):
     result = "PASS"
     success = True
 
-    # Clean up the rendered MTN ACLs
-    required_mtn_acls = []
-    for required_acl in mtn_acls.splitlines():
+    # Comparing the rendered Services ACLs
+    required_services_acls = []
+    for required_acl in services_acl.splitlines():
         if required_acl == "":
             continue
         for string in ["comment", "permit", "deny"]:
             index = required_acl.find(string)
             if index != -1:
-                required_mtn_acls.append(required_acl[index:])
+                required_services_acls.append(required_acl[index:])
 
-    total_required_mtn_acls = len(required_mtn_acls)
+    total_required_services_acls = len(required_services_acls)
 
     found_acls = 0
-    for required_acl in required_mtn_acls:
+    for required_acl in required_services_acls:
         if running_acls.find(required_acl) != -1:
             found_acls += 1
 
-    if found_acls < total_required_mtn_acls:
-        exception = f"Only {found_acls} of the required {total_required_mtn_acls} ACLs found to " \
-                    f"isolate Mountain cabinets"
+    if found_acls < total_required_services_acls:
+        exception = f"Only {found_acls} of the required {total_required_services_acls} ACLs found to isolate services"
         result = "FAIL"
         success = False
 

--- a/canu/test/aruba/test_suite.yaml
+++ b/canu/test/aruba/test_suite.yaml
@@ -41,6 +41,16 @@
     - cdu
   pre_install: True
 
+- name: SERVICES ACL TEST
+  task: show access-list ip nmn-hmn command
+  test: custom
+  function_file: services_acl_test.py
+  function_name: services_acl
+  device:
+    - spine
+    - leaf
+  pre_install: True
+
 - name: BGP Config
   task: show run bgp
   test: custom

--- a/canu/test/aruba/vlan_interface_test.py
+++ b/canu/test/aruba/vlan_interface_test.py
@@ -23,7 +23,7 @@
 from ttp import ttp
 
 
-def vlan_interface_config(result, vlan_ips, vrf=None, mtn_acls=None):
+def vlan_interface_config(result, vlan_ips, vrf=None, mtn_acls=None, services_acl=None):
     """Verify the switch VLAN IPs match SLS.
 
     Args:
@@ -31,6 +31,7 @@ def vlan_interface_config(result, vlan_ips, vrf=None, mtn_acls=None):
         vlan_ips: list of NCN and Switch IPs
         vrf: Named VRF used for CSM networks
         mtn_acls: Mountain Cabinet ACLs
+        services_acl: Services ACLs between managed and management nodes
 
     Returns:
         Pass or fail

--- a/canu/test/test.py
+++ b/canu/test/test.py
@@ -482,7 +482,7 @@ def test(
                             "vlan_ips": vlan_ips,
                             "vrf": vrf,
                             "mtn_acls": mtn_acls,
-                            "services_acl": services_acl
+                            "services_acl": services_acl,
                         }
 
                 elif switch in devices and isinstance(test_command["task"], list):

--- a/canu/test/test.py
+++ b/canu/test/test.py
@@ -256,6 +256,13 @@ def test(
             "HMNLB_PREFIX_LEN": sls_variables["HMNLB_PREFIX_LEN"],
             "NMNLB": sls_variables["NMNLB"],
             "NMNLB_TFTP": sls_variables["NMNLB_TFTP"],
+            "ISTIO": sls_variables["ISTIO"],
+            "ISTIO_LOCAL": sls_variables["ISTIO_LOCAL"],
+            "SPIRE_CLUSTER": sls_variables["SPIRE_CLUSTER"],
+            "SPIRE_LOCAL": sls_variables["SPIRE_LOCAL"],
+            "FLUENTBIT_AGGREGATOR": sls_variables["FLUENTBIT_AGGREGATOR"],
+            "RGW_VIP": sls_variables["RGW_VIP"],
+            "KUBEAPI_VIP": sls_variables["KUBEAPI_VIP"],
             "NMNLB_DHCP": "10.92.100.222",
             "NMNLB_DNS": sls_variables["NMNLB_DNS"],
             "NMNLB_NETMASK": sls_variables["NMNLB_NETMASK"],
@@ -327,6 +334,7 @@ def test(
     # Rendering any templates needs to be done before  NetworkManager munges sls_json.
     # There's a bug in NeworkManager where the ExtraProperties in json is lost.
     mtn_acls = render_template(sls_json, "1.7/aruba/common/mtn_acl.j2")
+    services_acl = render_template(sls_json, "1.7/aruba/common/services_acl.j2")
 
     networks = NetworkManager(sls_json["Networks"])
 
@@ -474,6 +482,7 @@ def test(
                             "vlan_ips": vlan_ips,
                             "vrf": vrf,
                             "mtn_acls": mtn_acls,
+                            "services_acl": services_acl
                         }
 
                 elif switch in devices and isinstance(test_command["task"], list):


### PR DESCRIPTION
### Summary and Scope
This change adds tests to verify if the required services ACLs are present on spine, leaf switches by comparing it with the Services ACLs templates. 

<!-- What does this change do? --->

- [x] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMNET-2290
### Testing
Tested on internal systems 
