### PR TITLE
CASMNET-2354: Add MTL NCN IPs to ACLs

### DIFF
--- a/canu/config/network/network.py
+++ b/canu/config/network/network.py
@@ -283,6 +283,7 @@ def network(
             variables = {
                 "NMN_VLAN": sls_variables["NMN_VLAN"],
                 "NMN_IPs": sls_variables["NMN_IPs"],
+                "MTL_IPs": sls_variables["MTL_IPs"],
                 "SPINE_SWITCH_IPs": sls_variables["SPINE_SWITCH_IPs"],
                 "ALL_SWITCH_IPs": sls_variables["ALL_SWITCH_IPs"],
                 "RGW_VIP": sls_variables["RGW_VIP"],

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -846,6 +846,7 @@ def generate_switch_config(
         "CMN_IPs": sls_variables["CMN_IPs"],
         "CMN_IPs6": sls_variables["CMN_IPs6"],
         "NMN_IPs": sls_variables["NMN_IPs"],
+        "MTL_IPs": sls_variables["MTL_IPs"],
         "HMN_IPs": sls_variables["HMN_IPs"],
         "SWITCH_ASN": sls_variables["SWITCH_ASN"],
         "BGP_CONTROL_PLANE": bgp_control_plane,
@@ -1866,6 +1867,10 @@ def parse_sls_for_config(input_json):
                     sls_variables["MTL_IP_GATEWAY"] = subnets["Gateway"]
                     for ip in subnets["IPReservations"]:
                         sls_variables["MTL_IPs"][ip["Name"]] = ip["IPAddress"]
+                elif subnets["Name"] == "bootstrap_dhcp":
+                    for ip in subnets["IPReservations"]:
+                        if ip["Name"].startswith("ncn-"):
+                            sls_variables["MTL_IPs"][ip["Name"]] = ip["IPAddress"]
 
         elif name == "NMN":
             sls_variables["NMN"] = netaddr.IPNetwork(

--- a/network_modeling/configs/templates/1.7/aruba/common/_acl_revert.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/_acl_revert.j2
@@ -1,7 +1,7 @@
 no access-list ip MANAGED_NODE_ISOLATION
 no object-group ip address ALL_SWITCHES
 no object-group ip address MANAGED_NODES
-no object-group ip address NMN_NCN
+no object-group ip address NCN
 no object-group ip address SPINE_SWITCHES
 no object-group ip address TFTP_SERVERS
 no object-group port NMN_TCP_SERVICES

--- a/network_modeling/configs/templates/1.7/aruba/common/services_acl.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/services_acl.j2
@@ -8,7 +8,7 @@
 {%- endif -%}
 
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit Unrestricted NCN to NCN Communication'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NMN_NCN NMN_NCN count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NCN NCN count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit DHCP traffic'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp any range 67 68 any count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit node to request TFTP file'}) -%}
@@ -18,29 +18,29 @@
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp any eq dns any count'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp any eq dns any count'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp MANAGED_NODES NMN_NCN group NMN_UDP_SERVICES count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit NTP replies from NCNs'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp NMN_NCN eq ntp MANAGED_NODES count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit udp NCN eq ntp MANAGED_NODES count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit access to NMN_TCP_SERVICES'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NMN_K8S_SERVICE MANAGED_NODES group NMN_TCP_SERVICES count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp MANAGED_NODES NMN_NCN group NMN_TCP_SERVICES count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NMN_NCN MANAGED_NODES group NMN_TCP_SERVICES count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NCN MANAGED_NODES group NMN_TCP_SERVICES count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Allow SSH from NCNs to Managed Nodes'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NMN_NCN MANAGED_NODES eq ssh count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp MANAGED_NODES eq ssh NMN_NCN count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NCN MANAGED_NODES eq ssh count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp MANAGED_NODES eq ssh NCN count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Allow ping'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit icmp any any count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit OSPF from switches'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit ospf ALL_SWITCHES any count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit BGP (port 179) between spines and NCNs'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp SPINE_SWITCHES NMN_NCN eq bgp count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NMN_NCN SPINE_SWITCHES eq bgp count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp SPINE_SWITCHES NCN eq bgp count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit tcp NCN SPINE_SWITCHES eq bgp count'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NMN_K8S_SERVICE NMN_NCN count'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NMN_NCN NMN_K8S_SERVICE count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NMN_K8S_SERVICE NCN count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit any NCN NMN_K8S_SERVICE count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': 'Permit VRRP from NCNs'}) -%}
-{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit 112 NMN_NCN 224.0.0.18 count'}) -%}
+{%- set _ = acl_rules.append({'type': 'rule', 'text': 'permit 112 NCN 224.0.0.18 count'}) -%}
 {%- set _ = acl_rules.append({'type': 'comment', 'text': '--- FINAL CATCH-ALL DENY ---'}) -%}
 {%- set _ = acl_rules.append({'type': 'rule', 'text': 'deny any any any count'}) -%}
 

--- a/network_modeling/configs/templates/1.7/aruba/common/services_objects.j2
+++ b/network_modeling/configs/templates/1.7/aruba/common/services_objects.j2
@@ -1,12 +1,19 @@
 {#- ACL Object groups for services ACL #}
-object-group ip address NMN_NCN
+object-group ip address NCN
 {%- set ns = namespace(last_sequence=0) %}
+    10 {{ variables.RGW_VIP }}
+    20 {{ variables.KUBEAPI_VIP }}
+{%- set ns.last_sequence = 20 %}
 {%- for name, ip in variables.NMN_IPs.items() if name.startswith('ncn-') %}
-    {{ loop.index * 10 }} {{ ip }}
-{%- set ns.last_sequence = loop.index * 10 %}
+    {{ ns.last_sequence + 10 }} {{ ip }}
+{%- set ns.last_sequence = ns.last_sequence + 10 %}
 {%- endfor %}
-    {{ ns.last_sequence + 10 }} {{ variables.RGW_VIP }}
-    {{ ns.last_sequence + 20 }} {{ variables.KUBEAPI_VIP }}
+{%- if variables.MTL_IPs %}
+{%- for name, ip in variables.MTL_IPs.items() if name.startswith('ncn-') %}
+    {{ ns.last_sequence + 10 }} {{ ip }}
+{%- set ns.last_sequence = ns.last_sequence + 10 %}
+{%- endfor %}
+{%- endif %}
 object-group ip address SPINE_SWITCHES
 {%- for ip in variables.SPINE_SWITCH_IPs %}
     {{ loop.index * 10 }} {{ ip }}

--- a/tests/data/golden_configs/individual_templates_1.7/services_acl.j2.cfg
+++ b/tests/data/golden_configs/individual_templates_1.7/services_acl.j2.cfg
@@ -2,7 +2,7 @@ access-list ip MANAGED_NODE_ISOLATION
     10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
     20 deny any MTN_NETWORKS MTN_NETWORKS count
     30 comment Permit Unrestricted NCN to NCN Communication
-    40 permit any NMN_NCN NMN_NCN count
+    40 permit any NCN NCN count
     50 comment Permit DHCP traffic
     60 permit udp any range 67 68 any count
     70 comment Permit node to request TFTP file
@@ -12,28 +12,28 @@ access-list ip MANAGED_NODE_ISOLATION
     110 permit udp any eq dns any count
     120 permit tcp any eq dns any count
     130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
-    140 permit udp MANAGED_NODES NMN_NCN group NMN_UDP_SERVICES count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
     150 comment Permit NTP replies from NCNs
-    160 permit udp NMN_NCN eq ntp MANAGED_NODES count
+    160 permit udp NCN eq ntp MANAGED_NODES count
     170 comment Permit access to NMN_TCP_SERVICES
     180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
     190 permit tcp NMN_K8S_SERVICE MANAGED_NODES group NMN_TCP_SERVICES count
-    200 permit tcp MANAGED_NODES NMN_NCN group NMN_TCP_SERVICES count
-    210 permit tcp NMN_NCN MANAGED_NODES group NMN_TCP_SERVICES count
+    200 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    210 permit tcp NCN MANAGED_NODES group NMN_TCP_SERVICES count
     220 comment Allow SSH from NCNs to Managed Nodes
-    230 permit tcp NMN_NCN MANAGED_NODES eq ssh count
-    240 permit tcp MANAGED_NODES eq ssh NMN_NCN count
+    230 permit tcp NCN MANAGED_NODES eq ssh count
+    240 permit tcp MANAGED_NODES eq ssh NCN count
     250 comment Allow ping
     260 permit icmp any any count
     270 comment Permit OSPF from switches
     280 permit ospf ALL_SWITCHES any count
     290 comment Permit BGP (port 179) between spines and NCNs
-    300 permit tcp SPINE_SWITCHES NMN_NCN eq bgp count
-    310 permit tcp NMN_NCN SPINE_SWITCHES eq bgp count
+    300 permit tcp SPINE_SWITCHES NCN eq bgp count
+    310 permit tcp NCN SPINE_SWITCHES eq bgp count
     320 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
-    330 permit any NMN_K8S_SERVICE NMN_NCN count
-    340 permit any NMN_NCN NMN_K8S_SERVICE count
+    330 permit any NMN_K8S_SERVICE NCN count
+    340 permit any NCN NMN_K8S_SERVICE count
     350 comment Permit VRRP from NCNs
-    360 permit 112 NMN_NCN 224.0.0.18 count
+    360 permit 112 NCN 224.0.0.18 count
     370 comment --- FINAL CATCH-ALL DENY ---
     380 deny any any any count

--- a/tests/data/golden_configs/individual_templates_1.7/services_objects.j2.cfg
+++ b/tests/data/golden_configs/individual_templates_1.7/services_objects.j2.cfg
@@ -1,10 +1,10 @@
 
-object-group ip address NMN_NCN
-    10 192.168.4.4
-    20 192.168.4.5
-    30 192.168.4.6
-    40 192.168.4.2
-    50 192.168.4.3
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
 object-group ip address SPINE_SWITCHES
     10 192.168.3.2
     20 192.168.3.3


### PR DESCRIPTION
### Summary and Scope

Add NCN MTL ips to the NCN object group.  This allows the NCNS to talk to each other on both their NMN and MTL IPs without any restrictions.  Required for booting from the pit.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CASMNET-2354`
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing
Tested on surtur


