### PR TITLE
CASMTRIAGE-8566 - canu report switch firmware fails for Mellanox

### DIFF
--- a/canu/report/switch/firmware/firmware.py
+++ b/canu/report/switch/firmware/firmware.py
@@ -387,30 +387,22 @@ def get_firmware_mellanox(ip, credentials, return_error=False):
 
         device_type = "mellanox"
 
-        commands = ["show version", "show inventory"]
+        commands = [
+            "show version concise",
+            "show system type",
+            "show hosts | include Hostname",
+        ]
+
         firmware_list = netmiko_commands(ip, credentials, commands, device_type)
 
-        # Show version - extract version and platform
-        version_output = firmware_list[0]
-        version_parts = version_output.strip().split()
-        if len(version_parts) >= 2:
-            switch_firmware["current_version"] = version_parts[1]
+        # Show version concise - extract version
+        switch_firmware["current_version"] = firmware_list[0].split()[1]
 
-        # Show inventory - extract platform and hostname
-        inventory_output = firmware_list[1]
-        platform_name = inventory_output.strip()
+        # Show system type - extract platform
+        platform_name = firmware_list[1].strip()
 
-        # Show inventory - hostname (from third element or parse from inventory)
-        if len(firmware_list) > 2:
-            hostname_output = firmware_list[2]
-            hostname_lines = hostname_output.split("\n")
-            hostname = "unknown"
-            for line in hostname_lines:
-                if "hostname" in line:
-                    hostname = line.split()[-1]
-                    break
-        else:
-            hostname = "unknown"
+        # show hosts | include Hostname - extract hostname
+        hostname = firmware_list[2].split(':')[1].strip()
 
         switch_info = {
             "platform_name": platform_name,

--- a/tests/test_report_switch_firmware.py
+++ b/tests/test_report_switch_firmware.py
@@ -749,5 +749,5 @@ dell_hostname_mock = {"dell-system:hostname": "test-dell"}
 netmiko_commands_mellanox = [
     "X86_64 3.9.1014 2020-01-01 01:00:00 x86_64\n",
     "MSN2100\n",
-    "   hostname test-mellanox\n   ip dhcp send-hostname\n",
+    "Hostname        : test-mellanox\n",
 ]


### PR DESCRIPTION
### Summary and Scope

The removal of the canu cache code in https://github.com/Cray-HPE/canu/pull/688 broke firmware version reporting for Mellanox devices because the commands used to gather the data were changed and the output processing doesn't work.

```
ncn-m001:~ # canu report switch firmware --csm 1.7 --ip 10.254.0.2 --password $SW_PASSWD
Traceback (most recent call last):
  File "cli.py", line 289, in <module>
  File "click/core.py", line 1161, in __call__
  File "click/core.py", line 1082, in main
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1697, in invoke
  File "click/core.py", line 1443, in invoke
  File "click/core.py", line 788, in invoke
  File "click/decorators.py", line 33, in new_func
  File "report/switch/firmware/firmware.py", line 146, in firmware
  File "ruamel/yaml/comments.py", line 853, in __getitem__
KeyError: '-----------------------------------------------------------------------------\nModule           Part Number        Serial Number        Asic Rev.    HW Rev.\n-----------------------------------------------------------------------------\nCHASSIS          MSN2100-CB2F       MT1933X19235         N/A          B8\nMGMT             MSN2100-CB2F       MT1933X19235         1            B8'
[PYI-1594451:ERROR] Failed to execute script 'cli' due to unhandled exception!
```

This also broke `canu report network firmware` for Mellanox devices although that command handles it a little more gracefully.

```
ncn-m001:~ # canu report network firmware --csm 1.7 --ips 10.254.0.2,10.254.0.3,10.254.0.4 --password $SW_PASSWD
------------------------------------------------------------------
    STATUS  IP              HOSTNAME            FIRMWARE
------------------------------------------------------------------
 🔺 Error   10.254.0.2
 🔺 Error   10.254.0.3
 🛶 Pass    10.254.0.4      sw-leaf-bmc-001     10.5.1.4


Errors
------------------------------------------------------------------
10.254.0.2      - Could not determine the vendor of the switch.
10.254.0.3      - Could not determine the vendor of the switch.

Summary
------------------------------------------------------------------
🔺 Error - 2 switches
🛶 Pass - 1 switches
10.5.1.4 - 1 switches
```

This PR resolves this issue.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: [CASMTRIAGE-8566](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8566)
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

Installed new RPM containing this change on wasp.

* `canu report switch firmware` output
   ```
   ncn-m001:~ # canu report switch firmware --csm 1.7 --ip 10.254.0.2 --password $SW_PASSWD
   🛶 - Pass - IP: 10.254.0.2 Hostname: sw-spine-001 Firmware: 3.9.3210
   ```
* `canu report network firmware` output
   ```
   ncn-m001:~ # canu report network firmware --csm 1.7 --ips 10.254.0.2,10.254.0.3,10.254.0.4 --password $SW_PASSWD
   ------------------------------------------------------------------
       STATUS  IP              HOSTNAME            FIRMWARE
   ------------------------------------------------------------------
    🛶 Pass    10.254.0.2      sw-spine-001        3.9.3210
    🛶 Pass    10.254.0.3      sw-spine-002        3.9.3210
    🛶 Pass    10.254.0.4      sw-leaf-bmc-001     10.5.1.4

   Summary
   ------------------------------------------------------------------
   🛶 Pass - 3 switches
   3.9.3210 - 2 switches
   10.5.1.4 - 1 switches
   ```