### PR TITLE
CASMNET-2380: Remove MANAGED_NODE_ISOLATION ACL due to TCAM constraint

### DIFF
--- a/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.primary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.primary.j2
@@ -21,12 +21,8 @@ vlan {{ variables.NMN_VLAN }}
 {%- if variables.NMN_ISOLATED_VLAN %}
     private-vlan primary
 {%- endif %}
-{%- if variables.ENABLE_NMN_ISOLATION %}
-    apply access-list ip MANAGED_NODE_ISOLATION in
-{%- else %}
     apply access-list ip nmn-hmn in
     apply access-list ip nmn-hmn out
-{%- endif %}
 {%- if variables.NMN_ISOLATED_VLAN %}
 vlan {{ variables.NMN_ISOLATED_VLAN }}
     name MANAGED_NODE_ISOLATED
@@ -89,10 +85,6 @@ interface vlan {{ variables.NATIVE_VLAN }}
 interface vlan {{ variables.NMN_VLAN }}
     vrf attach {{ variables.VRF }}
     description NMN
-{%- if variables.ENABLE_NMN_ISOLATION %}
-    apply access-list ip nmn-hmn routed-in
-    apply access-list ip nmn-hmn routed-out
-{%- endif %}
     ip mtu 9198
     ip address {{ variables.NMN_IP }}/{{variables.NMN_PREFIX_LEN}}
     ip ospf 2 area 0.0.0.0

--- a/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.secondary.j2
+++ b/network_modeling/configs/templates/1.7/aruba/full/sw-leaf.secondary.j2
@@ -21,12 +21,8 @@ vlan {{ variables.NMN_VLAN }}
 {%- if variables.NMN_ISOLATED_VLAN %}
     private-vlan primary
 {%- endif %}
-{%- if variables.ENABLE_NMN_ISOLATION %}
-    apply access-list ip MANAGED_NODE_ISOLATION in
-{%- else %}
     apply access-list ip nmn-hmn in
     apply access-list ip nmn-hmn out
-{%- endif %}
 {%- if variables.NMN_ISOLATED_VLAN %}
 vlan {{ variables.NMN_ISOLATED_VLAN }}
     name MANAGED_NODE_ISOLATED
@@ -89,10 +85,6 @@ interface vlan {{ variables.NATIVE_VLAN }}
 interface vlan {{ variables.NMN_VLAN }}
     vrf attach {{ variables.VRF }}
     description NMN
-{%- if variables.ENABLE_NMN_ISOLATION %}
-    apply access-list ip nmn-hmn routed-in
-    apply access-list ip nmn-hmn routed-out
-{%- endif %}
     ip mtu 9198
     ip address {{ variables.NMN_IP }}/{{variables.NMN_PREFIX_LEN}}
     ip ospf 2 area 0.0.0.0

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-001-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-001-isolation.cfg
@@ -1,0 +1,387 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip MANAGED_NODE_ISOLATION in
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip MANAGED_NODE_ISOLATION in
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.100.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:1<==sw-cdu-001
+    lag 5
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cec-x3002-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:5<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:5<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.16/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.16/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.3.16/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.16/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.16/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.16
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.16
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-cdu-002-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-cdu-002-isolation.cfg
@@ -1,0 +1,379 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip MANAGED_NODE_ISOLATION in
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_3002_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_3002_hmn
+    ip mtu 9198
+    ip address 192.168.104.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.104.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_3002_nmn
+    apply access-list ip MANAGED_NODE_ISOLATION in
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_3002_nmn
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.100.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 192.168.100.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x3002-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x3002-000:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x3002-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x3002-001:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x3002-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x3002-002:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x3002-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x3002-003:2<==sw-cdu-002
+    lag 5
+
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-002:6<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-001:6<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/48
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.17/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 192.168.1.17/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.3.17/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.17/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.17/24
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.17
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.17
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-001-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-001-isolation.cfg
@@ -1,0 +1,459 @@
+
+hostname sw-leaf-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    private-vlan primary
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 502
+    name MANAGED_NODE_ISOLATED
+    private-vlan isolated primary-vlan 2
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:ocp:1<==sw-leaf-001
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:ocp:1<==sw-leaf-001
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:1<==sw-leaf-001
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:1<==sw-leaf-001
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:ocp:2<==sw-leaf-001
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:1<==sw-leaf-001
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:ocp:2<==sw-leaf-001
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:ocp:2<==sw-leaf-001
+    lag 10
+
+
+interface lag 20 multi-chassis
+    no shutdown
+    description fmn001:ocp:1<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description fmn001:ocp:1<==sw-leaf-001
+    lag 20
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:48<==sw-leaf-001
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:1<==sw-leaf-001
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:1<==sw-leaf-001
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.4/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.4/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.4/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.4/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.4/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.4
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.4
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-002-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-002-isolation.cfg
@@ -1,0 +1,459 @@
+
+hostname sw-leaf-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    private-vlan primary
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 502
+    name MANAGED_NODE_ISOLATED
+    private-vlan isolated primary-vlan 2
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 1 multi-chassis
+    no shutdown
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:pcie-slot1:1<==sw-leaf-002
+    lag 1
+
+interface lag 3 multi-chassis
+    no shutdown
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m002:pcie-slot1:1<==sw-leaf-002
+    lag 3
+
+
+interface lag 5 multi-chassis
+    no shutdown
+    description ncn-w001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w001:ocp:2<==sw-leaf-002
+    lag 5
+
+
+interface lag 7 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:1<==sw-leaf-002
+    lag 7
+
+interface lag 8 multi-chassis
+    no shutdown
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s001:pcie-slot1:2<==sw-leaf-002
+    lag 8
+
+interface lag 9 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:1<==sw-leaf-002
+    lag 9
+
+interface lag 10 multi-chassis
+    no shutdown
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    no routing
+    vlan trunk native 10
+    vlan trunk allowed 10
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description ncn-s002:pcie-slot1:2<==sw-leaf-002
+    lag 10
+
+
+interface lag 20 multi-chassis
+    no shutdown
+    description fmn001:ocp:2<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7
+    lacp mode active
+    lacp fallback
+    spanning-tree port-type admin-edge
+    private-vlan port-type promiscuous
+
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description fmn001:ocp:2<==sw-leaf-002
+    lag 20
+
+
+
+interface lag 151 multi-chassis
+    no shutdown
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description sw-leaf-bmc-001:47<==sw-leaf-002
+    lag 151
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description leaf_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description sw-spine-002:2<==sw-leaf-002
+    lag 101
+
+interface 1/1/53
+    no shutdown
+    mtu 9198
+    description sw-spine-001:2<==sw-leaf-002
+    lag 101
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/54
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/55
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/56
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:01:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.5/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.5/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 192.168.3.5/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.5/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.5/24
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+router ospf 2 vrf CSM
+    router-id 10.2.0.5
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.5
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-leaf-bmc-001-isolation.cfg
@@ -1,0 +1,585 @@
+
+hostname sw-leaf-bmc-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf default
+ssh server vrf mgmt
+ssh server vrf CSM
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    private-vlan primary
+    apply access-list ip MANAGED_NODE_ISOLATION in
+vlan 502
+    name MANAGED_NODE_ISOLATED
+    private-vlan isolated primary-vlan 2
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+interface 1/1/28
+    no shutdown
+    mtu 9198
+    description gateway001:ocp:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 502
+    private-vlan port-type secondary
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/24
+    no shutdown
+    mtu 9198
+    description cn001:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 502
+    private-vlan port-type secondary
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/25
+    no shutdown
+    mtu 9198
+    description cn002:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 502
+    private-vlan port-type secondary
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/26
+    no shutdown
+    mtu 9198
+    description cn003:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 502
+    private-vlan port-type secondary
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/27
+    no shutdown
+    mtu 9198
+    description cn004:onboard:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 502
+    private-vlan port-type secondary
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description ncn-m001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description ncn-m002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description ncn-m003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description ncn-w001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description ncn-w002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description ncn-w003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description ncn-s001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description ncn-s002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/9
+    no shutdown
+    mtu 9198
+    description ncn-s003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/10
+    no shutdown
+    mtu 9198
+    description uan001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/11
+    no shutdown
+    mtu 9198
+    description cn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/12
+    no shutdown
+    mtu 9198
+    description cn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/13
+    no shutdown
+    mtu 9198
+    description cn003:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/14
+    no shutdown
+    mtu 9198
+    description cn004:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/15
+    no shutdown
+    mtu 9198
+    description pdu-x3000-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/16
+    no shutdown
+    mtu 9198
+    description pdu-x3000-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/17
+    no shutdown
+    mtu 9198
+    description pdu-x3001-000:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/18
+    no shutdown
+    mtu 9198
+    description pdu-x3001-001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/19
+    no shutdown
+    mtu 9198
+    description gateway001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/20
+    no shutdown
+    mtu 9198
+    description lmem001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/21
+    no shutdown
+    mtu 9198
+    description fmn001:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+interface 1/1/22
+    no shutdown
+    mtu 9198
+    description fmn002:bmc:1<==sw-leaf-bmc-001
+    no routing
+    vlan access 4
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255
+    no shutdown
+    description leaf_bmc_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+
+interface 1/1/47
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:51<==sw-leaf-bmc-001
+    lag 255
+
+interface 1/1/23
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/29
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/30
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/31
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/32
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/33
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/34
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/35
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/36
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/37
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/38
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/39
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/40
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/41
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/42
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/43
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/44
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/45
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/46
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/49
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/50
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/51
+    shutdown
+    no routing
+    vlan access 1
+interface 1/1/52
+    shutdown
+    no routing
+    vlan access 1
+
+interface loopback 0
+    ip address 10.2.0.12/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.12/16
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.3.12/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.12/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.12/24
+    ip ospf 1 area 0.0.0.0
+snmp-server vrf default
+snmp-server vrf CSM
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.12
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.12
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-001-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-001-isolation.cfg
@@ -1,0 +1,498 @@
+
+hostname sw-spine-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.4
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    private-vlan primary
+    apply access-list ip MANAGED_NODE_ISOLATION in
+vlan 502
+    name MANAGED_NODE_ISOLATED
+    private-vlan isolated primary-vlan 2
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:53<==sw-spine-001
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:53<==sw-spine-001
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:53<==sw-spine-001
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:53<==sw-spine-001
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:50<==sw-spine-001
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:50<==sw-spine-001
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:50<==sw-spine-001
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.2/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.2/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.3.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.2/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.2/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.2
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.2
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.3 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.3 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.2
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.3 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.3 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/full_configs_1.7/sw-spine-002-isolation.cfg
+++ b/tests/data/golden_configs/full_configs_1.7/sw-spine-002-isolation.cfg
@@ -1,0 +1,498 @@
+
+hostname sw-spine-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.6.dev1+g481e3907.d20251106
+###############################################################################
+!
+no ip icmp redirect
+vrf CSM
+vrf keepalive
+ntp server 192.168.4.4
+ntp server 192.168.4.5
+ntp server 192.168.4.6
+ntp enable
+ntp vrf CSM
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 192.168.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 192.168.0.0/255.255.128.0 any eq https
+    40 permit udp 192.168.0.0/255.255.128.0 any eq snmp
+    50 permit udp 192.168.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 192.168.12.0/255.255.255.0 eq ssh
+    70 permit udp any eq ntp 192.168.3.0/255.255.128.0
+    80 permit tcp 192.168.12.0/255.255.255.0 any eq https
+    90 permit udp 192.168.12.0/255.255.255.0 any eq snmp
+    100 permit udp 192.168.12.0/255.255.255.0 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 192.168.3.0/255.255.128.0 192.168.0.0/255.255.128.0
+    20 deny any 192.168.0.0/255.255.128.0 192.168.3.0/255.255.128.0
+    30 deny any 192.168.3.0/255.255.128.0 192.168.200.0/255.255.128.0
+    40 deny any 192.168.0.0/255.255.128.0 192.168.100.0/255.255.128.0
+    50 deny any 192.168.100.0/255.255.128.0 192.168.0.0/255.255.128.0
+    60 deny any 192.168.100.0/255.255.128.0 192.168.200.0/255.255.128.0
+    70 deny any 192.168.200.0/255.255.128.0 192.168.3.0/255.255.128.0
+    80 deny any 192.168.200.0/255.255.128.0 192.168.100.0/255.255.128.0
+    90 deny any 10.92.100.0/255.255.255.0 192.168.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 192.168.3.0/255.255.128.0
+    110 deny any 192.168.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 192.168.3.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+object-group ip address NCN
+    10 192.168.4.2
+    20 192.168.4.3
+    30 192.168.4.4
+    40 192.168.4.5
+    50 192.168.4.6
+    60 192.168.4.7
+    70 192.168.4.8
+    80 192.168.4.9
+    90 192.168.1.0/255.255.0.0
+object-group ip address SPINE_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+object-group ip address ALL_SWITCHES
+    10 192.168.3.2
+    20 192.168.3.3
+    30 192.168.3.4
+    40 192.168.3.5
+    50 192.168.3.6
+    60 192.168.3.7
+    70 192.168.3.12
+    80 192.168.3.13
+    90 192.168.3.14
+    100 192.168.3.15
+    110 192.168.3.16
+    120 192.168.3.17
+object-group ip address MTN_NETWORKS
+    10 192.168.100.0/255.255.128.0
+    20 192.168.100.0/255.255.252.0
+    30 192.168.104.0/255.255.252.0
+object-group ip address MANAGED_NODES
+    10 192.168.3.0/255.255.128.0
+    20 192.168.100.0/255.255.128.0
+object-group ip address NMN_K8S_SERVICE
+    10 10.92.100.0/255.255.255.0
+    20 192.168.4.2
+object-group ip address TFTP_SERVERS
+    10 10.92.100.60
+object-group port NMN_TCP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq http
+    40 eq https
+    50 eq syslog
+    60 eq 2020
+    70 eq 8080
+    80 eq 8081
+    90 eq 8883
+    100 eq 8888
+    110 eq 8514
+    120 eq 6817
+    130 eq 6818
+    140 eq 6819
+    150 eq 3260
+object-group port NMN_UDP_SERVICES
+    10 eq dns
+    20 eq dhcp-server
+    30 eq dhcp-client
+    40 eq tftp
+    50 eq syslog
+    60 eq 8514
+    70 eq ntp
+access-list ip MANAGED_NODE_ISOLATION
+    10 comment DENY MTN NETWORKS FROM TALKING TO EACH OTHER
+    20 deny any MTN_NETWORKS MTN_NETWORKS count
+    30 comment Permit Unrestricted NCN to NCN Communication
+    40 permit any NCN NCN count
+    50 comment Permit DHCP traffic
+    60 permit udp any range 67 68 any count
+    70 comment Permit node to request TFTP file
+    80 permit udp TFTP_SERVERS MANAGED_NODES count
+    90 permit udp MANAGED_NODES TFTP_SERVERS count
+    100 comment Permit node to perform DNS lookups
+    110 permit udp any eq dns any count
+    120 permit tcp any eq dns any count
+    130 permit udp MANAGED_NODES NMN_K8S_SERVICE eq dns count
+    140 permit udp MANAGED_NODES NCN group NMN_UDP_SERVICES count
+    150 comment Permit NTP replies from NCNs
+    160 permit udp NCN eq ntp MANAGED_NODES count
+    170 comment Permit access to NMN_TCP_SERVICES
+    180 permit tcp MANAGED_NODES NMN_K8S_SERVICE group NMN_TCP_SERVICES count
+    190 permit tcp MANAGED_NODES NCN group NMN_TCP_SERVICES count
+    200 comment Permit TCP replies using the 'established' keyword
+    210 permit tcp NCN MANAGED_NODES established count
+    220 permit tcp NMN_K8S_SERVICE MANAGED_NODES established count
+    230 comment Allow SSH from NCNs to Managed Nodes
+    240 permit tcp NCN MANAGED_NODES eq ssh count
+    250 permit tcp MANAGED_NODES eq ssh NCN count
+    260 comment Allow ping
+    270 permit icmp any any count
+    280 comment Permit OSPF from switches
+    290 permit ospf ALL_SWITCHES any count
+    300 comment Permit BGP (port 179) between spines and NCNs
+    310 permit tcp SPINE_SWITCHES NCN eq bgp count
+    320 permit tcp NCN SPINE_SWITCHES eq bgp count
+    330 permit any NMN_K8S_SERVICE NMN_K8S_SERVICE count
+    340 permit any NMN_K8S_SERVICE NCN count
+    350 permit any NCN NMN_K8S_SERVICE count
+    360 comment Permit VRRP from NCNs
+    370 permit 112 NCN 224.0.0.18 count
+    380 comment --- FINAL CATCH-ALL DENY ---
+    390 deny any any any count
+access-list ip cmn-can
+    10 deny any 192.168.12.0/255.255.255.0 192.168.11.0/255.255.255.0
+    20 deny any 192.168.11.0/255.255.255.0 192.168.12.0/255.255.255.0
+    30 deny any 192.168.12.0/255.255.255.0 192.168.200.0/255.255.255.0
+    40 deny any 192.168.200.0/255.255.255.0 192.168.12.0/255.255.255.0
+    50 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    private-vlan primary
+    apply access-list ip MANAGED_NODE_ISOLATION in
+vlan 502
+    name MANAGED_NODE_ISOLATED
+    private-vlan isolated primary-vlan 2
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 6
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+vlan 7
+    name CAN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 10
+    name SUN
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree priority 0
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+
+
+
+interface lag 101 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description sw-leaf-001:52<==sw-spine-002
+    lag 101
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description sw-leaf-002:52<==sw-spine-002
+    lag 101
+
+interface lag 103 multi-chassis
+    no shutdown
+    description spine_to_leaf_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6-7,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description sw-leaf-003:52<==sw-spine-002
+    lag 103
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description sw-leaf-004:52<==sw-spine-002
+    lag 103
+
+
+interface lag 201 multi-chassis
+    no shutdown
+    description sw-cdu-001:49<==sw-spine-002
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,6,502
+    lacp mode active
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description sw-cdu-001:49<==sw-spine-002
+    lag 201
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description sw-cdu-002:49<==sw-spine-002
+    lag 201
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/30
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/31
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/32
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:00:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.3/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    vrf attach CSM
+    ip mtu 9198
+    ip address 192.168.1.3/16
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.1.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    apply access-list ip nmn-hmn routed-in
+    apply access-list ip nmn-hmn routed-out
+    ip mtu 9198
+    ip address 192.168.3.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.3.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 192.168.0.3/17
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.0.1
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 6
+    description CMN
+    ip mtu 9198
+    ip address 192.168.12.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.12.1
+    ip ospf 1 area 0.0.0.0
+interface vlan 7
+    description CAN
+    ip mtu 9198
+    ip address 192.168.11.3/24
+    active-gateway ip mac 12:00:00:00:6b:00
+    active-gateway ip 192.168.11.1
+    ip ospf 1 area 0.0.0.0
+ip dns server-address 10.92.100.225 vrf CSM
+
+ip prefix-list pl-cmn seq 10 permit 192.168.12.0/24 ge 24
+ip prefix-list pl-can seq 20 permit 192.168.11.0/24 ge 24
+ip prefix-list pl-hmn seq 30 permit 10.94.100.0/24 ge 24
+ip prefix-list pl-nmn seq 40 permit 10.92.100.0/24 ge 24
+ip prefix-list tftp seq 10 permit 10.92.100.60/32 ge 32 le 32
+ip prefix-list tftp seq 20 permit 10.94.100.60/32 ge 32 le 32
+
+
+
+route-map ncn-w001 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w001 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w001 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w001 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.4
+route-map ncn-w001 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.4
+
+route-map ncn-w001-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.4
+route-map ncn-w001-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w002 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w002 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w002 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w002 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.5
+route-map ncn-w002 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.5
+
+route-map ncn-w002-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.5
+route-map ncn-w002-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+
+
+route-map ncn-w003 permit seq 10
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.4
+     set local-preference 1000
+route-map ncn-w003 permit seq 20
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.5
+     set local-preference 1100
+route-map ncn-w003 permit seq 30
+     match ip address prefix-list tftp
+     match ip next-hop 192.168.4.6
+     set local-preference 1200
+route-map ncn-w003 permit seq 40
+     match ip address prefix-list pl-hmn
+     set ip next-hop 192.168.0.6
+route-map ncn-w003 permit seq 50
+     match ip address prefix-list pl-nmn
+     set ip next-hop 192.168.4.6
+
+route-map ncn-w003-Customer permit seq 10
+     match ip address prefix-list pl-can
+     set ip next-hop 192.168.11.6
+route-map ncn-w003-Customer permit seq 20
+     match ip address prefix-list pl-cmn
+router ospf 2 vrf CSM
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.3
+    redistribute bgp
+    area 0.0.0.0
+
+router bgp 65533
+    bgp router-id 10.2.0.3
+    maximum-paths 32
+    timers bgp 1 3
+    distance bgp 20 70
+    neighbor 192.168.12.2 remote-as 65533
+    neighbor 192.168.12.4 remote-as 65532
+    neighbor 192.168.12.4 passive
+    neighbor 192.168.12.5 remote-as 65532
+    neighbor 192.168.12.5 passive
+    neighbor 192.168.12.6 remote-as 65532
+    neighbor 192.168.12.6 passive
+    address-family ipv4 unicast
+        neighbor 192.168.12.2 activate
+        neighbor 192.168.12.4 activate
+        neighbor 192.168.12.4 route-map ncn-w001-Customer in
+        neighbor 192.168.12.5 activate
+        neighbor 192.168.12.5 route-map ncn-w002-Customer in
+        neighbor 192.168.12.6 activate
+        neighbor 192.168.12.6 route-map ncn-w003-Customer in
+    exit-address-family
+    vrf CSM
+        bgp router-id 10.2.0.3
+        maximum-paths 32
+        timers bgp 1 3
+        distance bgp 20 70
+        neighbor 192.168.3.2 remote-as 65533
+        neighbor 192.168.4.4 remote-as 65531
+        neighbor 192.168.4.4 passive
+        neighbor 192.168.4.5 remote-as 65531
+        neighbor 192.168.4.5 passive
+        neighbor 192.168.4.6 remote-as 65531
+        neighbor 192.168.4.6 passive
+        address-family ipv4 unicast
+            neighbor 192.168.3.2 activate
+            neighbor 192.168.4.4 activate
+            neighbor 192.168.4.4 route-map ncn-w001 in
+            neighbor 192.168.4.5 activate
+            neighbor 192.168.4.5 route-map ncn-w002 in
+            neighbor 192.168.4.6 activate
+            neighbor 192.168.4.6 route-map ncn-w003 in
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
@@ -173,6 +173,7 @@ def test_switch_config_leaf_primary():
         assert result.exit_code == 0
         assert diff_config_files(golden_config_file, config_file) == 0
 
+
 def test_switch_config_leaf_secondary():
     """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
     switch_name = "sw-leaf-002"

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
@@ -1,0 +1,321 @@
+# MIT License
+#
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+"""Test CANU generate switch config commands with NMN Isolation flag."""
+from os import path
+from pathlib import Path
+
+import pkg_resources
+from click import testing
+
+from canu.cli import cli
+from tests.lib.diff import diff_config_files
+
+test_file_directory = Path(__file__).resolve().parent
+data_directory = path.join(test_file_directory, "data")
+
+# Set CSM version to test
+csm = "1.7"
+sls_address = "api-gw-service-nmn.local"
+
+sls_file_name = "sls_input_file_csm_1.2.json"
+sls_file = path.join(data_directory, sls_file_name)
+
+# Full systems
+test_shcd_name = "Full_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file = path.join(data_directory, test_shcd_name)
+custom_file_name = "aruba_custom.yaml"
+custom_file = path.join(data_directory, custom_file_name)
+architecture = "full"
+tabs = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners = "J14,T44,J14,T57,J14,T36,J14,T27"
+
+# TDS systems
+test_shcd_name_tds = "TDS_Architecture_Golden_Config_1.1.5.xlsx"
+test_shcd_file_tds = path.join(test_file_directory, "data", test_shcd_name_tds)
+architecture_tds = "tds"
+tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
+corners_tds = "J14,T30,J14,T57,J14,T34,J14,T27"
+
+canu_version = pkg_resources.get_distribution("canu").version
+
+banner_version = f"# CANU version: {canu_version}\n"
+
+runner = testing.CliRunner()
+
+
+def test_switch_config_spine_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary spine config."""
+    switch_name = "sw-spine-001"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_spine_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary spine config."""
+    switch_name = "sw-spine-002"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary leaf config."""
+    switch_name = "sw-leaf-001"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+def test_switch_config_leaf_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary leaf config."""
+    switch_name = "sw-leaf-002"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_leaf_bmc():
+    """Test that the `canu generate switch config` command runs and returns valid leaf bmc."""
+    switch_name = "sw-leaf-bmc-001"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_primary():
+    """Test that the `canu generate switch config` command runs and returns valid primary cdu config."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+
+
+def test_switch_config_cdu_secondary():
+    """Test that the `canu generate switch config` command runs and returns valid secondary cdu config."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}-isolation.cfg"
+    golden_config_file = path.join(data_directory, f"golden_configs/full_configs_1.7/{config_file}")
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--shcd",
+                test_shcd_file,
+                "--tabs",
+                tabs,
+                "--corners",
+                corners,
+                "--sls-file",
+                sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+                "--enable-nmn-isolation",
+                "--nmn-pvlan",
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0


### PR DESCRIPTION
### Summary and Scope

On a Full system (with leaf switches), NMN Isolation ACLs applied to the leaf prevented BGP (TCP/179) and SSH (TCP/22) from passing through the leaf to the spines (BGP) and beyond to CMMs (SSH). Perhaps only a 8320/8325 leaf problem, but that's the CSM standard.

This change removes the MANAGED_NODE_ISOLATION ACLs and reverting back to L2 nmn-hmn on the NMN VLAN as well as removing routed nmn-hmn ACLs on the NMN VLAN interface - for leaf pairs only.  

Researching root cause finds vague Aruba reference to over-using TCAMs. Application of the ACL ingress on leafs worked, but prevented ssh and BGP.  Application of ACL egress on leafs failed with an error that there was a problem applying to the TCAM (which matches up with Aruba doc).  Any application of the ACL egress - with or without the egress, and with or without routed nmn-hmn - failed. Note that looking at counters within the MANAGED_NODE_ISOLATION ACL applied to ingress showed that NCN BGP packets to spines were increasing but packets from the spines to the NCNs were no incrementing.  This also matches "one way" behavior.

Log:

```
2025-11-05T17:49:56.407711+00:00 sw-leaf-003 ops-switchd[3459]: Event|10202|LOG_ERR|AMM|1/1|TCAM entry installation has failed in table Egress_IPv4_VLAN_ACL
2025-11-05T17:49:56.466208+00:00 sw-leaf-003 ops-switchd[3459]: Event|10003|LOG_ERR|AMM|1/1|ACL ip MANAGED_NODE_ISOLATION failed to apply on vlan 2
```

NMN ISOLATION prevents EX-EX cabinet communication, prevents DL/XD managed node cross communication, and narrows the ability of managed nodes to access only management node services required to run jobs - allowing api-gw and dhcp for instance, but not ssh.  Removal of the MANAGED_NODE_ISOLATION from leafs needs to still follow isolation rules. Managed non-compute (UAN, gateway, etc...) continue to be covered by PVLAN and no existing official CSM configuration has a managed compute node attaching to the leaf switches at 25Gb.  NMN isolation still works with this change.

- [ ] I have added new tests to cover the new code
- [ ] If adding a new file, I have updated `pyinstaller.py`
- [ ] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `Issue CASMET-2380`
<!-- * Relates to: `Issue` --->
<!-- * Required: `Issue` --->

### Testing

Tested on the internal system Odin, including testing that NMN Isolation for managed nodes still works.