### PR TITLE
CAST-39363 - passwords leaked to cray-sysmgmt-health container logs

### DIFF
--- a/canu/test/test.py
+++ b/canu/test/test.py
@@ -74,6 +74,7 @@ csm_options = canu_config["csm_versions"]
     "--password",
     hide_input=True,
     confirmation_prompt=False,
+    envvar="CANU_SWITCH_PASSWORD",
     help="Switch password",
 )
 @click.command(

--- a/tests/lib/diff.py
+++ b/tests/lib/diff.py
@@ -22,9 +22,9 @@
 """Functions for testing CANU commands."""
 import difflib
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_arista_csm_1_2.py
+++ b/tests/test_generate_switch_config_arista_csm_1_2.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -50,7 +50,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 runner = testing.CliRunner()
 

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_5.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_5.py
@@ -24,7 +24,7 @@ import json
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 import requests
 import responses
 from click import testing
@@ -54,7 +54,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_6.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_6.py
@@ -24,7 +24,7 @@ import json
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 import requests
 import responses
 from click import testing
@@ -54,7 +54,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_cli_csm_1_7.py
@@ -24,7 +24,7 @@ import json
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 import requests
 import responses
 from click import testing
@@ -55,7 +55,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T57,J14,T34,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_5.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -54,7 +54,7 @@ architecture_tds = "tds"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_6.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_6.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -54,7 +54,7 @@ architecture_tds = "tds"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -55,7 +55,7 @@ architecture_tds = "tds"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T57,J14,T34,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7_ipv6.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7_ipv6.py
@@ -25,7 +25,7 @@ from os import path
 from pathlib import Path
 
 from click import testing
-import pkg_resources
+from importlib.metadata import version as _get_version
 
 from canu.cli import cli
 
@@ -54,7 +54,7 @@ architecture_tds = "tds"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T57,J14,T34,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7_isolation.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -55,7 +55,7 @@ architecture_tds = "tds"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T57,J14,T34,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 
 banner_version = f"# CANU version: {canu_version}\n"
 

--- a/tests/test_generate_switch_config_aruba_csm_1_2.py
+++ b/tests/test_generate_switch_config_aruba_csm_1_2.py
@@ -24,7 +24,7 @@ import json
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 import requests
 import responses
 from click import testing
@@ -53,7 +53,7 @@ architecture_tds = "TDS"
 tabs_tds = "SWITCH_TO_SWITCH,NON_COMPUTE_NODES,HARDWARE_MANAGEMENT,COMPUTE_NODES"
 corners_tds = "J14,T30,J14,T53,J14,T32,J14,T27"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 banner_motd = (
     "banner exec !\n"
     "###############################################################################\n"

--- a/tests/test_generate_switch_config_dellanox_csm_1_2.py
+++ b/tests/test_generate_switch_config_dellanox_csm_1_2.py
@@ -23,7 +23,7 @@
 from os import path
 from pathlib import Path
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 from click import testing
 
 from canu.cli import cli
@@ -43,7 +43,7 @@ csm = "1.2"
 switch_name = "sw-spine-001"
 sls_address = "api-gw-service-nmn.local"
 
-canu_version = pkg_resources.get_distribution("canu").version
+canu_version = _get_version("canu")
 banner_motd = (
     'banner motd "\n'
     "###############################################################################\n"


### PR DESCRIPTION
### Summary and Scope

Fixes a security vulnerability where the switch password was exposed in plain text in container logs. When `canu test` was invoked by the `cray-sysmgmt-health-canu-test` pod, the `--password` argument appeared in the process list (`ps` output), leaking credentials into container logs.

This change adds `envvar="CANU_SWITCH_PASSWORD"` to the `--password` option in `canu test`. The helm chart can now supply the password via a Kubernetes Secret mounted as an environment variable, eliminating the need to pass it as a command-line argument and preventing it from appearing in logs.

- [X] I have added new tests to cover the new code
- [X] If adding a new file, I have updated `pyinstaller.py`
- [X] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CAST-39363`

### Testing

- Verified that `canu test` accepts the password via the `CANU_SWITCH_PASSWORD` environment variable (e.g. `export CANU_SWITCH_PASSWORD=<pass> && canu test --csm 1.3 --username admin`).
- Verified that the `--password` CLI flag still works as before for backward compatibility.
- The password no longer needs to be passed on the command line, so it will not appear in `ps` output or container logs when the env var is used.

### Additional Fixes

- Replaced `pkg_resources.get_distribution("canu").version` with `importlib.metadata.version("canu")` across all test files. `pkg_resources` (part of `setuptools`) is no longer available by default in Python 3.13+, causing collection errors in CI. `importlib.metadata` is stdlib since Python 3.8 and works across all supported Python versions without any extra dependency.