### PR TITLE
CASMNET-2390 - `canu generate network config` silently emits wrong-cabinet VLANs on sw-cdu ports when a Mountain/Olympus cabinet is in the CCJ but not in SLS

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### [UNRELEASED]
 
+- CASMNET-2390 Fix wrong-VLAN rendering on CDU CMM/CEC ports when a Mountain cabinet is in the CCJ but missing from SLS
+
 ### [1.9.11]
 
 - CASMNET-2309 Fixed BGP tests in https://github.com/Cray-HPE/canu/pull/654

--- a/canu/generate/switch/config/config.py
+++ b/canu/generate/switch/config/config.py
@@ -1186,10 +1186,20 @@ def get_switch_nodes(
             nodes.append(new_node)
         elif shasta_name == "cec":
             destination_rack_int = int(re.search(r"\d+", destination_rack)[0])
+            hmn_mtn_vlan = None
             for cabinets in sls_variables["HMN_MTN_CABINETS"]:
                 sls_rack_int = int(re.search(r"\d+", (cabinets["Name"]))[0])
                 if destination_rack_int == sls_rack_int:
                     hmn_mtn_vlan = cabinets["VlanID"]
+            if hmn_mtn_vlan is None:
+                click.secho(
+                    f"WARNING: Skipping CEC port {source_port} on {switch_name} for "
+                    f"cabinet {destination_rack}: cabinet is in the CCJ/SHCD but not "
+                    f"in SLS (HMN_MTN_CABINETS). The CCJ and SLS are out of sync; "
+                    f"reconcile them and regenerate the config.",
+                    fg="red",
+                )
+                continue
             new_node = {
                 "subtype": "cec",
                 "slot": None,
@@ -1207,6 +1217,8 @@ def get_switch_nodes(
             nodes.append(new_node)
         elif shasta_name == "cmm":
             destination_rack_int = int(re.search(r"\d+", destination_rack)[0])
+            nmn_mtn_vlan = None
+            hmn_mtn_vlan = None
             for cabinets in sls_variables["NMN_MTN_CABINETS"]:
                 sls_rack_int = int(re.search(r"\d+", (cabinets["Name"]))[0])
                 if destination_rack_int == sls_rack_int:
@@ -1215,6 +1227,21 @@ def get_switch_nodes(
                 sls_rack_int = int(re.search(r"\d+", (cabinets["Name"]))[0])
                 if destination_rack_int == sls_rack_int:
                     hmn_mtn_vlan = cabinets["VlanID"]
+            if nmn_mtn_vlan is None or hmn_mtn_vlan is None:
+                missing = []
+                if nmn_mtn_vlan is None:
+                    missing.append("NMN_MTN_CABINETS")
+                if hmn_mtn_vlan is None:
+                    missing.append("HMN_MTN_CABINETS")
+                click.secho(
+                    f"WARNING: Skipping CMM port {source_port} (lag {primary_port}) "
+                    f"on {switch_name} for cabinet {destination_rack}: cabinet is in "
+                    f"the CCJ/SHCD but missing from SLS ({', '.join(missing)}). "
+                    f"The CCJ and SLS are out of sync; reconcile them and regenerate "
+                    f"the config.",
+                    fg="red",
+                )
+                continue
             new_node = {
                 "subtype": "cmm",
                 "slot": None,

--- a/tests/data/Full_Architecture_Mountain_2cab.json
+++ b/tests/data/Full_Architecture_Mountain_2cab.json
@@ -1,0 +1,2555 @@
+{
+  "canu_version": "2.0.10.dev6+gf6e4bca",
+  "architecture": "network_v2",
+  "shcd_file": "hela_a42.xlsx",
+  "tabs": "NMN,HMN,10G_25G_40G_100G,Mountain-TDS-Management",
+  "corners": "J15,T16,J20,U36,I37,T103,K15,U54",
+  "edge": "Arista",
+  "updated_at": "2026-06-09 11:08:55",
+  "topology": [
+    {
+      "common_name": "ncn-m001",
+      "id": 0,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u01"
+      }
+    },
+    {
+      "common_name": "pdu-x3000-001",
+      "id": 1,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 2,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "p1"
+      }
+    },
+    {
+      "common_name": "sw-leaf-bmc-002",
+      "id": 2,
+      "architecture": "river_bmc_leaf",
+      "model": "6300M_JL762A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 36,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 37,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 38,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 47,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 5,
+          "destination_port": 1,
+          "destination_slot": "mgmt"
+        },
+        {
+          "port": 48,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 1,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 51,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 48,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u32"
+      }
+    },
+    {
+      "common_name": "pdu-x3000-000",
+      "id": 3,
+      "architecture": "pdu",
+      "model": "pdu",
+      "type": "none",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "p0"
+      }
+    },
+    {
+      "common_name": "sw-leaf-bmc-001",
+      "id": 4,
+      "architecture": "river_bmc_leaf",
+      "model": "6300M_JL762A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 34,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 35,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 36,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 37,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 38,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 39,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 40,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 41,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 47,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 6,
+          "destination_port": 1,
+          "destination_slot": "mgmt"
+        },
+        {
+          "port": 48,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 3,
+          "destination_port": 1,
+          "destination_slot": "bmc"
+        },
+        {
+          "port": 51,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 48,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u31"
+      }
+    },
+    {
+      "common_name": "sw-hsn-x3000-002",
+      "id": 5,
+      "architecture": "slingshot_hsn_switch",
+      "model": "slingshot_hsn_switch",
+      "type": "switch",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "mgmt",
+          "destination_node_id": 2,
+          "destination_port": 47,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u40"
+      }
+    },
+    {
+      "common_name": "sw-hsn-x3000-001",
+      "id": 6,
+      "architecture": "slingshot_hsn_switch",
+      "model": "slingshot_hsn_switch",
+      "type": "switch",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "mgmt",
+          "destination_node_id": 4,
+          "destination_port": 47,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u39"
+      }
+    },
+    {
+      "common_name": "uan002",
+      "id": 7,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 41,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 13,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 13,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u16"
+      }
+    },
+    {
+      "common_name": "uan001",
+      "id": 8,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 40,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 12,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 12,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u15"
+      }
+    },
+    {
+      "common_name": "ncn-s003",
+      "id": 9,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 2,
+          "destination_port": 38,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 21,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 6,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u10"
+      }
+    },
+    {
+      "common_name": "ncn-s002",
+      "id": 10,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 39,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 21,
+          "destination_port": 4,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u09"
+      }
+    },
+    {
+      "common_name": "ncn-s001",
+      "id": 11,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 38,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 21,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 21,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u08"
+      }
+    },
+    {
+      "common_name": "ncn-w004",
+      "id": 12,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 2,
+          "destination_port": 37,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 21,
+          "destination_port": 2,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u07"
+      }
+    },
+    {
+      "common_name": "ncn-w003",
+      "id": 13,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 37,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 23,
+          "destination_port": 5,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u06"
+      }
+    },
+    {
+      "common_name": "ncn-w002",
+      "id": 14,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 36,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 23,
+          "destination_port": 4,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u05"
+      }
+    },
+    {
+      "common_name": "ncn-w001",
+      "id": 15,
+      "architecture": "river_ncn_node_2_port",
+      "model": "river_ncn_node_2_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 35,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": "ocp",
+          "destination_node_id": 23,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u04"
+      }
+    },
+    {
+      "common_name": "ncn-m003",
+      "id": 16,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 2,
+          "destination_port": 36,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 20,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 21,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u03"
+      }
+    },
+    {
+      "common_name": "ncn-m002",
+      "id": 17,
+      "architecture": "river_ncn_node_4_port",
+      "model": "river_ncn_node_4_port",
+      "type": "server",
+      "vendor": "hpe",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "bmc",
+          "destination_node_id": 4,
+          "destination_port": 34,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "ocp",
+          "destination_node_id": 22,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": "pcie-slot1",
+          "destination_node_id": 23,
+          "destination_port": 2,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u02"
+      }
+    },
+    {
+      "common_name": "sw-spine-002",
+      "id": 18,
+      "architecture": "spine",
+      "model": "8325_JL627A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 54,
+          "destination_slot": null
+        },
+        {
+          "port": 15,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 50,
+          "destination_slot": null
+        },
+        {
+          "port": 16,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 50,
+          "destination_slot": null
+        },
+        {
+          "port": 28,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 25,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 29,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 24,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 30,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 30,
+          "destination_slot": null
+        },
+        {
+          "port": 31,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 31,
+          "destination_slot": null
+        },
+        {
+          "port": 32,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 32,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u38"
+      }
+    },
+    {
+      "common_name": "sw-spine-001",
+      "id": 19,
+      "architecture": "spine",
+      "model": "8325_JL627A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 53,
+          "destination_slot": null
+        },
+        {
+          "port": 15,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 49,
+          "destination_slot": null
+        },
+        {
+          "port": 16,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 49,
+          "destination_slot": null
+        },
+        {
+          "port": 28,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 25,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 29,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 24,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 30,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 30,
+          "destination_slot": null
+        },
+        {
+          "port": 31,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 31,
+          "destination_slot": null
+        },
+        {
+          "port": 32,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 32,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u37"
+      }
+    },
+    {
+      "common_name": "sw-leaf-003",
+      "id": 20,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 3,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 4,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 6,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 47,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 21,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u36"
+      }
+    },
+    {
+      "common_name": "sw-leaf-004",
+      "id": 21,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 16,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 2,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 12,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 3,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 4,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 5,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 6,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 11,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 47,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 2,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 20,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u35"
+      }
+    },
+    {
+      "common_name": "sw-leaf-001",
+      "id": 22,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 4,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 6,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 7,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 8,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 9,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 1,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 12,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 13,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 47,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 52,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 23,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u34"
+      }
+    },
+    {
+      "common_name": "sw-leaf-002",
+      "id": 23,
+      "architecture": "river_ncn_leaf",
+      "model": "8325_JL625A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 0,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 2,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 17,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 3,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 15,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 4,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 14,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 5,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 13,
+          "destination_port": 2,
+          "destination_slot": "ocp"
+        },
+        {
+          "port": 6,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 9,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 7,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 10,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 8,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 9,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 1,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 12,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 8,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 13,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 7,
+          "destination_port": 2,
+          "destination_slot": "pcie-slot1"
+        },
+        {
+          "port": 47,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 25,
+          "slot": null,
+          "destination_node_id": 4,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 53,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 54,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 55,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 55,
+          "destination_slot": null
+        },
+        {
+          "port": 56,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 22,
+          "destination_port": 56,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u33"
+      }
+    },
+    {
+      "common_name": "sw-edge-001",
+      "id": 24,
+      "architecture": "customer_edge_router",
+      "model": "customer_edge_router",
+      "type": "switch",
+      "vendor": "arista",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 29,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 29,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u18"
+      }
+    },
+    {
+      "common_name": "sw-edge-002",
+      "id": 25,
+      "architecture": "customer_edge_router",
+      "model": "customer_edge_router",
+      "type": "switch",
+      "vendor": "arista",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 28,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 28,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x3000",
+        "elevation": "u19"
+      }
+    },
+    {
+      "common_name": "sw-cdu-002",
+      "id": 26,
+      "architecture": "mountain_compute_leaf",
+      "model": "8360_JL706A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 28,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 29,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 30,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 31,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 32,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 6,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 33,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 7,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 34,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 8,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 35,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 9,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 38,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 10,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 39,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 11,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 40,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 12,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 41,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 13,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 42,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 14,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 43,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 15,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 44,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 16,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 45,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 46,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 47,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 47,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 37,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 49,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 16,
+          "destination_slot": null
+        },
+        {
+          "port": 50,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 16,
+          "destination_slot": null
+        },
+        {
+          "port": 51,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 52,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "u42"
+      }
+    },
+    {
+      "common_name": "sw-cdu-001",
+      "id": 27,
+      "architecture": "mountain_compute_leaf",
+      "model": "8360_JL706A",
+      "type": "switch",
+      "vendor": "aruba",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 28,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 29,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 3,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 30,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 4,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 31,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 5,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 32,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 6,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 33,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 7,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 34,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 8,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 35,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 9,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 38,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 10,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 39,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 11,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 40,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 12,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 41,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 13,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 42,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 14,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 43,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 15,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 44,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 16,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 45,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 46,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 46,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 47,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 47,
+          "destination_slot": null
+        },
+        {
+          "port": 48,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 36,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 49,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 19,
+          "destination_port": 15,
+          "destination_slot": null
+        },
+        {
+          "port": 50,
+          "speed": 100,
+          "slot": null,
+          "destination_node_id": 18,
+          "destination_port": 15,
+          "destination_slot": null
+        },
+        {
+          "port": 51,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 51,
+          "destination_slot": null
+        },
+        {
+          "port": 52,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 52,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "u41"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-000",
+      "id": 28,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 1,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 1,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c0"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-001",
+      "id": 29,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 2,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 2,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c1"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-002",
+      "id": 30,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 3,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 3,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c2"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-003",
+      "id": 31,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 4,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 4,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c3"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-004",
+      "id": 32,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 5,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 5,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c4"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-005",
+      "id": 33,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 6,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 6,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c5"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-006",
+      "id": 34,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 7,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 7,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c6"
+      }
+    },
+    {
+      "common_name": "cmm-x1000-007",
+      "id": 35,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 8,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 8,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c7"
+      }
+    },
+    {
+      "common_name": "cec-x1000-000",
+      "id": 36,
+      "architecture": "cec",
+      "model": "cec",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c6"
+      }
+    },
+    {
+      "common_name": "cec-x1000-001",
+      "id": 37,
+      "architecture": "cec",
+      "model": "cec",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 48,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1000",
+        "elevation": "c7"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-000",
+      "id": 38,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 9,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 9,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c0"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-001",
+      "id": 39,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 10,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 10,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c1"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-002",
+      "id": 40,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 11,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 11,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c2"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-003",
+      "id": 41,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 12,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 12,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c3"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-004",
+      "id": 42,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 13,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 13,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c4"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-005",
+      "id": 43,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 14,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 14,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c5"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-006",
+      "id": 44,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 15,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 15,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c6"
+      }
+    },
+    {
+      "common_name": "cmm-x1001-007",
+      "id": 45,
+      "architecture": "cmm",
+      "model": "cmm",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 16,
+          "destination_slot": null
+        },
+        {
+          "port": 2,
+          "speed": 10,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 16,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c7"
+      }
+    },
+    {
+      "common_name": "cec-x1001-000",
+      "id": 46,
+      "architecture": "cec",
+      "model": "cec",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 27,
+          "destination_port": 46,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c6"
+      }
+    },
+    {
+      "common_name": "cec-x1001-001",
+      "id": 47,
+      "architecture": "cec",
+      "model": "cec",
+      "type": "none",
+      "vendor": "cray",
+      "ports": [
+        {
+          "port": 1,
+          "speed": 1,
+          "slot": null,
+          "destination_node_id": 26,
+          "destination_port": 46,
+          "destination_slot": null
+        }
+      ],
+      "location": {
+        "rack": "x1001",
+        "elevation": "c7"
+      }
+    }
+  ]
+}

--- a/tests/data/golden_configs/mtn_sls_mismatch_1.7/sw-cdu-001.cfg
+++ b/tests/data/golden_configs/mtn_sls_mismatch_1.7/sw-cdu-001.cfg
@@ -1,0 +1,333 @@
+
+hostname sw-cdu-001
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.10.dev7+g87e9d6a.d20260609
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 10.252.1.8
+ntp server 10.252.1.7
+ntp server 10.252.1.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 10.254.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 10.254.0.0/255.255.128.0 any eq https
+    40 permit udp 10.254.0.0/255.255.128.0 any eq snmp
+    50 permit udp 10.254.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 10.102.66.0/255.255.255.128 eq ssh
+    70 permit udp any eq ntp 10.252.0.0/255.255.128.0
+    80 permit tcp 10.102.66.0/255.255.255.128 any eq https
+    90 permit udp 10.102.66.0/255.255.255.128 any eq snmp
+    100 permit udp 10.102.66.0/255.255.255.128 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 10.252.0.0/255.255.128.0 10.254.0.0/255.255.128.0
+    20 deny any 10.254.0.0/255.255.128.0 10.252.0.0/255.255.128.0
+    30 deny any 10.252.0.0/255.255.128.0 10.104.0.0/255.255.128.0
+    40 deny any 10.254.0.0/255.255.128.0 10.100.0.0/255.255.248.0
+    50 deny any 10.100.0.0/255.255.248.0 10.254.0.0/255.255.128.0
+    60 deny any 10.100.0.0/255.255.248.0 10.104.0.0/255.255.128.0
+    70 deny any 10.104.0.0/255.255.128.0 10.252.0.0/255.255.128.0
+    80 deny any 10.104.0.0/255.255.128.0 10.100.0.0/255.255.248.0
+    90 deny any 10.92.100.0/255.255.255.0 10.254.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 10.252.0.0/255.255.128.0
+    110 deny any 10.254.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 10.252.0.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 10.102.66.0/255.255.255.128 10.102.66.128/255.255.255.128
+    20 deny any 10.102.66.128/255.255.255.128 10.102.66.0/255.255.255.128
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 7
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_1000_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_1000_hmn
+    ip mtu 9198
+    ip address 10.104.0.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 10.104.0.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_1000_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_1000_nmn
+    ip mtu 9198
+    ip address 10.100.0.2/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 10.100.0.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 1 multi-chassis static
+    no shutdown
+    description cmm-x1000-000:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cmm-x1000-000:1<==sw-cdu-001
+    lag 1
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x1000-001:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x1000-001:1<==sw-cdu-001
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x1000-002:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x1000-002:1<==sw-cdu-001
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x1000-003:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x1000-003:1<==sw-cdu-001
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x1000-004:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x1000-004:1<==sw-cdu-001
+    lag 5
+interface lag 6 multi-chassis static
+    no shutdown
+    description cmm-x1000-005:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description cmm-x1000-005:1<==sw-cdu-001
+    lag 6
+interface lag 7 multi-chassis static
+    no shutdown
+    description cmm-x1000-006:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description cmm-x1000-006:1<==sw-cdu-001
+    lag 7
+interface lag 8 multi-chassis static
+    no shutdown
+    description cmm-x1000-007:1<==sw-cdu-001
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description cmm-x1000-007:1<==sw-cdu-001
+    lag 8
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description cec-x1000-000:1<==sw-cdu-001
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,7
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-001:15<==sw-cdu-001
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-002:15<==sw-cdu-001
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.0/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role primary
+    keepalive peer 192.168.255.1 source 192.168.255.0 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.10/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 10.1.0.10/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 10.252.0.10/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 10.254.0.10/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 7
+    description CMN
+    ip mtu 9198
+    ip address 10.102.66.10/25
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.10
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.10
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/golden_configs/mtn_sls_mismatch_1.7/sw-cdu-002.cfg
+++ b/tests/data/golden_configs/mtn_sls_mismatch_1.7/sw-cdu-002.cfg
@@ -1,0 +1,333 @@
+
+hostname sw-cdu-002
+
+banner exec !
+###############################################################################
+# CSM version:  1.7
+# CANU version: 2.0.10.dev7+g87e9d6a.d20260609
+###############################################################################
+!
+no ip icmp redirect
+vrf keepalive
+vrf CSM
+ntp server 10.252.1.8
+ntp server 10.252.1.7
+ntp server 10.252.1.6
+ntp enable
+
+
+aruba-central
+    disable
+ssh server vrf CSM
+ssh server vrf default
+ssh server vrf keepalive
+ssh server vrf mgmt
+access-list ip mgmt
+    10 comment ALLOW SSH, HTTPS, AND SNMP ON HMN SUBNET and CMN
+    20 permit tcp 10.254.0.0/255.255.128.0 any eq ssh
+    30 permit tcp 10.254.0.0/255.255.128.0 any eq https
+    40 permit udp 10.254.0.0/255.255.128.0 any eq snmp
+    50 permit udp 10.254.0.0/255.255.128.0 any eq snmp-trap
+    60 permit tcp any 10.102.66.0/255.255.255.128 eq ssh
+    70 permit udp any eq ntp 10.252.0.0/255.255.128.0
+    80 permit tcp 10.102.66.0/255.255.255.128 any eq https
+    90 permit udp 10.102.66.0/255.255.255.128 any eq snmp
+    100 permit udp 10.102.66.0/255.255.255.128 any eq snmp-trap
+    110 comment ALLOW SNMP FROM HMN METALLB SUBNET
+    120 permit udp 10.94.100.0/255.255.255.0 any eq snmp
+    130 permit udp 10.94.100.0/255.255.255.0 any eq snmp-trap
+    140 comment BLOCK SSH, HTTPS, AND SNMP FROM EVERYWHERE ELSE
+    150 deny tcp any any eq ssh
+    160 deny tcp any any eq https
+    170 deny udp any any eq snmp
+    180 deny udp any any eq snmp-trap
+    190 comment ALLOW ANYTHING ELSE
+    200 permit any any any
+access-list ip nmn-hmn
+    10 deny any 10.252.0.0/255.255.128.0 10.254.0.0/255.255.128.0
+    20 deny any 10.254.0.0/255.255.128.0 10.252.0.0/255.255.128.0
+    30 deny any 10.252.0.0/255.255.128.0 10.104.0.0/255.255.128.0
+    40 deny any 10.254.0.0/255.255.128.0 10.100.0.0/255.255.248.0
+    50 deny any 10.100.0.0/255.255.248.0 10.254.0.0/255.255.128.0
+    60 deny any 10.100.0.0/255.255.248.0 10.104.0.0/255.255.128.0
+    70 deny any 10.104.0.0/255.255.128.0 10.252.0.0/255.255.128.0
+    80 deny any 10.104.0.0/255.255.128.0 10.100.0.0/255.255.248.0
+    90 deny any 10.92.100.0/255.255.255.0 10.254.0.0/255.255.128.0
+    100 deny any 10.94.100.0/255.255.255.0 10.252.0.0/255.255.128.0
+    110 deny any 10.254.0.0/255.255.128.0 10.92.100.0/255.255.255.0
+    120 deny any 10.252.0.0/255.255.128.0 10.94.100.0/255.255.255.0
+    130 permit udp 10.92.100.222 range 67 68 any
+    140 permit udp any range 67 68 10.92.100.222
+    150 deny any any 10.92.100.222
+    160 permit udp 10.94.100.222 range 67 68 any
+    170 permit udp any range 67 68 10.94.100.222
+    180 deny any any 10.94.100.222
+    190 permit any any any
+access-list ip cmn-can
+    10 deny any 10.102.66.0/255.255.255.128 10.102.66.128/255.255.255.128
+    20 deny any 10.102.66.128/255.255.255.128 10.102.66.0/255.255.255.128
+    30 permit any any any
+apply access-list ip mgmt control-plane vrf default
+apply access-list ip mgmt control-plane vrf CSM
+
+vlan 1
+vlan 2
+    name NMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 4
+    name HMN
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+vlan 7
+    name CMN
+    apply access-list ip cmn-can in
+    apply access-list ip cmn-can out
+vlan 2701
+    name NULL2701
+    description Black hole VLAN 2701
+vlan 2707
+    name NULL2707
+    description Black hole VLAN 2707
+spanning-tree
+spanning-tree forward-delay 4
+spanning-tree config-name MST0
+spanning-tree config-revision 1
+interface mgmt
+    shutdown
+    ip dhcp
+vlan 3000
+    name cabinet_1000_hmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 3000
+    vrf attach CSM
+    description cabinet_1000_hmn
+    ip mtu 9198
+    ip address 10.104.0.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 10.104.0.1
+    ipv6 address autoconfig
+    ip helper-address 10.94.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+vlan 2000
+    name cabinet_1000_nmn
+    apply access-list ip nmn-hmn in
+    apply access-list ip nmn-hmn out
+
+interface vlan 2000
+    vrf attach CSM
+    description cabinet_1000_nmn
+    ip mtu 9198
+    ip address 10.100.0.3/22
+    active-gateway ip mac 12:00:00:00:73:00
+    active-gateway ip 10.100.0.1
+    ip helper-address 10.92.100.222
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+
+interface lag 1 multi-chassis static
+    no shutdown
+    description cmm-x1000-000:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/1
+    no shutdown
+    mtu 9198
+    description cmm-x1000-000:2<==sw-cdu-002
+    lag 1
+interface lag 2 multi-chassis static
+    no shutdown
+    description cmm-x1000-001:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/2
+    no shutdown
+    mtu 9198
+    description cmm-x1000-001:2<==sw-cdu-002
+    lag 2
+interface lag 3 multi-chassis static
+    no shutdown
+    description cmm-x1000-002:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/3
+    no shutdown
+    mtu 9198
+    description cmm-x1000-002:2<==sw-cdu-002
+    lag 3
+interface lag 4 multi-chassis static
+    no shutdown
+    description cmm-x1000-003:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/4
+    no shutdown
+    mtu 9198
+    description cmm-x1000-003:2<==sw-cdu-002
+    lag 4
+interface lag 5 multi-chassis static
+    no shutdown
+    description cmm-x1000-004:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/5
+    no shutdown
+    mtu 9198
+    description cmm-x1000-004:2<==sw-cdu-002
+    lag 5
+interface lag 6 multi-chassis static
+    no shutdown
+    description cmm-x1000-005:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/6
+    no shutdown
+    mtu 9198
+    description cmm-x1000-005:2<==sw-cdu-002
+    lag 6
+interface lag 7 multi-chassis static
+    no shutdown
+    description cmm-x1000-006:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/7
+    no shutdown
+    mtu 9198
+    description cmm-x1000-006:2<==sw-cdu-002
+    lag 7
+interface lag 8 multi-chassis static
+    no shutdown
+    description cmm-x1000-007:2<==sw-cdu-002
+    no routing
+    vlan trunk native 2000
+    vlan trunk allowed 2000,3000
+    spanning-tree root-guard
+
+interface 1/1/8
+    no shutdown
+    mtu 9198
+    description cmm-x1000-007:2<==sw-cdu-002
+    lag 8
+
+interface 1/1/48
+    no shutdown
+    mtu 9198
+    description cec-x1000-001:1<==sw-cdu-002
+    no routing
+    vlan access 3000
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+
+interface lag 255 multi-chassis
+    no shutdown
+    description cdu_to_spines_lag
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed 1-2,4,7
+    lacp mode active
+
+interface 1/1/49
+    no shutdown
+    mtu 9198
+    description sw-spine-001:16<==sw-cdu-002
+    lag 255
+
+interface 1/1/50
+    no shutdown
+    mtu 9198
+    description sw-spine-002:16<==sw-cdu-002
+    lag 255
+
+
+interface lag 256
+    no shutdown
+    description ISL link
+    no routing
+    vlan trunk native 1 tag
+    vlan trunk allowed all
+    lacp mode active
+interface 1/1/47
+    no shutdown
+    vrf attach keepalive
+    description VSX keepalive
+    ip address 192.168.255.1/31
+interface 1/1/51
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+interface 1/1/52
+    no shutdown
+    mtu 9198
+    description vsx isl
+    lag 256
+vsx
+    system-mac 02:02:00:00:01:00
+    inter-switch-link lag 256
+    role secondary
+    keepalive peer 192.168.255.0 source 192.168.255.1 vrf keepalive
+    linkup-delay-timer 600
+    vsx-sync vsx-global
+
+interface loopback 0
+    ip address 10.2.0.11/32
+    ip ospf 1 area 0.0.0.0
+interface vlan 1
+    ip mtu 9198
+    ip address 10.1.0.11/16
+    ip ospf 1 area 0.0.0.0
+    ip ospf passive
+interface vlan 2
+    vrf attach CSM
+    description NMN
+    ip mtu 9198
+    ip address 10.252.0.11/17
+    ip ospf 2 area 0.0.0.0
+interface vlan 4
+    vrf attach CSM
+    description HMN
+    ip mtu 9198
+    ip address 10.254.0.11/17
+    ip ospf 2 area 0.0.0.0
+    ip ospf passive
+interface vlan 7
+    description CMN
+    ip mtu 9198
+    ip address 10.102.66.11/25
+    ip ospf 1 area 0.0.0.0
+
+ip dns server-address 10.92.100.225 vrf CSM
+router ospf 2 vrf CSM
+    router-id 10.2.0.11
+    area 0.0.0.0
+router ospf 1
+    router-id 10.2.0.11
+    area 0.0.0.0
+https-server vrf CSM
+https-server vrf default
+https-server vrf mgmt
+

--- a/tests/data/sls_input_file_csm_1.7_mtn_mismatch.json
+++ b/tests/data/sls_input_file_csm_1.7_mtn_mismatch.json
@@ -1,0 +1,5723 @@
+{
+    "Hardware": {
+        "d0w1": {
+            "Parent": "d0",
+            "Xname": "d0w1",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-001"
+                ]
+            }
+        },
+        "d0w2": {
+            "Parent": "d0",
+            "Xname": "d0w2",
+            "Type": "comptype_cdu_mgmt_switch",
+            "Class": "Mountain",
+            "TypeString": "CDUMgmtSwitch",
+            "ExtraProperties": {
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-cdu-002"
+                ]
+            }
+        },
+        "x1000": {
+            "Parent": "s0",
+            "Xname": "x1000",
+            "Type": "comptype_cabinet",
+            "Class": "Mountain",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.104.0.0/22",
+                            "Gateway": "10.104.0.1",
+                            "VLan": 3000
+                        },
+                        "NMN": {
+                            "CIDR": "10.100.0.0/22",
+                            "Gateway": "10.100.0.1",
+                            "VLan": 2000
+                        }
+                    }
+                }
+            }
+        },
+        "x1000c0": {
+            "Parent": "x1000",
+            "Xname": "x1000c0",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c0b0": {
+            "Parent": "x1000c0",
+            "Xname": "x1000c0b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c0s0b0n0": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1000,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001000"
+                ]
+            }
+        },
+        "x1000c0s0b0n1": {
+            "Parent": "x1000c0s0b0",
+            "Xname": "x1000c0s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1001,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001001"
+                ]
+            }
+        },
+        "x1000c0s0b1n0": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1002,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001002"
+                ]
+            }
+        },
+        "x1000c0s0b1n1": {
+            "Parent": "x1000c0s0b1",
+            "Xname": "x1000c0s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1003,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001003"
+                ]
+            }
+        },
+        "x1000c0s1b0n0": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1004,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001004"
+                ]
+            }
+        },
+        "x1000c0s1b0n1": {
+            "Parent": "x1000c0s1b0",
+            "Xname": "x1000c0s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1005,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001005"
+                ]
+            }
+        },
+        "x1000c0s1b1n0": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1006,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001006"
+                ]
+            }
+        },
+        "x1000c0s1b1n1": {
+            "Parent": "x1000c0s1b1",
+            "Xname": "x1000c0s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1007,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001007"
+                ]
+            }
+        },
+        "x1000c0s2b0n0": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1008,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001008"
+                ]
+            }
+        },
+        "x1000c0s2b0n1": {
+            "Parent": "x1000c0s2b0",
+            "Xname": "x1000c0s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1009,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001009"
+                ]
+            }
+        },
+        "x1000c0s2b1n0": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1010,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001010"
+                ]
+            }
+        },
+        "x1000c0s2b1n1": {
+            "Parent": "x1000c0s2b1",
+            "Xname": "x1000c0s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1011,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001011"
+                ]
+            }
+        },
+        "x1000c0s3b0n0": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1012,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001012"
+                ]
+            }
+        },
+        "x1000c0s3b0n1": {
+            "Parent": "x1000c0s3b0",
+            "Xname": "x1000c0s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1013,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001013"
+                ]
+            }
+        },
+        "x1000c0s3b1n0": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1014,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001014"
+                ]
+            }
+        },
+        "x1000c0s3b1n1": {
+            "Parent": "x1000c0s3b1",
+            "Xname": "x1000c0s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1015,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001015"
+                ]
+            }
+        },
+        "x1000c0s4b0n0": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1016,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001016"
+                ]
+            }
+        },
+        "x1000c0s4b0n1": {
+            "Parent": "x1000c0s4b0",
+            "Xname": "x1000c0s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1017,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001017"
+                ]
+            }
+        },
+        "x1000c0s4b1n0": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1018,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001018"
+                ]
+            }
+        },
+        "x1000c0s4b1n1": {
+            "Parent": "x1000c0s4b1",
+            "Xname": "x1000c0s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1019,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001019"
+                ]
+            }
+        },
+        "x1000c0s5b0n0": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1020,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001020"
+                ]
+            }
+        },
+        "x1000c0s5b0n1": {
+            "Parent": "x1000c0s5b0",
+            "Xname": "x1000c0s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1021,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001021"
+                ]
+            }
+        },
+        "x1000c0s5b1n0": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1022,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001022"
+                ]
+            }
+        },
+        "x1000c0s5b1n1": {
+            "Parent": "x1000c0s5b1",
+            "Xname": "x1000c0s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1023,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001023"
+                ]
+            }
+        },
+        "x1000c0s6b0n0": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1024,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001024"
+                ]
+            }
+        },
+        "x1000c0s6b0n1": {
+            "Parent": "x1000c0s6b0",
+            "Xname": "x1000c0s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1025,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001025"
+                ]
+            }
+        },
+        "x1000c0s6b1n0": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1026,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001026"
+                ]
+            }
+        },
+        "x1000c0s6b1n1": {
+            "Parent": "x1000c0s6b1",
+            "Xname": "x1000c0s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1027,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001027"
+                ]
+            }
+        },
+        "x1000c0s7b0n0": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1028,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001028"
+                ]
+            }
+        },
+        "x1000c0s7b0n1": {
+            "Parent": "x1000c0s7b0",
+            "Xname": "x1000c0s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1029,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001029"
+                ]
+            }
+        },
+        "x1000c0s7b1n0": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1030,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001030"
+                ]
+            }
+        },
+        "x1000c0s7b1n1": {
+            "Parent": "x1000c0s7b1",
+            "Xname": "x1000c0s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1031,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001031"
+                ]
+            }
+        },
+        "x1000c1": {
+            "Parent": "x1000",
+            "Xname": "x1000c1",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c1b0": {
+            "Parent": "x1000c1",
+            "Xname": "x1000c1b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c1s0b0n0": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1032,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001032"
+                ]
+            }
+        },
+        "x1000c1s0b0n1": {
+            "Parent": "x1000c1s0b0",
+            "Xname": "x1000c1s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1033,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001033"
+                ]
+            }
+        },
+        "x1000c1s0b1n0": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1034,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001034"
+                ]
+            }
+        },
+        "x1000c1s0b1n1": {
+            "Parent": "x1000c1s0b1",
+            "Xname": "x1000c1s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1035,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001035"
+                ]
+            }
+        },
+        "x1000c1s1b0n0": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1036,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001036"
+                ]
+            }
+        },
+        "x1000c1s1b0n1": {
+            "Parent": "x1000c1s1b0",
+            "Xname": "x1000c1s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1037,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001037"
+                ]
+            }
+        },
+        "x1000c1s1b1n0": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1038,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001038"
+                ]
+            }
+        },
+        "x1000c1s1b1n1": {
+            "Parent": "x1000c1s1b1",
+            "Xname": "x1000c1s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1039,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001039"
+                ]
+            }
+        },
+        "x1000c1s2b0n0": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1040,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001040"
+                ]
+            }
+        },
+        "x1000c1s2b0n1": {
+            "Parent": "x1000c1s2b0",
+            "Xname": "x1000c1s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1041,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001041"
+                ]
+            }
+        },
+        "x1000c1s2b1n0": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1042,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001042"
+                ]
+            }
+        },
+        "x1000c1s2b1n1": {
+            "Parent": "x1000c1s2b1",
+            "Xname": "x1000c1s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1043,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001043"
+                ]
+            }
+        },
+        "x1000c1s3b0n0": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1044,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001044"
+                ]
+            }
+        },
+        "x1000c1s3b0n1": {
+            "Parent": "x1000c1s3b0",
+            "Xname": "x1000c1s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1045,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001045"
+                ]
+            }
+        },
+        "x1000c1s3b1n0": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1046,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001046"
+                ]
+            }
+        },
+        "x1000c1s3b1n1": {
+            "Parent": "x1000c1s3b1",
+            "Xname": "x1000c1s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1047,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001047"
+                ]
+            }
+        },
+        "x1000c1s4b0n0": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1048,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001048"
+                ]
+            }
+        },
+        "x1000c1s4b0n1": {
+            "Parent": "x1000c1s4b0",
+            "Xname": "x1000c1s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1049,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001049"
+                ]
+            }
+        },
+        "x1000c1s4b1n0": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1050,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001050"
+                ]
+            }
+        },
+        "x1000c1s4b1n1": {
+            "Parent": "x1000c1s4b1",
+            "Xname": "x1000c1s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1051,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001051"
+                ]
+            }
+        },
+        "x1000c1s5b0n0": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1052,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001052"
+                ]
+            }
+        },
+        "x1000c1s5b0n1": {
+            "Parent": "x1000c1s5b0",
+            "Xname": "x1000c1s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1053,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001053"
+                ]
+            }
+        },
+        "x1000c1s5b1n0": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1054,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001054"
+                ]
+            }
+        },
+        "x1000c1s5b1n1": {
+            "Parent": "x1000c1s5b1",
+            "Xname": "x1000c1s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1055,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001055"
+                ]
+            }
+        },
+        "x1000c1s6b0n0": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1056,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001056"
+                ]
+            }
+        },
+        "x1000c1s6b0n1": {
+            "Parent": "x1000c1s6b0",
+            "Xname": "x1000c1s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1057,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001057"
+                ]
+            }
+        },
+        "x1000c1s6b1n0": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1058,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001058"
+                ]
+            }
+        },
+        "x1000c1s6b1n1": {
+            "Parent": "x1000c1s6b1",
+            "Xname": "x1000c1s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1059,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001059"
+                ]
+            }
+        },
+        "x1000c1s7b0n0": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1060,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001060"
+                ]
+            }
+        },
+        "x1000c1s7b0n1": {
+            "Parent": "x1000c1s7b0",
+            "Xname": "x1000c1s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1061,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001061"
+                ]
+            }
+        },
+        "x1000c1s7b1n0": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1062,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001062"
+                ]
+            }
+        },
+        "x1000c1s7b1n1": {
+            "Parent": "x1000c1s7b1",
+            "Xname": "x1000c1s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1063,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001063"
+                ]
+            }
+        },
+        "x1000c2": {
+            "Parent": "x1000",
+            "Xname": "x1000c2",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c2b0": {
+            "Parent": "x1000c2",
+            "Xname": "x1000c2b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c2s0b0n0": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1064,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001064"
+                ]
+            }
+        },
+        "x1000c2s0b0n1": {
+            "Parent": "x1000c2s0b0",
+            "Xname": "x1000c2s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1065,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001065"
+                ]
+            }
+        },
+        "x1000c2s0b1n0": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1066,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001066"
+                ]
+            }
+        },
+        "x1000c2s0b1n1": {
+            "Parent": "x1000c2s0b1",
+            "Xname": "x1000c2s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1067,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001067"
+                ]
+            }
+        },
+        "x1000c2s1b0n0": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1068,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001068"
+                ]
+            }
+        },
+        "x1000c2s1b0n1": {
+            "Parent": "x1000c2s1b0",
+            "Xname": "x1000c2s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1069,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001069"
+                ]
+            }
+        },
+        "x1000c2s1b1n0": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1070,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001070"
+                ]
+            }
+        },
+        "x1000c2s1b1n1": {
+            "Parent": "x1000c2s1b1",
+            "Xname": "x1000c2s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1071,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001071"
+                ]
+            }
+        },
+        "x1000c2s2b0n0": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1072,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001072"
+                ]
+            }
+        },
+        "x1000c2s2b0n1": {
+            "Parent": "x1000c2s2b0",
+            "Xname": "x1000c2s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1073,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001073"
+                ]
+            }
+        },
+        "x1000c2s2b1n0": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1074,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001074"
+                ]
+            }
+        },
+        "x1000c2s2b1n1": {
+            "Parent": "x1000c2s2b1",
+            "Xname": "x1000c2s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1075,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001075"
+                ]
+            }
+        },
+        "x1000c2s3b0n0": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1076,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001076"
+                ]
+            }
+        },
+        "x1000c2s3b0n1": {
+            "Parent": "x1000c2s3b0",
+            "Xname": "x1000c2s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1077,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001077"
+                ]
+            }
+        },
+        "x1000c2s3b1n0": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1078,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001078"
+                ]
+            }
+        },
+        "x1000c2s3b1n1": {
+            "Parent": "x1000c2s3b1",
+            "Xname": "x1000c2s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1079,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001079"
+                ]
+            }
+        },
+        "x1000c2s4b0n0": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1080,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001080"
+                ]
+            }
+        },
+        "x1000c2s4b0n1": {
+            "Parent": "x1000c2s4b0",
+            "Xname": "x1000c2s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1081,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001081"
+                ]
+            }
+        },
+        "x1000c2s4b1n0": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1082,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001082"
+                ]
+            }
+        },
+        "x1000c2s4b1n1": {
+            "Parent": "x1000c2s4b1",
+            "Xname": "x1000c2s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1083,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001083"
+                ]
+            }
+        },
+        "x1000c2s5b0n0": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1084,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001084"
+                ]
+            }
+        },
+        "x1000c2s5b0n1": {
+            "Parent": "x1000c2s5b0",
+            "Xname": "x1000c2s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1085,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001085"
+                ]
+            }
+        },
+        "x1000c2s5b1n0": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1086,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001086"
+                ]
+            }
+        },
+        "x1000c2s5b1n1": {
+            "Parent": "x1000c2s5b1",
+            "Xname": "x1000c2s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1087,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001087"
+                ]
+            }
+        },
+        "x1000c2s6b0n0": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1088,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001088"
+                ]
+            }
+        },
+        "x1000c2s6b0n1": {
+            "Parent": "x1000c2s6b0",
+            "Xname": "x1000c2s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1089,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001089"
+                ]
+            }
+        },
+        "x1000c2s6b1n0": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1090,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001090"
+                ]
+            }
+        },
+        "x1000c2s6b1n1": {
+            "Parent": "x1000c2s6b1",
+            "Xname": "x1000c2s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1091,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001091"
+                ]
+            }
+        },
+        "x1000c2s7b0n0": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1092,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001092"
+                ]
+            }
+        },
+        "x1000c2s7b0n1": {
+            "Parent": "x1000c2s7b0",
+            "Xname": "x1000c2s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1093,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001093"
+                ]
+            }
+        },
+        "x1000c2s7b1n0": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1094,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001094"
+                ]
+            }
+        },
+        "x1000c2s7b1n1": {
+            "Parent": "x1000c2s7b1",
+            "Xname": "x1000c2s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1095,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001095"
+                ]
+            }
+        },
+        "x1000c3": {
+            "Parent": "x1000",
+            "Xname": "x1000c3",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c3b0": {
+            "Parent": "x1000c3",
+            "Xname": "x1000c3b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c3s0b0n0": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1096,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001096"
+                ]
+            }
+        },
+        "x1000c3s0b0n1": {
+            "Parent": "x1000c3s0b0",
+            "Xname": "x1000c3s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1097,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001097"
+                ]
+            }
+        },
+        "x1000c3s0b1n0": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1098,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001098"
+                ]
+            }
+        },
+        "x1000c3s0b1n1": {
+            "Parent": "x1000c3s0b1",
+            "Xname": "x1000c3s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1099,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001099"
+                ]
+            }
+        },
+        "x1000c3s1b0n0": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1100,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001100"
+                ]
+            }
+        },
+        "x1000c3s1b0n1": {
+            "Parent": "x1000c3s1b0",
+            "Xname": "x1000c3s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1101,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001101"
+                ]
+            }
+        },
+        "x1000c3s1b1n0": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1102,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001102"
+                ]
+            }
+        },
+        "x1000c3s1b1n1": {
+            "Parent": "x1000c3s1b1",
+            "Xname": "x1000c3s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1103,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001103"
+                ]
+            }
+        },
+        "x1000c3s2b0n0": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1104,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001104"
+                ]
+            }
+        },
+        "x1000c3s2b0n1": {
+            "Parent": "x1000c3s2b0",
+            "Xname": "x1000c3s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1105,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001105"
+                ]
+            }
+        },
+        "x1000c3s2b1n0": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1106,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001106"
+                ]
+            }
+        },
+        "x1000c3s2b1n1": {
+            "Parent": "x1000c3s2b1",
+            "Xname": "x1000c3s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1107,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001107"
+                ]
+            }
+        },
+        "x1000c3s3b0n0": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1108,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001108"
+                ]
+            }
+        },
+        "x1000c3s3b0n1": {
+            "Parent": "x1000c3s3b0",
+            "Xname": "x1000c3s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1109,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001109"
+                ]
+            }
+        },
+        "x1000c3s3b1n0": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1110,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001110"
+                ]
+            }
+        },
+        "x1000c3s3b1n1": {
+            "Parent": "x1000c3s3b1",
+            "Xname": "x1000c3s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1111,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001111"
+                ]
+            }
+        },
+        "x1000c3s4b0n0": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1112,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001112"
+                ]
+            }
+        },
+        "x1000c3s4b0n1": {
+            "Parent": "x1000c3s4b0",
+            "Xname": "x1000c3s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1113,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001113"
+                ]
+            }
+        },
+        "x1000c3s4b1n0": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1114,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001114"
+                ]
+            }
+        },
+        "x1000c3s4b1n1": {
+            "Parent": "x1000c3s4b1",
+            "Xname": "x1000c3s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1115,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001115"
+                ]
+            }
+        },
+        "x1000c3s5b0n0": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1116,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001116"
+                ]
+            }
+        },
+        "x1000c3s5b0n1": {
+            "Parent": "x1000c3s5b0",
+            "Xname": "x1000c3s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1117,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001117"
+                ]
+            }
+        },
+        "x1000c3s5b1n0": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1118,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001118"
+                ]
+            }
+        },
+        "x1000c3s5b1n1": {
+            "Parent": "x1000c3s5b1",
+            "Xname": "x1000c3s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1119,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001119"
+                ]
+            }
+        },
+        "x1000c3s6b0n0": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1120,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001120"
+                ]
+            }
+        },
+        "x1000c3s6b0n1": {
+            "Parent": "x1000c3s6b0",
+            "Xname": "x1000c3s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1121,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001121"
+                ]
+            }
+        },
+        "x1000c3s6b1n0": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1122,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001122"
+                ]
+            }
+        },
+        "x1000c3s6b1n1": {
+            "Parent": "x1000c3s6b1",
+            "Xname": "x1000c3s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1123,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001123"
+                ]
+            }
+        },
+        "x1000c3s7b0n0": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1124,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001124"
+                ]
+            }
+        },
+        "x1000c3s7b0n1": {
+            "Parent": "x1000c3s7b0",
+            "Xname": "x1000c3s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1125,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001125"
+                ]
+            }
+        },
+        "x1000c3s7b1n0": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1126,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001126"
+                ]
+            }
+        },
+        "x1000c3s7b1n1": {
+            "Parent": "x1000c3s7b1",
+            "Xname": "x1000c3s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1127,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001127"
+                ]
+            }
+        },
+        "x1000c4": {
+            "Parent": "x1000",
+            "Xname": "x1000c4",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c4b0": {
+            "Parent": "x1000c4",
+            "Xname": "x1000c4b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c4s0b0n0": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1128,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001128"
+                ]
+            }
+        },
+        "x1000c4s0b0n1": {
+            "Parent": "x1000c4s0b0",
+            "Xname": "x1000c4s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1129,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001129"
+                ]
+            }
+        },
+        "x1000c4s0b1n0": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1130,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001130"
+                ]
+            }
+        },
+        "x1000c4s0b1n1": {
+            "Parent": "x1000c4s0b1",
+            "Xname": "x1000c4s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1131,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001131"
+                ]
+            }
+        },
+        "x1000c4s1b0n0": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1132,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001132"
+                ]
+            }
+        },
+        "x1000c4s1b0n1": {
+            "Parent": "x1000c4s1b0",
+            "Xname": "x1000c4s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1133,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001133"
+                ]
+            }
+        },
+        "x1000c4s1b1n0": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1134,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001134"
+                ]
+            }
+        },
+        "x1000c4s1b1n1": {
+            "Parent": "x1000c4s1b1",
+            "Xname": "x1000c4s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1135,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001135"
+                ]
+            }
+        },
+        "x1000c4s2b0n0": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1136,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001136"
+                ]
+            }
+        },
+        "x1000c4s2b0n1": {
+            "Parent": "x1000c4s2b0",
+            "Xname": "x1000c4s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1137,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001137"
+                ]
+            }
+        },
+        "x1000c4s2b1n0": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1138,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001138"
+                ]
+            }
+        },
+        "x1000c4s2b1n1": {
+            "Parent": "x1000c4s2b1",
+            "Xname": "x1000c4s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1139,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001139"
+                ]
+            }
+        },
+        "x1000c4s3b0n0": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1140,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001140"
+                ]
+            }
+        },
+        "x1000c4s3b0n1": {
+            "Parent": "x1000c4s3b0",
+            "Xname": "x1000c4s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1141,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001141"
+                ]
+            }
+        },
+        "x1000c4s3b1n0": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1142,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001142"
+                ]
+            }
+        },
+        "x1000c4s3b1n1": {
+            "Parent": "x1000c4s3b1",
+            "Xname": "x1000c4s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1143,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001143"
+                ]
+            }
+        },
+        "x1000c4s4b0n0": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1144,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001144"
+                ]
+            }
+        },
+        "x1000c4s4b0n1": {
+            "Parent": "x1000c4s4b0",
+            "Xname": "x1000c4s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1145,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001145"
+                ]
+            }
+        },
+        "x1000c4s4b1n0": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1146,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001146"
+                ]
+            }
+        },
+        "x1000c4s4b1n1": {
+            "Parent": "x1000c4s4b1",
+            "Xname": "x1000c4s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1147,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001147"
+                ]
+            }
+        },
+        "x1000c4s5b0n0": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1148,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001148"
+                ]
+            }
+        },
+        "x1000c4s5b0n1": {
+            "Parent": "x1000c4s5b0",
+            "Xname": "x1000c4s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1149,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001149"
+                ]
+            }
+        },
+        "x1000c4s5b1n0": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1150,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001150"
+                ]
+            }
+        },
+        "x1000c4s5b1n1": {
+            "Parent": "x1000c4s5b1",
+            "Xname": "x1000c4s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1151,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001151"
+                ]
+            }
+        },
+        "x1000c4s6b0n0": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1152,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001152"
+                ]
+            }
+        },
+        "x1000c4s6b0n1": {
+            "Parent": "x1000c4s6b0",
+            "Xname": "x1000c4s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1153,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001153"
+                ]
+            }
+        },
+        "x1000c4s6b1n0": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1154,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001154"
+                ]
+            }
+        },
+        "x1000c4s6b1n1": {
+            "Parent": "x1000c4s6b1",
+            "Xname": "x1000c4s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1155,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001155"
+                ]
+            }
+        },
+        "x1000c4s7b0n0": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1156,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001156"
+                ]
+            }
+        },
+        "x1000c4s7b0n1": {
+            "Parent": "x1000c4s7b0",
+            "Xname": "x1000c4s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1157,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001157"
+                ]
+            }
+        },
+        "x1000c4s7b1n0": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1158,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001158"
+                ]
+            }
+        },
+        "x1000c4s7b1n1": {
+            "Parent": "x1000c4s7b1",
+            "Xname": "x1000c4s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1159,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001159"
+                ]
+            }
+        },
+        "x1000c5": {
+            "Parent": "x1000",
+            "Xname": "x1000c5",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c5b0": {
+            "Parent": "x1000c5",
+            "Xname": "x1000c5b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c5s0b0n0": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1160,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001160"
+                ]
+            }
+        },
+        "x1000c5s0b0n1": {
+            "Parent": "x1000c5s0b0",
+            "Xname": "x1000c5s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1161,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001161"
+                ]
+            }
+        },
+        "x1000c5s0b1n0": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1162,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001162"
+                ]
+            }
+        },
+        "x1000c5s0b1n1": {
+            "Parent": "x1000c5s0b1",
+            "Xname": "x1000c5s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1163,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001163"
+                ]
+            }
+        },
+        "x1000c5s1b0n0": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1164,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001164"
+                ]
+            }
+        },
+        "x1000c5s1b0n1": {
+            "Parent": "x1000c5s1b0",
+            "Xname": "x1000c5s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1165,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001165"
+                ]
+            }
+        },
+        "x1000c5s1b1n0": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1166,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001166"
+                ]
+            }
+        },
+        "x1000c5s1b1n1": {
+            "Parent": "x1000c5s1b1",
+            "Xname": "x1000c5s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1167,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001167"
+                ]
+            }
+        },
+        "x1000c5s2b0n0": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1168,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001168"
+                ]
+            }
+        },
+        "x1000c5s2b0n1": {
+            "Parent": "x1000c5s2b0",
+            "Xname": "x1000c5s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1169,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001169"
+                ]
+            }
+        },
+        "x1000c5s2b1n0": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1170,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001170"
+                ]
+            }
+        },
+        "x1000c5s2b1n1": {
+            "Parent": "x1000c5s2b1",
+            "Xname": "x1000c5s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1171,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001171"
+                ]
+            }
+        },
+        "x1000c5s3b0n0": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1172,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001172"
+                ]
+            }
+        },
+        "x1000c5s3b0n1": {
+            "Parent": "x1000c5s3b0",
+            "Xname": "x1000c5s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1173,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001173"
+                ]
+            }
+        },
+        "x1000c5s3b1n0": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1174,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001174"
+                ]
+            }
+        },
+        "x1000c5s3b1n1": {
+            "Parent": "x1000c5s3b1",
+            "Xname": "x1000c5s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1175,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001175"
+                ]
+            }
+        },
+        "x1000c5s4b0n0": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1176,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001176"
+                ]
+            }
+        },
+        "x1000c5s4b0n1": {
+            "Parent": "x1000c5s4b0",
+            "Xname": "x1000c5s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1177,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001177"
+                ]
+            }
+        },
+        "x1000c5s4b1n0": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1178,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001178"
+                ]
+            }
+        },
+        "x1000c5s4b1n1": {
+            "Parent": "x1000c5s4b1",
+            "Xname": "x1000c5s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1179,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001179"
+                ]
+            }
+        },
+        "x1000c5s5b0n0": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1180,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001180"
+                ]
+            }
+        },
+        "x1000c5s5b0n1": {
+            "Parent": "x1000c5s5b0",
+            "Xname": "x1000c5s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1181,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001181"
+                ]
+            }
+        },
+        "x1000c5s5b1n0": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1182,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001182"
+                ]
+            }
+        },
+        "x1000c5s5b1n1": {
+            "Parent": "x1000c5s5b1",
+            "Xname": "x1000c5s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1183,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001183"
+                ]
+            }
+        },
+        "x1000c5s6b0n0": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1184,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001184"
+                ]
+            }
+        },
+        "x1000c5s6b0n1": {
+            "Parent": "x1000c5s6b0",
+            "Xname": "x1000c5s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1185,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001185"
+                ]
+            }
+        },
+        "x1000c5s6b1n0": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1186,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001186"
+                ]
+            }
+        },
+        "x1000c5s6b1n1": {
+            "Parent": "x1000c5s6b1",
+            "Xname": "x1000c5s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1187,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001187"
+                ]
+            }
+        },
+        "x1000c5s7b0n0": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1188,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001188"
+                ]
+            }
+        },
+        "x1000c5s7b0n1": {
+            "Parent": "x1000c5s7b0",
+            "Xname": "x1000c5s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1189,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001189"
+                ]
+            }
+        },
+        "x1000c5s7b1n0": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1190,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001190"
+                ]
+            }
+        },
+        "x1000c5s7b1n1": {
+            "Parent": "x1000c5s7b1",
+            "Xname": "x1000c5s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1191,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001191"
+                ]
+            }
+        },
+        "x1000c6": {
+            "Parent": "x1000",
+            "Xname": "x1000c6",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c6b0": {
+            "Parent": "x1000c6",
+            "Xname": "x1000c6b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c6s0b0n0": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1192,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001192"
+                ]
+            }
+        },
+        "x1000c6s0b0n1": {
+            "Parent": "x1000c6s0b0",
+            "Xname": "x1000c6s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1193,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001193"
+                ]
+            }
+        },
+        "x1000c6s0b1n0": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1194,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001194"
+                ]
+            }
+        },
+        "x1000c6s0b1n1": {
+            "Parent": "x1000c6s0b1",
+            "Xname": "x1000c6s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1195,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001195"
+                ]
+            }
+        },
+        "x1000c6s1b0n0": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1196,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001196"
+                ]
+            }
+        },
+        "x1000c6s1b0n1": {
+            "Parent": "x1000c6s1b0",
+            "Xname": "x1000c6s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1197,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001197"
+                ]
+            }
+        },
+        "x1000c6s1b1n0": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1198,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001198"
+                ]
+            }
+        },
+        "x1000c6s1b1n1": {
+            "Parent": "x1000c6s1b1",
+            "Xname": "x1000c6s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1199,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001199"
+                ]
+            }
+        },
+        "x1000c6s2b0n0": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1200,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001200"
+                ]
+            }
+        },
+        "x1000c6s2b0n1": {
+            "Parent": "x1000c6s2b0",
+            "Xname": "x1000c6s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1201,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001201"
+                ]
+            }
+        },
+        "x1000c6s2b1n0": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1202,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001202"
+                ]
+            }
+        },
+        "x1000c6s2b1n1": {
+            "Parent": "x1000c6s2b1",
+            "Xname": "x1000c6s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1203,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001203"
+                ]
+            }
+        },
+        "x1000c6s3b0n0": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1204,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001204"
+                ]
+            }
+        },
+        "x1000c6s3b0n1": {
+            "Parent": "x1000c6s3b0",
+            "Xname": "x1000c6s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1205,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001205"
+                ]
+            }
+        },
+        "x1000c6s3b1n0": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1206,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001206"
+                ]
+            }
+        },
+        "x1000c6s3b1n1": {
+            "Parent": "x1000c6s3b1",
+            "Xname": "x1000c6s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1207,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001207"
+                ]
+            }
+        },
+        "x1000c6s4b0n0": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1208,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001208"
+                ]
+            }
+        },
+        "x1000c6s4b0n1": {
+            "Parent": "x1000c6s4b0",
+            "Xname": "x1000c6s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1209,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001209"
+                ]
+            }
+        },
+        "x1000c6s4b1n0": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1210,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001210"
+                ]
+            }
+        },
+        "x1000c6s4b1n1": {
+            "Parent": "x1000c6s4b1",
+            "Xname": "x1000c6s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1211,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001211"
+                ]
+            }
+        },
+        "x1000c6s5b0n0": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1212,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001212"
+                ]
+            }
+        },
+        "x1000c6s5b0n1": {
+            "Parent": "x1000c6s5b0",
+            "Xname": "x1000c6s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1213,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001213"
+                ]
+            }
+        },
+        "x1000c6s5b1n0": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1214,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001214"
+                ]
+            }
+        },
+        "x1000c6s5b1n1": {
+            "Parent": "x1000c6s5b1",
+            "Xname": "x1000c6s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1215,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001215"
+                ]
+            }
+        },
+        "x1000c6s6b0n0": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1216,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001216"
+                ]
+            }
+        },
+        "x1000c6s6b0n1": {
+            "Parent": "x1000c6s6b0",
+            "Xname": "x1000c6s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1217,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001217"
+                ]
+            }
+        },
+        "x1000c6s6b1n0": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1218,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001218"
+                ]
+            }
+        },
+        "x1000c6s6b1n1": {
+            "Parent": "x1000c6s6b1",
+            "Xname": "x1000c6s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1219,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001219"
+                ]
+            }
+        },
+        "x1000c6s7b0n0": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1220,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001220"
+                ]
+            }
+        },
+        "x1000c6s7b0n1": {
+            "Parent": "x1000c6s7b0",
+            "Xname": "x1000c6s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1221,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001221"
+                ]
+            }
+        },
+        "x1000c6s7b1n0": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1222,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001222"
+                ]
+            }
+        },
+        "x1000c6s7b1n1": {
+            "Parent": "x1000c6s7b1",
+            "Xname": "x1000c6s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1223,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001223"
+                ]
+            }
+        },
+        "x1000c7": {
+            "Parent": "x1000",
+            "Xname": "x1000c7",
+            "Type": "comptype_chassis",
+            "Class": "Mountain",
+            "TypeString": "Chassis"
+        },
+        "x1000c7b0": {
+            "Parent": "x1000c7",
+            "Xname": "x1000c7b0",
+            "Type": "comptype_chassis_bmc",
+            "Class": "Mountain",
+            "TypeString": "ChassisBMC"
+        },
+        "x1000c7s0b0n0": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1224,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001224"
+                ]
+            }
+        },
+        "x1000c7s0b0n1": {
+            "Parent": "x1000c7s0b0",
+            "Xname": "x1000c7s0b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1225,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001225"
+                ]
+            }
+        },
+        "x1000c7s0b1n0": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1226,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001226"
+                ]
+            }
+        },
+        "x1000c7s0b1n1": {
+            "Parent": "x1000c7s0b1",
+            "Xname": "x1000c7s0b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1227,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001227"
+                ]
+            }
+        },
+        "x1000c7s1b0n0": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1228,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001228"
+                ]
+            }
+        },
+        "x1000c7s1b0n1": {
+            "Parent": "x1000c7s1b0",
+            "Xname": "x1000c7s1b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1229,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001229"
+                ]
+            }
+        },
+        "x1000c7s1b1n0": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1230,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001230"
+                ]
+            }
+        },
+        "x1000c7s1b1n1": {
+            "Parent": "x1000c7s1b1",
+            "Xname": "x1000c7s1b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1231,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001231"
+                ]
+            }
+        },
+        "x1000c7s2b0n0": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1232,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001232"
+                ]
+            }
+        },
+        "x1000c7s2b0n1": {
+            "Parent": "x1000c7s2b0",
+            "Xname": "x1000c7s2b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1233,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001233"
+                ]
+            }
+        },
+        "x1000c7s2b1n0": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1234,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001234"
+                ]
+            }
+        },
+        "x1000c7s2b1n1": {
+            "Parent": "x1000c7s2b1",
+            "Xname": "x1000c7s2b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1235,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001235"
+                ]
+            }
+        },
+        "x1000c7s3b0n0": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1236,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001236"
+                ]
+            }
+        },
+        "x1000c7s3b0n1": {
+            "Parent": "x1000c7s3b0",
+            "Xname": "x1000c7s3b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1237,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001237"
+                ]
+            }
+        },
+        "x1000c7s3b1n0": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1238,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001238"
+                ]
+            }
+        },
+        "x1000c7s3b1n1": {
+            "Parent": "x1000c7s3b1",
+            "Xname": "x1000c7s3b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1239,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001239"
+                ]
+            }
+        },
+        "x1000c7s4b0n0": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1240,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001240"
+                ]
+            }
+        },
+        "x1000c7s4b0n1": {
+            "Parent": "x1000c7s4b0",
+            "Xname": "x1000c7s4b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1241,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001241"
+                ]
+            }
+        },
+        "x1000c7s4b1n0": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1242,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001242"
+                ]
+            }
+        },
+        "x1000c7s4b1n1": {
+            "Parent": "x1000c7s4b1",
+            "Xname": "x1000c7s4b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1243,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001243"
+                ]
+            }
+        },
+        "x1000c7s5b0n0": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1244,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001244"
+                ]
+            }
+        },
+        "x1000c7s5b0n1": {
+            "Parent": "x1000c7s5b0",
+            "Xname": "x1000c7s5b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1245,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001245"
+                ]
+            }
+        },
+        "x1000c7s5b1n0": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1246,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001246"
+                ]
+            }
+        },
+        "x1000c7s5b1n1": {
+            "Parent": "x1000c7s5b1",
+            "Xname": "x1000c7s5b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1247,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001247"
+                ]
+            }
+        },
+        "x1000c7s6b0n0": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1248,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001248"
+                ]
+            }
+        },
+        "x1000c7s6b0n1": {
+            "Parent": "x1000c7s6b0",
+            "Xname": "x1000c7s6b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1249,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001249"
+                ]
+            }
+        },
+        "x1000c7s6b1n0": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1250,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001250"
+                ]
+            }
+        },
+        "x1000c7s6b1n1": {
+            "Parent": "x1000c7s6b1",
+            "Xname": "x1000c7s6b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1251,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001251"
+                ]
+            }
+        },
+        "x1000c7s7b0n0": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1252,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001252"
+                ]
+            }
+        },
+        "x1000c7s7b0n1": {
+            "Parent": "x1000c7s7b0",
+            "Xname": "x1000c7s7b0n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1253,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001253"
+                ]
+            }
+        },
+        "x1000c7s7b1n0": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n0",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1254,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001254"
+                ]
+            }
+        },
+        "x1000c7s7b1n1": {
+            "Parent": "x1000c7s7b1",
+            "Xname": "x1000c7s7b1n1",
+            "Type": "comptype_node",
+            "Class": "Mountain",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 1255,
+                "Role": "Compute",
+                "Aliases": [
+                    "nid001255"
+                ]
+            }
+        },
+        "x3000": {
+            "Parent": "s0",
+            "Xname": "x3000",
+            "Type": "comptype_cabinet",
+            "Class": "River",
+            "TypeString": "Cabinet",
+            "ExtraProperties": {
+                "Networks": {
+                    "cn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    },
+                    "ncn": {
+                        "HMN": {
+                            "CIDR": "10.107.0.0/22",
+                            "Gateway": "10.107.0.1",
+                            "VLan": 1513
+                        },
+                        "NMN": {
+                            "CIDR": "10.106.0.0/22",
+                            "Gateway": "10.106.0.1",
+                            "VLan": 1770
+                        }
+                    }
+                }
+            }
+        },
+        "x3000c0h33s1": {
+            "Parent": "x3000c0h33",
+            "Xname": "x3000c0h33s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.4",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-001"
+                ]
+            }
+        },
+        "x3000c0h34s1": {
+            "Parent": "x3000c0h34",
+            "Xname": "x3000c0h34s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.5",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-002"
+                ]
+            }
+        },
+        "x3000c0h35s1": {
+            "Parent": "x3000c0h35",
+            "Xname": "x3000c0h35s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.6",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-003"
+                ]
+            }
+        },
+        "x3000c0h36s1": {
+            "Parent": "x3000c0h36",
+            "Xname": "x3000c0h36s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.7",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-leaf-004"
+                ]
+            }
+        },
+        "x3000c0h37s1": {
+            "Parent": "x3000c0h37",
+            "Xname": "x3000c0h37s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.2",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-001"
+                ]
+            }
+        },
+        "x3000c0h38s1": {
+            "Parent": "x3000c0h38",
+            "Xname": "x3000c0h38s1",
+            "Type": "comptype_hl_switch",
+            "Class": "River",
+            "TypeString": "MgmtHLSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.3",
+                "Brand": "Aruba",
+                "Aliases": [
+                    "sw-spine-002"
+                ]
+            }
+        },
+        "x3000c0r39b0": {
+            "Parent": "x3000c0r39",
+            "Xname": "x3000c0r39b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r39b0",
+                "Password": "vault://hms-creds/x3000c0r39b0"
+            }
+        },
+        "x3000c0r40b0": {
+            "Parent": "x3000c0r40",
+            "Xname": "x3000c0r40b0",
+            "Type": "comptype_rtr_bmc",
+            "Class": "River",
+            "TypeString": "RouterBMC",
+            "ExtraProperties": {
+                "Username": "vault://hms-creds/x3000c0r40b0",
+                "Password": "vault://hms-creds/x3000c0r40b0"
+            }
+        },
+        "x3000c0s10b0n0": {
+            "Parent": "x3000c0s10b0",
+            "Xname": "x3000c0s10b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100001,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s003"
+                ]
+            }
+        },
+        "x3000c0s15b0n0": {
+            "Parent": "x3000c0s15b0",
+            "Xname": "x3000c0s15b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan01"
+                ]
+            }
+        },
+        "x3000c0s16b0n0": {
+            "Parent": "x3000c0s16b0",
+            "Xname": "x3000c0s16b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "Role": "Application",
+                "SubRole": "UAN",
+                "Aliases": [
+                    "uan02"
+                ]
+            }
+        },
+        "x3000c0s1b0n0": {
+            "Parent": "x3000c0s1b0",
+            "Xname": "x3000c0s1b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100010,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m001"
+                ]
+            }
+        },
+        "x3000c0s2b0n0": {
+            "Parent": "x3000c0s2b0",
+            "Xname": "x3000c0s2b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100009,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m002"
+                ]
+            }
+        },
+        "x3000c0s3b0n0": {
+            "Parent": "x3000c0s3b0",
+            "Xname": "x3000c0s3b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100008,
+                "Role": "Management",
+                "SubRole": "Master",
+                "Aliases": [
+                    "ncn-m003"
+                ]
+            }
+        },
+        "x3000c0s4b0n0": {
+            "Parent": "x3000c0s4b0",
+            "Xname": "x3000c0s4b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100007,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w001"
+                ]
+            }
+        },
+        "x3000c0s5b0n0": {
+            "Parent": "x3000c0s5b0",
+            "Xname": "x3000c0s5b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100006,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w002"
+                ]
+            }
+        },
+        "x3000c0s6b0n0": {
+            "Parent": "x3000c0s6b0",
+            "Xname": "x3000c0s6b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100005,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w003"
+                ]
+            }
+        },
+        "x3000c0s7b0n0": {
+            "Parent": "x3000c0s7b0",
+            "Xname": "x3000c0s7b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100004,
+                "Role": "Management",
+                "SubRole": "Worker",
+                "Aliases": [
+                    "ncn-w004"
+                ]
+            }
+        },
+        "x3000c0s8b0n0": {
+            "Parent": "x3000c0s8b0",
+            "Xname": "x3000c0s8b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100003,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s001"
+                ]
+            }
+        },
+        "x3000c0s9b0n0": {
+            "Parent": "x3000c0s9b0",
+            "Xname": "x3000c0s9b0n0",
+            "Type": "comptype_node",
+            "Class": "River",
+            "TypeString": "Node",
+            "ExtraProperties": {
+                "NID": 100002,
+                "Role": "Management",
+                "SubRole": "Storage",
+                "Aliases": [
+                    "ncn-s002"
+                ]
+            }
+        },
+        "x3000c0w31": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w31",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.8",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w31",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-001"
+                ]
+            }
+        },
+        "x3000c0w31j34": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j34",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s2b0"
+                ],
+                "VendorName": "1/1/34"
+            }
+        },
+        "x3000c0w31j35": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j35",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s4b0"
+                ],
+                "VendorName": "1/1/35"
+            }
+        },
+        "x3000c0w31j36": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s5b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w31j37": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s6b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w31j38": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s8b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w31j39": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j39",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s9b0"
+                ],
+                "VendorName": "1/1/39"
+            }
+        },
+        "x3000c0w31j40": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j40",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s15b0"
+                ],
+                "VendorName": "1/1/40"
+            }
+        },
+        "x3000c0w31j41": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j41",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s16b0"
+                ],
+                "VendorName": "1/1/41"
+            }
+        },
+        "x3000c0w31j47": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r39b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w31j48": {
+            "Parent": "x3000c0w31",
+            "Xname": "x3000c0w31j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m0"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000c0w32": {
+            "Parent": "x3000c0",
+            "Xname": "x3000c0w32",
+            "Type": "comptype_mgmt_switch",
+            "Class": "River",
+            "TypeString": "MgmtSwitch",
+            "ExtraProperties": {
+                "IP4addr": "10.254.0.9",
+                "Brand": "Aruba",
+                "SNMPAuthPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPAuthProtocol": "MD5",
+                "SNMPPrivPassword": "vault://hms-creds/x3000c0w32",
+                "SNMPPrivProtocol": "DES",
+                "SNMPUsername": "testuser",
+                "Aliases": [
+                    "sw-leaf-bmc-002"
+                ]
+            }
+        },
+        "x3000c0w32j36": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j36",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s3b0"
+                ],
+                "VendorName": "1/1/36"
+            }
+        },
+        "x3000c0w32j37": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j37",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s7b0"
+                ],
+                "VendorName": "1/1/37"
+            }
+        },
+        "x3000c0w32j38": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j38",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0s10b0"
+                ],
+                "VendorName": "1/1/38"
+            }
+        },
+        "x3000c0w32j47": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j47",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000c0r40b0"
+                ],
+                "VendorName": "1/1/47"
+            }
+        },
+        "x3000c0w32j48": {
+            "Parent": "x3000c0w32",
+            "Xname": "x3000c0w32j48",
+            "Type": "comptype_mgmt_switch_connector",
+            "Class": "River",
+            "TypeString": "MgmtSwitchConnector",
+            "ExtraProperties": {
+                "NodeNics": [
+                    "x3000m1"
+                ],
+                "VendorName": "1/1/48"
+            }
+        },
+        "x3000m0": {
+            "Parent": "x3000",
+            "Xname": "x3000m0",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        },
+        "x3000m1": {
+            "Parent": "x3000",
+            "Xname": "x3000m1",
+            "Type": "comptype_cab_pdu_controller",
+            "Class": "River",
+            "TypeString": "CabinetPDUController"
+        }
+    },
+    "Networks": {
+        "BICAN": {
+            "Name": "BICAN",
+            "FullName": "SystemDefaultRoute points the network name of the default route",
+            "IPRanges": [
+                "0.0.0.0/0"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "0.0.0.0/0",
+                "VlanRange": [
+                    0
+                ],
+                "MTU": 9000,
+                "Subnets": [],
+                "SystemDefaultRoute": "CHN"
+            }
+        },
+        "CHN": {
+            "Name": "CHN",
+            "FullName": "Customer High-Speed Network",
+            "IPRanges": [
+                "10.102.66.128/25"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.102.66.128/25",
+                "VlanRange": [
+                    5
+                ],
+                "MTU": 9000,
+                "PeerASN": 65533,
+                "MyASN": 65530,
+                "Subnets": [
+                    {
+                        "FullName": "CHN Dynamic MetalLB",
+                        "CIDR": "10.102.66.192/26",
+                        "Name": "chn_metallb_address_pool",
+                        "VlanID": 0,
+                        "Gateway": "10.102.66.193",
+                        "MetalLBPoolName": "customer-high-speed"
+                    },
+                    {
+                        "FullName": "CHN Bootstrap DHCP Subnet",
+                        "CIDR": "10.102.66.128/25",
+                        "IPReservations": [
+                            {
+                                "Name": "chn-switch-1",
+                                "IPAddress": "10.102.66.130",
+                                "Comment": "x3000c0h18s1"
+                            },
+                            {
+                                "Name": "chn-switch-2",
+                                "IPAddress": "10.102.66.131",
+                                "Comment": "x3000c0h19s1"
+                            },
+                            {
+                                "Name": "ncn-s003",
+                                "IPAddress": "10.102.66.132",
+                                "Aliases": [
+                                    "ncn-s003-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s10b0n0"
+                            },
+                            {
+                                "Name": "ncn-s002",
+                                "IPAddress": "10.102.66.133",
+                                "Aliases": [
+                                    "ncn-s002-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s9b0n0"
+                            },
+                            {
+                                "Name": "ncn-s001",
+                                "IPAddress": "10.102.66.134",
+                                "Aliases": [
+                                    "ncn-s001-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s8b0n0"
+                            },
+                            {
+                                "Name": "ncn-w004",
+                                "IPAddress": "10.102.66.135",
+                                "Aliases": [
+                                    "ncn-w004-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s7b0n0"
+                            },
+                            {
+                                "Name": "ncn-w003",
+                                "IPAddress": "10.102.66.136",
+                                "Aliases": [
+                                    "ncn-w003-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s6b0n0"
+                            },
+                            {
+                                "Name": "ncn-w002",
+                                "IPAddress": "10.102.66.137",
+                                "Aliases": [
+                                    "ncn-w002-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s5b0n0"
+                            },
+                            {
+                                "Name": "ncn-w001",
+                                "IPAddress": "10.102.66.138",
+                                "Aliases": [
+                                    "ncn-w001-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s4b0n0"
+                            },
+                            {
+                                "Name": "ncn-m003",
+                                "IPAddress": "10.102.66.139",
+                                "Aliases": [
+                                    "ncn-m003-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s3b0n0"
+                            },
+                            {
+                                "Name": "ncn-m002",
+                                "IPAddress": "10.102.66.140",
+                                "Aliases": [
+                                    "ncn-m002-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s2b0n0"
+                            },
+                            {
+                                "Name": "ncn-m001",
+                                "IPAddress": "10.102.66.141",
+                                "Aliases": [
+                                    "ncn-m001-chn",
+                                    "time-chn",
+                                    "time-chn.local"
+                                ],
+                                "Comment": "x3000c0s1b0n0"
+                            },
+                            {
+                                "Name": "uan01",
+                                "IPAddress": "10.102.66.142",
+                                "Comment": "x3000c0s15b0n0"
+                            },
+                            {
+                                "Name": "uan02",
+                                "IPAddress": "10.102.66.143",
+                                "Comment": "x3000c0s16b0n0"
+                            }
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 5,
+                        "Gateway": "10.102.66.129",
+                        "DHCPStart": "10.102.66.144",
+                        "DHCPEnd": "10.102.66.191"
+                    }
+                ]
+            }
+        },
+        "CMN": {
+            "Name": "CMN",
+            "FullName": "Customer Management Network",
+            "IPRanges": [
+                "10.102.66.0/25"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.102.66.0/25",
+                "VlanRange": [
+                    7
+                ],
+                "MTU": 9000,
+                "PeerASN": 65533,
+                "MyASN": 65532,
+                "Subnets": [
+                    {
+                        "FullName": "CMN Static Pool MetalLB",
+                        "CIDR": "10.102.66.60/30",
+                        "IPReservations": [
+                            {
+                                "Name": "external-dns",
+                                "IPAddress": "10.102.66.61",
+                                "Comment": "site to system lookups"
+                            }
+                        ],
+                        "Name": "cmn_metallb_static_pool",
+                        "VlanID": 7,
+                        "Gateway": "10.102.66.61",
+                        "MetalLBPoolName": "customer-management-static"
+                    },
+                    {
+                        "FullName": "CMN Dynamic MetalLB",
+                        "CIDR": "10.102.66.64/26",
+                        "Name": "cmn_metallb_address_pool",
+                        "VlanID": 7,
+                        "Gateway": "10.102.66.65",
+                        "MetalLBPoolName": "customer-management"
+                    },
+                    {
+                        "FullName": "CMN Management Network Infrastructure",
+                        "CIDR": "10.102.66.0/25",
+                        "IPReservations": [
+                            {
+                                "Name": "sw-spine-001",
+                                "IPAddress": "10.102.66.2",
+                                "Comment": "x3000c0h37s1"
+                            },
+                            {
+                                "Name": "sw-spine-002",
+                                "IPAddress": "10.102.66.3",
+                                "Comment": "x3000c0h38s1"
+                            },
+                            {
+                                "Name": "sw-leaf-001",
+                                "IPAddress": "10.102.66.4",
+                                "Comment": "x3000c0h33s1"
+                            },
+                            {
+                                "Name": "sw-leaf-002",
+                                "IPAddress": "10.102.66.5",
+                                "Comment": "x3000c0h34s1"
+                            },
+                            {
+                                "Name": "sw-leaf-003",
+                                "IPAddress": "10.102.66.6",
+                                "Comment": "x3000c0h35s1"
+                            },
+                            {
+                                "Name": "sw-leaf-004",
+                                "IPAddress": "10.102.66.7",
+                                "Comment": "x3000c0h36s1"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-001",
+                                "IPAddress": "10.102.66.8",
+                                "Comment": "x3000c0w31"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-002",
+                                "IPAddress": "10.102.66.9",
+                                "Comment": "x3000c0w32"
+                            },
+                            {
+                                "Name": "sw-cdu-001",
+                                "IPAddress": "10.102.66.10",
+                                "Comment": "d0w1"
+                            },
+                            {
+                                "Name": "sw-cdu-002",
+                                "IPAddress": "10.102.66.11",
+                                "Comment": "d0w2"
+                            }
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 7,
+                        "Gateway": "10.102.66.1"
+                    },
+                    {
+                        "FullName": "CMN Bootstrap DHCP Subnet",
+                        "CIDR": "10.102.66.32/25",
+                        "IPReservations": [
+                            {
+                                "Name": "ncn-s003",
+                                "IPAddress": "10.102.66.32",
+                                "Aliases": [
+                                    "ncn-s003-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s10b0n0"
+                            },
+                            {
+                                "Name": "ncn-s002",
+                                "IPAddress": "10.102.66.33",
+                                "Aliases": [
+                                    "ncn-s002-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s9b0n0"
+                            },
+                            {
+                                "Name": "ncn-s001",
+                                "IPAddress": "10.102.66.34",
+                                "Aliases": [
+                                    "ncn-s001-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s8b0n0"
+                            },
+                            {
+                                "Name": "ncn-w004",
+                                "IPAddress": "10.102.66.35",
+                                "Aliases": [
+                                    "ncn-w004-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s7b0n0"
+                            },
+                            {
+                                "Name": "ncn-w003",
+                                "IPAddress": "10.102.66.36",
+                                "Aliases": [
+                                    "ncn-w003-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s6b0n0"
+                            },
+                            {
+                                "Name": "ncn-w002",
+                                "IPAddress": "10.102.66.37",
+                                "Aliases": [
+                                    "ncn-w002-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s5b0n0"
+                            },
+                            {
+                                "Name": "ncn-w001",
+                                "IPAddress": "10.102.66.38",
+                                "Aliases": [
+                                    "ncn-w001-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s4b0n0"
+                            },
+                            {
+                                "Name": "ncn-m003",
+                                "IPAddress": "10.102.66.39",
+                                "Aliases": [
+                                    "ncn-m003-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s3b0n0"
+                            },
+                            {
+                                "Name": "ncn-m002",
+                                "IPAddress": "10.102.66.40",
+                                "Aliases": [
+                                    "ncn-m002-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s2b0n0"
+                            },
+                            {
+                                "Name": "ncn-m001",
+                                "IPAddress": "10.102.66.41",
+                                "Aliases": [
+                                    "ncn-m001-cmn",
+                                    "time-cmn",
+                                    "time-cmn.local"
+                                ],
+                                "Comment": "x3000c0s1b0n0"
+                            }
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 7,
+                        "Gateway": "10.102.66.1",
+                        "DHCPStart": "10.102.66.44",
+                        "DHCPEnd": "10.102.66.59"
+                    }
+                ]
+            }
+        },
+        "HMN": {
+            "Name": "HMN",
+            "FullName": "Hardware Management Network",
+            "IPRanges": [
+                "10.254.0.0/17"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.254.0.0/17",
+                "VlanRange": [
+                    4
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "HMN Management Network Infrastructure",
+                        "CIDR": "10.254.0.0/17",
+                        "IPReservations": [
+                            {
+                                "Name": "sw-spine-001",
+                                "IPAddress": "10.254.0.2",
+                                "Comment": "x3000c0h37s1"
+                            },
+                            {
+                                "Name": "sw-spine-002",
+                                "IPAddress": "10.254.0.3",
+                                "Comment": "x3000c0h38s1"
+                            },
+                            {
+                                "Name": "sw-leaf-001",
+                                "IPAddress": "10.254.0.4",
+                                "Comment": "x3000c0h33s1"
+                            },
+                            {
+                                "Name": "sw-leaf-002",
+                                "IPAddress": "10.254.0.5",
+                                "Comment": "x3000c0h34s1"
+                            },
+                            {
+                                "Name": "sw-leaf-003",
+                                "IPAddress": "10.254.0.6",
+                                "Comment": "x3000c0h35s1"
+                            },
+                            {
+                                "Name": "sw-leaf-004",
+                                "IPAddress": "10.254.0.7",
+                                "Comment": "x3000c0h36s1"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-001",
+                                "IPAddress": "10.254.0.8",
+                                "Comment": "x3000c0w31"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-002",
+                                "IPAddress": "10.254.0.9",
+                                "Comment": "x3000c0w32"
+                            },
+                            {
+                                "Name": "sw-cdu-001",
+                                "IPAddress": "10.254.0.10",
+                                "Comment": "d0w1"
+                            },
+                            {
+                                "Name": "sw-cdu-002",
+                                "IPAddress": "10.254.0.11",
+                                "Comment": "d0w2"
+                            }
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 4,
+                        "Gateway": "10.254.0.1"
+                    },
+                    {
+                        "FullName": "HMN Bootstrap DHCP Subnet",
+                        "CIDR": "10.254.1.0/17",
+                        "IPReservations": [
+                            {
+                                "Name": "x3000c0s10b0",
+                                "IPAddress": "10.254.1.0",
+                                "Aliases": [
+                                    "ncn-s003-mgmt"
+                                ],
+                                "Comment": "x3000c0s10b0"
+                            },
+                            {
+                                "Name": "ncn-s003",
+                                "IPAddress": "10.254.1.1",
+                                "Aliases": [
+                                    "ncn-s003-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local",
+                                    "rgw-vip.hmn"
+                                ],
+                                "Comment": "x3000c0s10b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s9b0",
+                                "IPAddress": "10.254.1.2",
+                                "Aliases": [
+                                    "ncn-s002-mgmt"
+                                ],
+                                "Comment": "x3000c0s9b0"
+                            },
+                            {
+                                "Name": "ncn-s002",
+                                "IPAddress": "10.254.1.3",
+                                "Aliases": [
+                                    "ncn-s002-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local",
+                                    "rgw-vip.hmn"
+                                ],
+                                "Comment": "x3000c0s9b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s8b0",
+                                "IPAddress": "10.254.1.4",
+                                "Aliases": [
+                                    "ncn-s001-mgmt"
+                                ],
+                                "Comment": "x3000c0s8b0"
+                            },
+                            {
+                                "Name": "ncn-s001",
+                                "IPAddress": "10.254.1.5",
+                                "Aliases": [
+                                    "ncn-s001-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local",
+                                    "rgw-vip.hmn"
+                                ],
+                                "Comment": "x3000c0s8b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s7b0",
+                                "IPAddress": "10.254.1.6",
+                                "Aliases": [
+                                    "ncn-w004-mgmt"
+                                ],
+                                "Comment": "x3000c0s7b0"
+                            },
+                            {
+                                "Name": "ncn-w004",
+                                "IPAddress": "10.254.1.7",
+                                "Aliases": [
+                                    "ncn-w004-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s7b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s6b0",
+                                "IPAddress": "10.254.1.8",
+                                "Aliases": [
+                                    "ncn-w003-mgmt"
+                                ],
+                                "Comment": "x3000c0s6b0"
+                            },
+                            {
+                                "Name": "ncn-w003",
+                                "IPAddress": "10.254.1.9",
+                                "Aliases": [
+                                    "ncn-w003-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s6b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s5b0",
+                                "IPAddress": "10.254.1.10",
+                                "Aliases": [
+                                    "ncn-w002-mgmt"
+                                ],
+                                "Comment": "x3000c0s5b0"
+                            },
+                            {
+                                "Name": "ncn-w002",
+                                "IPAddress": "10.254.1.11",
+                                "Aliases": [
+                                    "ncn-w002-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s5b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s4b0",
+                                "IPAddress": "10.254.1.12",
+                                "Aliases": [
+                                    "ncn-w001-mgmt"
+                                ],
+                                "Comment": "x3000c0s4b0"
+                            },
+                            {
+                                "Name": "ncn-w001",
+                                "IPAddress": "10.254.1.13",
+                                "Aliases": [
+                                    "ncn-w001-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s4b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s3b0",
+                                "IPAddress": "10.254.1.14",
+                                "Aliases": [
+                                    "ncn-m003-mgmt"
+                                ],
+                                "Comment": "x3000c0s3b0"
+                            },
+                            {
+                                "Name": "ncn-m003",
+                                "IPAddress": "10.254.1.15",
+                                "Aliases": [
+                                    "ncn-m003-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s3b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s2b0",
+                                "IPAddress": "10.254.1.16",
+                                "Aliases": [
+                                    "ncn-m002-mgmt"
+                                ],
+                                "Comment": "x3000c0s2b0"
+                            },
+                            {
+                                "Name": "ncn-m002",
+                                "IPAddress": "10.254.1.17",
+                                "Aliases": [
+                                    "ncn-m002-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s2b0n0"
+                            },
+                            {
+                                "Name": "x3000c0s1b0",
+                                "IPAddress": "10.254.1.18",
+                                "Aliases": [
+                                    "ncn-m001-mgmt"
+                                ],
+                                "Comment": "x3000c0s1b0"
+                            },
+                            {
+                                "Name": "ncn-m001",
+                                "IPAddress": "10.254.1.19",
+                                "Aliases": [
+                                    "ncn-m001-hmn",
+                                    "time-hmn",
+                                    "time-hmn.local"
+                                ],
+                                "Comment": "x3000c0s1b0n0"
+                            }
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 4,
+                        "Gateway": "10.254.0.1",
+                        "DHCPStart": "10.254.1.22",
+                        "DHCPEnd": "10.254.1.222"
+                    }
+                ]
+            }
+        },
+        "HMNLB": {
+            "Name": "HMNLB",
+            "FullName": "Hardware Management Network LoadBalancers",
+            "IPRanges": [
+                "10.94.100.0/24"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.94.100.0/24",
+                "VlanRange": null,
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "HMN MetalLB",
+                        "CIDR": "10.94.100.0/24",
+                        "IPReservations": [
+                            {
+                                "Name": "cray-tftp",
+                                "IPAddress": "10.94.100.60",
+                                "Aliases": [
+                                    "tftp-service"
+                                ],
+                                "Comment": "tftp-service"
+                            },
+                            {
+                                "Name": "unbound",
+                                "IPAddress": "10.94.100.225",
+                                "Aliases": [
+                                    "unbound"
+                                ],
+                                "Comment": "unbound"
+                            },
+                            {
+                                "Name": "docker-registry",
+                                "IPAddress": "10.94.100.73",
+                                "Aliases": [
+                                    "docker_registry_service"
+                                ],
+                                "Comment": "docker_registry_service"
+                            },
+                            {
+                                "Name": "istio-ingressgateway",
+                                "IPAddress": "10.94.100.71"
+                            },
+                            {
+                                "Name": "rsyslog-aggregator",
+                                "IPAddress": "10.94.100.72",
+                                "Aliases": [
+                                    "rsyslog-agg-service"
+                                ],
+                                "Comment": "rsyslog-agg-service"
+                            }
+                        ],
+                        "Name": "hmn_metallb_address_pool",
+                        "VlanID": 4,
+                        "Gateway": "10.94.100.1",
+                        "MetalLBPoolName": "hardware-management"
+                    }
+                ]
+            }
+        },
+        "HMN_MTN": {
+            "Name": "HMN_MTN",
+            "FullName": "Mountain Compute Hardware Management Network",
+            "IPRanges": [
+                "10.104.0.0/17"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.104.0.0/17",
+                "VlanRange": [
+                    4095,
+                    0
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "10.104.0.0/22",
+                        "Name": "cabinet_1000",
+                        "VlanID": 3000,
+                        "Gateway": "10.104.0.1",
+                        "DHCPStart": "10.104.0.10",
+                        "DHCPEnd": "10.104.3.254"
+                    }
+                ]
+            }
+        },
+        "HMN_RVR": {
+            "Name": "HMN_RVR",
+            "FullName": "River Compute Hardware Management Network",
+            "IPRanges": [
+                "10.107.0.0/17"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.107.0.0/17",
+                "VlanRange": [
+                    1513,
+                    1513
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "10.107.0.0/22",
+                        "Name": "cabinet_3000",
+                        "VlanID": 1513,
+                        "Gateway": "10.107.0.1",
+                        "DHCPStart": "10.107.0.10",
+                        "DHCPEnd": "10.107.3.254"
+                    }
+                ]
+            }
+        },
+        "HSN": {
+            "Name": "HSN",
+            "FullName": "High Speed Network",
+            "IPRanges": [
+                "10.253.0.0/16"
+            ],
+            "Type": "slingshot10",
+            "ExtraProperties": {
+                "CIDR": "10.253.0.0/16",
+                "VlanRange": [
+                    613,
+                    868
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "HSN Base Subnet",
+                        "CIDR": "10.253.0.0/16",
+                        "Name": "hsn_base_subnet",
+                        "VlanID": 613,
+                        "Gateway": "10.253.0.1"
+                    }
+                ]
+            }
+        },
+        "MTL": {
+            "Name": "MTL",
+            "FullName": "Provisioning Network (untagged)",
+            "IPRanges": [
+                "10.1.1.0/16"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.1.1.0/16",
+                "VlanRange": [
+                    1
+                ],
+                "MTU": 9000,
+                "Comment": "This network is only valid for the NCNs",
+                "Subnets": [
+                    {
+                        "FullName": "MTL Management Network Infrastructure",
+                        "CIDR": "10.1.0.0/16",
+                        "IPReservations": [
+                            {
+                                "Name": "sw-spine-001",
+                                "IPAddress": "10.1.0.2",
+                                "Comment": "x3000c0h37s1"
+                            },
+                            {
+                                "Name": "sw-spine-002",
+                                "IPAddress": "10.1.0.3",
+                                "Comment": "x3000c0h38s1"
+                            },
+                            {
+                                "Name": "sw-leaf-001",
+                                "IPAddress": "10.1.0.4",
+                                "Comment": "x3000c0h33s1"
+                            },
+                            {
+                                "Name": "sw-leaf-002",
+                                "IPAddress": "10.1.0.5",
+                                "Comment": "x3000c0h34s1"
+                            },
+                            {
+                                "Name": "sw-leaf-003",
+                                "IPAddress": "10.1.0.6",
+                                "Comment": "x3000c0h35s1"
+                            },
+                            {
+                                "Name": "sw-leaf-004",
+                                "IPAddress": "10.1.0.7",
+                                "Comment": "x3000c0h36s1"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-001",
+                                "IPAddress": "10.1.0.8",
+                                "Comment": "x3000c0w31"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-002",
+                                "IPAddress": "10.1.0.9",
+                                "Comment": "x3000c0w32"
+                            },
+                            {
+                                "Name": "sw-cdu-001",
+                                "IPAddress": "10.1.0.10",
+                                "Comment": "d0w1"
+                            },
+                            {
+                                "Name": "sw-cdu-002",
+                                "IPAddress": "10.1.0.11",
+                                "Comment": "d0w2"
+                            }
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 1,
+                        "Gateway": "10.1.0.1"
+                    },
+                    {
+                        "FullName": "MTL Bootstrap DHCP Subnet",
+                        "CIDR": "10.1.1.0/16",
+                        "IPReservations": [
+                            {
+                                "Name": "ncn-s003",
+                                "IPAddress": "10.1.1.0",
+                                "Aliases": [
+                                    "ncn-s003-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s10b0n0"
+                            },
+                            {
+                                "Name": "ncn-s002",
+                                "IPAddress": "10.1.1.1",
+                                "Aliases": [
+                                    "ncn-s002-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s9b0n0"
+                            },
+                            {
+                                "Name": "ncn-s001",
+                                "IPAddress": "10.1.1.2",
+                                "Aliases": [
+                                    "ncn-s001-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s8b0n0"
+                            },
+                            {
+                                "Name": "ncn-w004",
+                                "IPAddress": "10.1.1.3",
+                                "Aliases": [
+                                    "ncn-w004-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s7b0n0"
+                            },
+                            {
+                                "Name": "ncn-w003",
+                                "IPAddress": "10.1.1.4",
+                                "Aliases": [
+                                    "ncn-w003-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s6b0n0"
+                            },
+                            {
+                                "Name": "ncn-w002",
+                                "IPAddress": "10.1.1.5",
+                                "Aliases": [
+                                    "ncn-w002-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s5b0n0"
+                            },
+                            {
+                                "Name": "ncn-w001",
+                                "IPAddress": "10.1.1.6",
+                                "Aliases": [
+                                    "ncn-w001-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s4b0n0"
+                            },
+                            {
+                                "Name": "ncn-m003",
+                                "IPAddress": "10.1.1.7",
+                                "Aliases": [
+                                    "ncn-m003-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s3b0n0"
+                            },
+                            {
+                                "Name": "ncn-m002",
+                                "IPAddress": "10.1.1.8",
+                                "Aliases": [
+                                    "ncn-m002-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s2b0n0"
+                            },
+                            {
+                                "Name": "ncn-m001",
+                                "IPAddress": "10.1.1.9",
+                                "Aliases": [
+                                    "ncn-m001-mtl",
+                                    "time-mtl",
+                                    "time-mtl.local"
+                                ],
+                                "Comment": "x3000c0s1b0n0"
+                            }
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 1,
+                        "Gateway": "10.1.0.1",
+                        "DHCPStart": "10.1.1.12",
+                        "DHCPEnd": "10.1.1.212"
+                    }
+                ]
+            }
+        },
+        "NMN": {
+            "Name": "NMN",
+            "FullName": "Node Management Network",
+            "IPRanges": [
+                "10.252.0.0/17"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.252.0.0/17",
+                "VlanRange": [
+                    2
+                ],
+                "MTU": 9000,
+                "PeerASN": 65533,
+                "MyASN": 65533,
+                "Subnets": [
+                    {
+                        "FullName": "NMN Management Network Infrastructure",
+                        "CIDR": "10.252.0.0/17",
+                        "IPReservations": [
+                            {
+                                "Name": "sw-spine-001",
+                                "IPAddress": "10.252.0.2",
+                                "Comment": "x3000c0h37s1"
+                            },
+                            {
+                                "Name": "sw-spine-002",
+                                "IPAddress": "10.252.0.3",
+                                "Comment": "x3000c0h38s1"
+                            },
+                            {
+                                "Name": "sw-leaf-001",
+                                "IPAddress": "10.252.0.4",
+                                "Comment": "x3000c0h33s1"
+                            },
+                            {
+                                "Name": "sw-leaf-002",
+                                "IPAddress": "10.252.0.5",
+                                "Comment": "x3000c0h34s1"
+                            },
+                            {
+                                "Name": "sw-leaf-003",
+                                "IPAddress": "10.252.0.6",
+                                "Comment": "x3000c0h35s1"
+                            },
+                            {
+                                "Name": "sw-leaf-004",
+                                "IPAddress": "10.252.0.7",
+                                "Comment": "x3000c0h36s1"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-001",
+                                "IPAddress": "10.252.0.8",
+                                "Comment": "x3000c0w31"
+                            },
+                            {
+                                "Name": "sw-leaf-bmc-002",
+                                "IPAddress": "10.252.0.9",
+                                "Comment": "x3000c0w32"
+                            },
+                            {
+                                "Name": "sw-cdu-001",
+                                "IPAddress": "10.252.0.10",
+                                "Comment": "d0w1"
+                            },
+                            {
+                                "Name": "sw-cdu-002",
+                                "IPAddress": "10.252.0.11",
+                                "Comment": "d0w2"
+                            }
+                        ],
+                        "Name": "network_hardware",
+                        "VlanID": 2,
+                        "Gateway": "10.252.0.1"
+                    },
+                    {
+                        "FullName": "NMN Bootstrap DHCP Subnet",
+                        "CIDR": "10.252.1.0/17",
+                        "IPReservations": [
+                            {
+                                "Name": "rgw-vip",
+                                "IPAddress": "10.252.1.2",
+                                "Aliases": [
+                                    "rgw-vip.local"
+                                ],
+                                "Comment": "rgw-virtual-ip"
+                            },
+                            {
+                                "Name": "kubeapi-vip",
+                                "IPAddress": "10.252.1.3",
+                                "Aliases": [
+                                    "kubeapi-vip.local"
+                                ],
+                                "Comment": "k8s-virtual-ip"
+                            },
+                            {
+                                "Name": "ncn-s003",
+                                "IPAddress": "10.252.1.0",
+                                "Aliases": [
+                                    "ncn-s003-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s10b0n0",
+                                    "ncn-s003.local"
+                                ],
+                                "Comment": "x3000c0s10b0n0"
+                            },
+                            {
+                                "Name": "ncn-s002",
+                                "IPAddress": "10.252.1.1",
+                                "Aliases": [
+                                    "ncn-s002-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s9b0n0",
+                                    "ncn-s002.local"
+                                ],
+                                "Comment": "x3000c0s9b0n0"
+                            },
+                            {
+                                "Name": "ncn-s001",
+                                "IPAddress": "10.252.1.4",
+                                "Aliases": [
+                                    "ncn-s001-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s8b0n0",
+                                    "ncn-s001.local"
+                                ],
+                                "Comment": "x3000c0s8b0n0"
+                            },
+                            {
+                                "Name": "ncn-w004",
+                                "IPAddress": "10.252.1.5",
+                                "Aliases": [
+                                    "ncn-w004-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s7b0n0",
+                                    "ncn-w004.local"
+                                ],
+                                "Comment": "x3000c0s7b0n0"
+                            },
+                            {
+                                "Name": "ncn-w003",
+                                "IPAddress": "10.252.1.6",
+                                "Aliases": [
+                                    "ncn-w003-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s6b0n0",
+                                    "ncn-w003.local"
+                                ],
+                                "Comment": "x3000c0s6b0n0"
+                            },
+                            {
+                                "Name": "ncn-w002",
+                                "IPAddress": "10.252.1.7",
+                                "Aliases": [
+                                    "ncn-w002-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s5b0n0",
+                                    "ncn-w002.local"
+                                ],
+                                "Comment": "x3000c0s5b0n0"
+                            },
+                            {
+                                "Name": "ncn-w001",
+                                "IPAddress": "10.252.1.8",
+                                "Aliases": [
+                                    "ncn-w001-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s4b0n0",
+                                    "ncn-w001.local"
+                                ],
+                                "Comment": "x3000c0s4b0n0"
+                            },
+                            {
+                                "Name": "ncn-m003",
+                                "IPAddress": "10.252.1.9",
+                                "Aliases": [
+                                    "ncn-m003-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s3b0n0",
+                                    "ncn-m003.local"
+                                ],
+                                "Comment": "x3000c0s3b0n0"
+                            },
+                            {
+                                "Name": "ncn-m002",
+                                "IPAddress": "10.252.1.10",
+                                "Aliases": [
+                                    "ncn-m002-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s2b0n0",
+                                    "ncn-m002.local"
+                                ],
+                                "Comment": "x3000c0s2b0n0"
+                            },
+                            {
+                                "Name": "ncn-m001",
+                                "IPAddress": "10.252.1.11",
+                                "Aliases": [
+                                    "ncn-m001-nmn",
+                                    "time-nmn",
+                                    "time-nmn.local",
+                                    "x3000c0s1b0n0",
+                                    "ncn-m001.local"
+                                ],
+                                "Comment": "x3000c0s1b0n0"
+                            }
+                        ],
+                        "Name": "bootstrap_dhcp",
+                        "VlanID": 2,
+                        "Gateway": "10.252.0.1",
+                        "DHCPStart": "10.252.1.14",
+                        "DHCPEnd": "10.252.1.214"
+                    },
+                    {
+                        "FullName": "NMN UAIs",
+                        "CIDR": "10.252.2.0/23",
+                        "IPReservations": [
+                            {
+                                "Name": "pbs_comm_service",
+                                "IPAddress": "10.252.2.1",
+                                "Aliases": [
+                                    "pbs-comm-service",
+                                    "pbs-comm-service-nmn",
+                                    "pbs_comm_service.local"
+                                ],
+                                "Comment": "pbs-comm-service,pbs-comm-service-nmn"
+                            },
+                            {
+                                "Name": "pbs_service",
+                                "IPAddress": "10.252.2.2",
+                                "Aliases": [
+                                    "pbs-service",
+                                    "pbs-service-nmn",
+                                    "pbs_service.local"
+                                ],
+                                "Comment": "pbs-service,pbs-service-nmn"
+                            },
+                            {
+                                "Name": "slurmctld_service",
+                                "IPAddress": "10.252.2.3",
+                                "Aliases": [
+                                    "slurmctld-service",
+                                    "slurmctld-service-nmn",
+                                    "slurmctld_service.local"
+                                ],
+                                "Comment": "slurmctld-service,slurmctld-service-nmn"
+                            },
+                            {
+                                "Name": "slurmdbd_service",
+                                "IPAddress": "10.252.2.4",
+                                "Aliases": [
+                                    "slurmdbd-service",
+                                    "slurmdbd-service-nmn",
+                                    "slurmdbd_service.local"
+                                ],
+                                "Comment": "slurmdbd-service,slurmdbd-service-nmn"
+                            },
+                            {
+                                "Name": "uai_nmn_blackhole",
+                                "IPAddress": "10.252.2.5",
+                                "Aliases": [
+                                    "uai-nmn-blackhole",
+                                    "uai_nmn_blackhole.local"
+                                ],
+                                "Comment": "uai-nmn-blackhole"
+                            }
+                        ],
+                        "Name": "uai_macvlan",
+                        "VlanID": 2,
+                        "Gateway": "10.252.0.1",
+                        "ReservationStart": "10.252.2.10",
+                        "ReservationEnd": "10.252.3.254"
+                    }
+                ]
+            }
+        },
+        "NMNLB": {
+            "Name": "NMNLB",
+            "FullName": "Node Management Network LoadBalancers",
+            "IPRanges": [
+                "10.92.100.0/24"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.92.100.0/24",
+                "VlanRange": null,
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "NMN MetalLB",
+                        "CIDR": "10.92.100.0/24",
+                        "IPReservations": [
+                            {
+                                "Name": "istio-ingressgateway",
+                                "IPAddress": "10.92.100.71",
+                                "Aliases": [
+                                    "api-gw-service",
+                                    "api-gw-service-nmn.local",
+                                    "packages",
+                                    "registry",
+                                    "spire.local",
+                                    "api_gw_service",
+                                    "registry.local",
+                                    "packages",
+                                    "packages.local",
+                                    "spire"
+                                ],
+                                "Comment": "api-gw-service,api-gw-service-nmn.local,packages,registry,spire.local,api_gw_service,registry.local,packages,packages.local,spire"
+                            },
+                            {
+                                "Name": "istio-ingressgateway-local",
+                                "IPAddress": "10.92.100.81",
+                                "Aliases": [
+                                    "api-gw-service.local"
+                                ],
+                                "Comment": "api-gw-service.local"
+                            },
+                            {
+                                "Name": "rsyslog-aggregator",
+                                "IPAddress": "10.92.100.72",
+                                "Aliases": [
+                                    "rsyslog-agg-service"
+                                ],
+                                "Comment": "rsyslog-agg-service"
+                            },
+                            {
+                                "Name": "cray-tftp",
+                                "IPAddress": "10.92.100.60",
+                                "Aliases": [
+                                    "tftp-service"
+                                ],
+                                "Comment": "tftp-service"
+                            },
+                            {
+                                "Name": "unbound",
+                                "IPAddress": "10.92.100.225",
+                                "Aliases": [
+                                    "unbound"
+                                ],
+                                "Comment": "unbound"
+                            },
+                            {
+                                "Name": "docker-registry",
+                                "IPAddress": "10.92.100.73",
+                                "Aliases": [
+                                    "docker_registry_service"
+                                ],
+                                "Comment": "docker_registry_service"
+                            }
+                        ],
+                        "Name": "nmn_metallb_address_pool",
+                        "VlanID": 2,
+                        "Gateway": "10.92.100.1",
+                        "MetalLBPoolName": "node-management"
+                    }
+                ]
+            }
+        },
+        "NMN_MTN": {
+            "Name": "NMN_MTN",
+            "FullName": "Mountain Compute Node Management Network",
+            "IPRanges": [
+                "10.100.0.0/21"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.100.0.0/21",
+                "VlanRange": [
+                    4095,
+                    0
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "10.100.0.0/22",
+                        "Name": "cabinet_1000",
+                        "VlanID": 2000,
+                        "Gateway": "10.100.0.1",
+                        "DHCPStart": "10.100.0.10",
+                        "DHCPEnd": "10.100.3.254"
+                    }
+                ]
+            }
+        },
+        "NMN_RVR": {
+            "Name": "NMN_RVR",
+            "FullName": "River Compute Node Management Network",
+            "IPRanges": [
+                "10.106.0.0/17"
+            ],
+            "Type": "ethernet",
+            "ExtraProperties": {
+                "CIDR": "10.106.0.0/17",
+                "VlanRange": [
+                    1770,
+                    1770
+                ],
+                "MTU": 9000,
+                "Subnets": [
+                    {
+                        "FullName": "",
+                        "CIDR": "10.106.0.0/22",
+                        "Name": "cabinet_3000",
+                        "VlanID": 1770,
+                        "Gateway": "10.106.0.1",
+                        "DHCPStart": "10.106.0.10",
+                        "DHCPEnd": "10.106.3.254"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/scripts/README.md
+++ b/tests/scripts/README.md
@@ -44,10 +44,11 @@ git diff tests/data/golden_configs/individual_templates_1.7/
 - When adding new object groups or changing ACL structure
 
 **What it does:**
-- Regenerates 57 golden config files across 3 categories:
+- Regenerates 59 golden config files across 4 categories:
   - Full architecture configs (11 standard + 7 isolation + 11 IPv6)
   - TDS architecture configs (5 standard + 5 IPv6)
   - Custom configs (9 standard + 9 IPv6)
+  - Mountain/SLS-mismatch CDU configs (2 — CASMNET-2390 regression)
 
 **Usage:**
 ```bash
@@ -202,7 +203,8 @@ bash tests/scripts/regenerate_golden_configs_1.7.sh
 | Full | 11 | 7 | 11 | 29 |
 | TDS | 5 | - | 5 | 10 |
 | Custom | 9 | - | 9 | 18 |
-| **Total** | **25** | **7** | **25** | **57** |
+| Mtn SLS-mismatch | 2 | - | - | 2 |
+| **Total** | **27** | **7** | **25** | **59** |
 
 ### Switches by Architecture
 

--- a/tests/scripts/regenerate_golden_configs_1.7.sh
+++ b/tests/scripts/regenerate_golden_configs_1.7.sh
@@ -14,7 +14,8 @@
 #   - Full architecture configs (standard, isolation, IPv6)
 #   - TDS architecture configs (standard, IPv6)
 #   - Custom configs (standard, IPv6)
-#   Total: 57 golden config files
+#   - Mountain/SLS-mismatch CDU configs (CASMNET-2390)
+#   Total: 59 golden config files
 #
 # After running:
 #   1. Review changes: git diff tests/data/golden_configs/
@@ -46,10 +47,13 @@ SHCD_TDS="$DATA_DIR/TDS_Architecture_Golden_Config_1.1.5.xlsx"
 SLS_FILE="$DATA_DIR/sls_input_file_csm_1.2.json"
 SLS_IPV6_FILE="$DATA_DIR/sls_input_file_csm_1.2_ipv6.json"
 CUSTOM_FILE="$DATA_DIR/aruba_custom.yaml"
+MTN_MISMATCH_CCJ="$DATA_DIR/Full_Architecture_Mountain_2cab.json"
+MTN_MISMATCH_SLS="$DATA_DIR/sls_input_file_csm_1.7_mtn_mismatch.json"
 
 GOLDEN_FULL="$DATA_DIR/golden_configs/full_configs_1.7"
 GOLDEN_TDS="$DATA_DIR/golden_configs/tds_configs_1.7"
 GOLDEN_CUSTOM="$DATA_DIR/golden_configs/full_configs_custom_1.7"
+GOLDEN_MTN_MISMATCH="$DATA_DIR/golden_configs/mtn_sls_mismatch_1.7"
 
 # Common arguments for full architecture
 FULL_ARGS=(--csm 1.7 -a full --shcd "$SHCD_FULL")
@@ -63,7 +67,7 @@ TDS_CORNERS=(--corners "J14,T30,J14,T57,J14,T34,J14,T27")
 
 # Counter for progress
 count=0
-total=57
+total=59
 
 # Helper function to generate config
 generate_config() {
@@ -82,7 +86,7 @@ generate_config() {
 
 echo ""
 echo "========================================="
-echo "Part 1/5: Full Configs (no flags)"
+echo "Part 1/6: Full Configs (no flags)"
 echo "========================================="
 
 for switch in sw-spine-001 sw-spine-002 sw-leaf-001 sw-leaf-002 sw-leaf-003 sw-leaf-004 sw-leaf-bmc-001 sw-cdu-001 sw-cdu-002 sw-edge-001 sw-edge-002; do
@@ -92,7 +96,7 @@ done
 
 echo ""
 echo "========================================="
-echo "Part 2/5: Full Configs (WITH isolation)"
+echo "Part 2/6: Full Configs (WITH isolation)"
 echo "========================================="
 
 for switch in sw-spine-001 sw-spine-002 sw-leaf-001 sw-leaf-002 sw-leaf-bmc-001 sw-cdu-001 sw-cdu-002; do
@@ -103,7 +107,7 @@ done
 
 echo ""
 echo "========================================="
-echo "Part 3/5: Full Configs (WITH IPv6)"
+echo "Part 3/6: Full Configs (WITH IPv6)"
 echo "========================================="
 
 for switch in sw-spine-001 sw-spine-002 sw-leaf-001 sw-leaf-002 sw-leaf-003 sw-leaf-004 sw-leaf-bmc-001 sw-cdu-001 sw-cdu-002 sw-edge-001 sw-edge-002; do
@@ -113,7 +117,7 @@ done
 
 echo ""
 echo "========================================="
-echo "Part 4/5: TDS Configs"
+echo "Part 4/6: TDS Configs"
 echo "========================================="
 
 # TDS configs (standard)
@@ -130,7 +134,7 @@ done
 
 echo ""
 echo "========================================="
-echo "Part 5/5: Custom Configs"
+echo "Part 5/6: Custom Configs"
 echo "========================================="
 
 # Custom configs (standard)
@@ -145,6 +149,19 @@ for switch in sw-spine-001 sw-spine-002 sw-leaf-001 sw-leaf-002 sw-leaf-003 sw-l
     generate_config "$switch" "$GOLDEN_CUSTOM/${switch}-ipv6.cfg" \
         "${FULL_ARGS[@]}" "${FULL_TABS[@]}" "${FULL_CORNERS[@]}" --sls-file "$SLS_IPV6_FILE" \
         --custom-config "$CUSTOM_FILE"
+done
+
+echo ""
+echo "========================================="
+echo "Part 6/6: Mountain/SLS-mismatch CDU Configs (CASMNET-2390)"
+echo "========================================="
+
+# Regression fixture for CASMNET-2390: CCJ contains two Mountain cabinets
+# (x1000, x1001) but SLS only contains x1000. The renderer must skip the
+# CMM/CEC ports for x1001 and emit warnings instead of stamping stale VLANs.
+for switch in sw-cdu-001 sw-cdu-002; do
+    generate_config "$switch" "$GOLDEN_MTN_MISMATCH/${switch}.cfg" \
+        --csm 1.7 -a full --ccj "$MTN_MISMATCH_CCJ" --sls-file "$MTN_MISMATCH_SLS"
 done
 
 echo ""

--- a/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
+++ b/tests/test_generate_switch_config_aruba_configs_csm_1_7.py
@@ -713,6 +713,103 @@ def test_switch_config_cdu_secondary_custom():
         assert diff_config_files(golden_config_file, config_file) == 0
 
 
+# CASMNET-2390: A Mountain/Olympus cabinet that exists in the CCJ/SHCD but not
+# in SLS (NMN_MTN_CABINETS / HMN_MTN_CABINETS) must NOT be rendered onto the
+# CDU switch with stale VLAN values from a previously-processed cabinet.
+# The fixture pair below contains two Mountain cabinets (x1000, x1001) in the
+# CCJ but only x1000 in SLS.
+mtn_mismatch_ccj_file = path.join(data_directory, "Full_Architecture_Mountain_2cab.json")
+mtn_mismatch_sls_file = path.join(data_directory, "sls_input_file_csm_1.7_mtn_mismatch.json")
+
+
+def _assert_mtn_mismatch_warnings(output, switch_name):
+    """Assert the expected per-port skip warnings appear for the missing Mountain cabinet."""
+    assert "WARNING: Skipping" in output
+    assert "x1001" in output
+    assert switch_name in output
+    # CMM ports skipped because both NMN_MTN and HMN_MTN entries are missing.
+    assert "NMN_MTN_CABINETS, HMN_MTN_CABINETS" in output
+    # The CEC port skip names only the HMN_MTN list.
+    assert "Skipping CEC port" in output
+
+
+def test_switch_config_cdu_primary_mtn_sls_mismatch():
+    """Test that primary CDU rendering skips CMM/CEC ports for cabinets missing from SLS (CASMNET-2390)."""
+    switch_name = "sw-cdu-001"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(
+        data_directory,
+        f"golden_configs/mtn_sls_mismatch_1.7/{config_file}",
+    )
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--ccj",
+                mtn_mismatch_ccj_file,
+                "--sls-file",
+                mtn_mismatch_sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+        _assert_mtn_mismatch_warnings(result.output, switch_name)
+        with open(config_file) as cfg:
+            rendered = cfg.read()
+        # No port stanza should reference the SLS-missing cabinet.
+        assert "x1001" not in rendered
+
+
+def test_switch_config_cdu_secondary_mtn_sls_mismatch():
+    """Test that secondary CDU rendering skips CMM/CEC ports for cabinets missing from SLS (CASMNET-2390)."""
+    switch_name = "sw-cdu-002"
+    config_file = f"{switch_name}.cfg"
+    golden_config_file = path.join(
+        data_directory,
+        f"golden_configs/mtn_sls_mismatch_1.7/{config_file}",
+    )
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "switch",
+                "config",
+                "--csm",
+                csm,
+                "--architecture",
+                architecture,
+                "--ccj",
+                mtn_mismatch_ccj_file,
+                "--sls-file",
+                mtn_mismatch_sls_file,
+                "--name",
+                switch_name,
+                "--out",
+                config_file,
+            ],
+        )
+        assert result.exit_code == 0
+        assert diff_config_files(golden_config_file, config_file) == 0
+        _assert_mtn_mismatch_warnings(result.output, switch_name)
+        with open(config_file) as cfg:
+            rendered = cfg.read()
+        assert "x1001" not in rendered
+
+
 def test_switch_config_edge_primary():
     """Test that the `canu generate switch config` command runs and returns valid primary edge config."""
     switch_name = "sw-edge-001"


### PR DESCRIPTION
### Summary and Scope

Fixes [CASMNET-2390](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2390): when a Mountain/Olympus cabinet is present in the CCJ/SHCD but absent from SLS (`Networks.NMN_MTN` / `HMN_MTN`), `canu generate switch config` silently emitted CDU CMM/CEC port stanzas that trunked/accessed the **wrong cabinet's VLANs** — VLANs that the SLS-driven sections of the same template never defined on the switch.

Root cause: in `canu/generate/switch/config/config.py::get_switch_nodes`, the `cmm`/`cec` branches did not initialise `nmn_mtn_vlan` / `hmn_mtn_vlan` before the inner `for cabinets in sls_variables[...]` loops. When the CCJ cabinet had no SLS match, the locals retained the stale value from a prior outer-loop iteration (a different cabinet) and were silently emitted onto the new cabinet's ports. The node was appended unconditionally — there was no skip/warn/error guard. If the very first `cmm`/`cec` port hit had no SLS match, the same code path raised `UnboundLocalError`.

This PR:

- Initialises `nmn_mtn_vlan` / `hmn_mtn_vlan` to `None` per port (kills both the stale-leak and the `UnboundLocalError` first-port case).
- When no SLS cabinet matches the CCJ rack number, emits a red `WARNING: Skipping …` via `click.secho` naming the switch, port, lag, cabinet, and which SLS list is missing, then `continue`s so the node is **not** appended. The switch will not silently get a misconfigured port stanza for an SLS-missing cabinet.
- Adds a regression-guarding fixture pair and two new tests in `tests/test_generate_switch_config_aruba_configs_csm_1_7.py` (`test_switch_config_cdu_primary_mtn_sls_mismatch` and `test_switch_config_cdu_secondary_mtn_sls_mismatch`) modelled on the existing CDU tests, using `--ccj` (matching `test_generate_switch_config_aruba_templates_csm_1_7.py`).
- Extends `tests/scripts/regenerate_golden_configs_1.7.sh` (and its `README.md`) with a `Part 6/6` block that regenerates the new goldens; total bumped from 57 to 59.

Scope is limited to CSM 1.7 + Aruba CDU rendering, but the patched code path is shared across all CSM versions and vendors.

#### Out of scope — inverse scenario (cabinet in SLS but not in CCJ)

This PR does not change the inverse mismatch direction. The code already behaves correctly there: the outer port loop in `get_switch_nodes` only iterates CCJ-derived ports, so no CMM/CEC stanzas are rendered, and the SLS-driven VLAN/gateway build (around `config.py:947`) is gated by `if sls_rack_int in destination_rack_list`, which keeps SLS-only cabinets out of `NMN_MTN_VLANS` / `HMN_MTN_VLANS`. The cabinet is silently omitted in both halves of the render — the resulting config is valid, but the operator gets no signal that the SHCD/CCJ may be missing an intended cabinet. Adding a symmetric warning is a separate, lower-severity follow-up.

- [x] I have added new tests to cover the new code
- [x] If adding a new file, I have updated `pyinstaller.py` *(no product files added; new files are tests/fixtures, which `pyinstaller.py` already excludes via `excludes=["tests"]`)*
- [x] I have added entries in `CHANGELOG.md` for the changes in this PR

### Issues and Related PRs

* Resolves: `CASMNET-2390`

### Testing

**Reproduction (pre-fix, on `main`):**

Two runs against the same CCJ with two Mountain cabinets (`x1000`, `x1001`):

```bash
canu generate network config --csm 1.7 \
  --ccj hela-ccj.json \
  --sls-file sls_input_file.json --folder output         # x1000 + x1001 in SLS
canu generate network config --csm 1.7 \
  --ccj hela-ccj.json \
  --sls-file sls_input_file_single.json --folder output2 # x1000 only in SLS
```

In `output2`, x1001's VLAN definitions and `interface vlan` stanzas correctly disappear, but the CMM/CEC ports for x1001 still render — trunking `vlan trunk native 2000 / allowed 2000,3000` (x1000's VLANs) and `vlan access 3000` instead of x1001's `2001 / 2001,3001 / 3001`. **No warning or error is printed.** Excerpt from `diff output/sw-cdu-001.cfg output2/sw-cdu-001.cfg`:

```diff
< interface lag 9 multi-chassis static
<     no shutdown
<     description cmm-x1001-000:1<==sw-cdu-001
<     no routing
<     vlan trunk native 2000           # ← should be 2001 (x1001's NMN VLAN)
<     vlan trunk allowed 2000,3000     # ← should be 2001,3001
<     spanning-tree root-guard
…
< interface 1/1/46
<     no shutdown
<     description cec-x1001-000<==sw-cdu-001
<     vlan access 3000                 # ← should be 3001 (x1001's HMN VLAN)
```

**Post-fix behaviour:**

Same `single-cabinet` invocation now refuses to render the SLS-missing cabinet's ports and warns loudly per skipped port:

```text
$ canu generate network config --csm 1.7 \
    --ccj hela-ccj.json \
    --sls-file sls_input_file_single.json --folder /tmp/output_pr
…
sw-leaf-002 Config Generated
sw-edge-001 Config Generated
sw-edge-002 Config Generated
WARNING: Skipping CMM port 9 (lag 9) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 10 (lag 10) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 11 (lag 11) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 12 (lag 12) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 13 (lag 13) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 14 (lag 14) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 15 (lag 15) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 16 (lag 16) on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CEC port 46 on sw-cdu-002 for cabinet x1001: cabinet is in the CCJ/SHCD but not in SLS (HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
sw-cdu-002 Config Generated
WARNING: Skipping CMM port 9 (lag 9) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 10 (lag 10) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 11 (lag 11) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 12 (lag 12) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 13 (lag 13) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 14 (lag 14) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 15 (lag 15) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CMM port 16 (lag 16) on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but missing from SLS (NMN_MTN_CABINETS, HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
WARNING: Skipping CEC port 46 on sw-cdu-001 for cabinet x1001: cabinet is in the CCJ/SHCD but not in SLS (HMN_MTN_CABINETS). The CCJ and SLS are out of sync; reconcile them and regenerate the config.
sw-cdu-001 Config Generated
```

The resulting `/tmp/output_pr/sw-cdu-001.cfg` and `sw-cdu-002.cfg` contain zero `x1001` references; the only x1000-VLAN stanzas left are the legitimate x1000 CMM/CEC ports.

**Other validation:**

1. The full-SLS invocation (`--sls-file sls_input_file.json`) produces a config byte-identical to the pre-fix good output — no regression on the happy path.
2. `make unit` → `510 passed, 0 failed` (was 508, +2 new). Both new tests fail when run against the pre-fix source (verified by temporarily reverting `canu/generate/switch/config/config.py` to `main`).
3. `tests/scripts/regenerate_golden_configs_1.7.sh` runs end-to-end and produces 59 files; the only diffs in pre-existing goldens are CANU version-banner strings, which `tests/lib/diff.py::diff_config_files` already strips.

Each new test asserts:

1. `exit_code == 0`
2. Generated config matches the new golden (which was produced by the fixed code, so this asserts the fix is sticky).
3. Expected `WARNING: Skipping …` text appears in `result.output` covering `x1001`, the switch name, and the missing SLS list(s) for both CMM and CEC ports.
4. The rendered config contains no `x1001` references at all (defence-in-depth).